### PR TITLE
Dev/raquela/bug fixes

### DIFF
--- a/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.ManageLibraries);
             var cmd = new OleMenuCommand(Execute, cmdId);
-            cmd.BeforeQueryStatus += BeforeQueryStatus;
             commandService.AddCommand(cmd);
         }
 
@@ -33,18 +32,6 @@ namespace Microsoft.Web.LibraryManager.Vsix
             Instance = new ManageLibrariesCommand(package, commandService);
         }
 
-        private void BeforeQueryStatus(object sender, EventArgs e)
-        {
-            var button = (OleMenuCommand)sender;
-            button.Visible = button.Enabled = false;
-
-            if (VsHelpers.DTE.SelectedItems.MultiSelect)
-                return;
-
-            Project project = VsHelpers.DTE.SelectedItems.Item(1).Project;
-
-            button.Visible = button.Enabled = project.IsSupported();
-        }
 
         private void Execute(object sender, EventArgs e)
         {

--- a/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
@@ -1,30 +1,45 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using EnvDTE;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
+using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.Telemetry;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
     internal sealed class RestoreSolutionCommand
     {
         private readonly Package _package;
-        private static readonly string[] _ignore = { "\\node_modules\\", "\\bower_components\\", "\\jspm_packages\\", "\\lib\\", "\\vendor\\" };
-
         private RestoreSolutionCommand(Package package, OleMenuCommandService commandService)
         {
             _package = package;
 
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.RestoreSolution);
             var cmd = new OleMenuCommand(ExecuteAsync, cmdId);
+            cmd.BeforeQueryStatus += BeforeQueryStatus;
             commandService.AddCommand(cmd);
+        }
+
+        private void BeforeQueryStatus(object sender, EventArgs e)
+        {
+            var button = (OleMenuCommand)sender;
+            button.Visible = button.Enabled = false;
+
+            if (VsHelpers.DTE.SelectedItems.MultiSelect)
+                return;
+
+            var solution = (IVsSolution)ServiceProvider.GetService(typeof(SVsSolution));
+
+            if (VsHelpers.SolutionContainsConfigFile(solution))
+            {
+                button.Visible = true;
+                button.Enabled = KnownUIContexts.SolutionExistsAndNotBuildingAndNotDebuggingContext.IsActive;
+            }
         }
 
         public static RestoreSolutionCommand Instance { get; private set; }
@@ -39,14 +54,18 @@ namespace Microsoft.Web.LibraryManager.Vsix
         private async void ExecuteAsync(object sender, EventArgs e)
         {
             var solution = (IVsSolution)ServiceProvider.GetService(typeof(SVsSolution));
-            IEnumerable<IVsHierarchy> hierarchies = GetProjectsInSolution(solution, __VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION);
+            IEnumerable<IVsHierarchy> hierarchies = VsHelpers.GetProjectsInSolution(solution, __VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION);
             var configFiles = new List<string>();
 
             foreach (IVsHierarchy hierarchy in hierarchies)
             {
-                Project project = GetDTEProject(hierarchy);
+                Project project = VsHelpers.GetDTEProject(hierarchy);
 
-                configFiles.AddRange(FindConfigFiles(project.ProjectItems));
+                if (VsHelpers.ProjectContainsConfigFile(project))
+                {
+                    string configFilePath = Path.Combine(project.GetRootFolder(), Constants.ConfigFileName);
+                    configFiles.Add(configFilePath);
+                }
             }
 
             await LibraryHelpers.RestoreAsync(configFiles);
@@ -54,51 +73,5 @@ namespace Microsoft.Web.LibraryManager.Vsix
             Telemetry.TrackUserTask("restoresolution");
         }
 
-        public static IEnumerable<IVsHierarchy> GetProjectsInSolution(IVsSolution solution, __VSENUMPROJFLAGS flags)
-        {
-            if (solution == null)
-                yield break;
-
-            Guid guid = Guid.Empty;
-            solution.GetProjectEnum((uint)flags, ref guid, out IEnumHierarchies enumHierarchies);
-            if (enumHierarchies == null)
-                yield break;
-
-            IVsHierarchy[] hierarchy = new IVsHierarchy[1];
-            while (enumHierarchies.Next(1, hierarchy, out uint fetched) == VSConstants.S_OK && fetched == 1)
-            {
-                if (hierarchy.Length > 0 && hierarchy[0] != null)
-                    yield return hierarchy[0];
-            }
-        }
-
-        public static Project GetDTEProject(IVsHierarchy hierarchy)
-        {
-            hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out object obj);
-            return obj as Project;
-        }
-
-        private static IEnumerable<string> FindConfigFiles(ProjectItems items, List<string> files = null)
-        {
-            files = files ?? new List<string>();
-
-            foreach (ProjectItem item in items)
-            {
-                if (item.Name.Equals(Constants.ConfigFileName, StringComparison.OrdinalIgnoreCase))
-                {
-                    files.Add(item.FileNames[1]);
-                }
-
-                if (!ShouldIgnore(item.FileNames[1]) && item.ProjectItems != null)
-                    FindConfigFiles(item.ProjectItems, files);
-            }
-
-            return files;
-        }
-
-        public static bool ShouldIgnore(string filePath)
-        {
-            return _ignore.Any(ign => filePath.IndexOf(ign, StringComparison.OrdinalIgnoreCase) > -1);
-        }
     }
 }

--- a/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             var solution = (IVsSolution)ServiceProvider.GetService(typeof(SVsSolution));
 
-            if (VsHelpers.SolutionContainsConfigFile(solution))
+            if (VsHelpers.SolutionContainsManifestFile(solution))
             {
                 button.Visible = true;
                 button.Enabled = KnownUIContexts.SolutionExistsAndNotBuildingAndNotDebuggingContext.IsActive;
@@ -61,7 +61,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             {
                 Project project = VsHelpers.GetDTEProject(hierarchy);
 
-                if (VsHelpers.ProjectContainsConfigFile(project))
+                if (VsHelpers.ProjectContainsManifestFile(project))
                 {
                     string configFilePath = Path.Combine(project.GetRootFolder(), Constants.ConfigFileName);
                     configFiles.Add(configFilePath);

--- a/src/LibraryManager.Vsix/LibraryManagerPackage.cs
+++ b/src/LibraryManager.Vsix/LibraryManagerPackage.cs
@@ -17,38 +17,30 @@ namespace Microsoft.Web.LibraryManager.Vsix
     [ProvideAutoLoad(PackageGuids.guidUiContextString)]
     [ProvideUIContextRule(PackageGuids.guidUiContextConfigFileString,
         name: "ConfigFile",
-        expression: "(WAP | WebSite | DotNetCoreWeb | Cordova) & !Node & Config",
+        expression: "(WAP | WebSite | DotNetCoreWeb ) & Config",
         termNames: new string[] {
             "WAP",
             "WebSite",
             "DotNetCoreWeb",
-            "Cordova",
-            "Node",
             "Config"
         },
         termValues: new string[] {
             "ActiveProjectFlavor:{349C5851-65DF-11DA-9384-00065B846F21}",
             "ActiveProjectFlavor:{E24C65DC-7377-472B-9ABA-BC803B73C61A}",
             "ActiveProjectCapability:DotNetCoreWeb",
-            "ActiveProjectCapability:DependencyPackageManagement",
-            "ActiveProjectFlavor:{3AF33F2E-1136-4D97-BBB7-1795711AC8B8}",
             "HierSingleSelectionName:" + Constants.ConfigFileName + "$" })]
     [ProvideUIContextRule(PackageGuids.guidUiContextString, 
         name: Vsix.Name,
-        expression: "(WAP | WebSite | DotNetCoreWeb | Cordova) & !Node",
+        expression: "(WAP | WebSite | DotNetCoreWeb )",
         termNames: new string[] {
             "WAP",
             "WebSite",
-            "DotNetCoreWeb",
-            "Cordova",
-            "Node"
+            "DotNetCoreWeb"
         },
         termValues: new string[] {
             "ActiveProjectFlavor:{349C5851-65DF-11DA-9384-00065B846F21}",
             "ActiveProjectFlavor:{E24C65DC-7377-472B-9ABA-BC803B73C61A}",
-            "ActiveProjectCapability:DotNetCoreWeb",
-            "ActiveProjectCapability:DependencyPackageManagement",
-            "ActiveProjectFlavor:{3AF33F2E-1136-4D97-BBB7-1795711AC8B8}" })]
+            "ActiveProjectCapability:DotNetCoreWeb" })]
 
     public sealed class LibraryManagerPackage : AsyncPackage
     {

--- a/src/LibraryManager.Vsix/LibraryManagerPackage.cs
+++ b/src/LibraryManager.Vsix/LibraryManagerPackage.cs
@@ -14,29 +14,42 @@ namespace Microsoft.Web.LibraryManager.Vsix
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    [ProvideAutoLoad(PackageGuids.guidUiContextConfigFileString)]
-    [ProvideUIContextRule(PackageGuids.guidUiContextConfigFileString, "ConfigFile",
-        expression: "Config",
-        termNames: new string[] { "Config" },
-        termValues: new[] { "HierSingleSelectionName:" + Constants.ConfigFileName + "$" })]
-    [ProvideUIContextRule(PackageGuids.guidUiContextString, Vsix.Name,
-        "WAP | WebSite | DotNetCoreWeb | ProjectK",// | Cordova | Node",
-        new string[] {
+    [ProvideAutoLoad(PackageGuids.guidUiContextString)]
+    [ProvideUIContextRule(PackageGuids.guidUiContextConfigFileString,
+        name: "ConfigFile",
+        expression: "(WAP | WebSite | DotNetCoreWeb | Cordova) & !Node & Config",
+        termNames: new string[] {
             "WAP",
             "WebSite",
             "DotNetCoreWeb",
-            "ProjectK",
             "Cordova",
-            "Node"
+            "Node",
+            "Config"
         },
-        new string[] {
+        termValues: new string[] {
             "ActiveProjectFlavor:{349C5851-65DF-11DA-9384-00065B846F21}",
             "ActiveProjectFlavor:{E24C65DC-7377-472B-9ABA-BC803B73C61A}",
-            "ActiveProjectFlavor:{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}",
             "ActiveProjectCapability:DotNetCoreWeb",
             "ActiveProjectCapability:DependencyPackageManagement",
             "ActiveProjectFlavor:{3AF33F2E-1136-4D97-BBB7-1795711AC8B8}",
-        })]
+            "HierSingleSelectionName:" + Constants.ConfigFileName + "$" })]
+    [ProvideUIContextRule(PackageGuids.guidUiContextString, 
+        name: Vsix.Name,
+        expression: "(WAP | WebSite | DotNetCoreWeb | Cordova) & !Node",
+        termNames: new string[] {
+            "WAP",
+            "WebSite",
+            "DotNetCoreWeb",
+            "Cordova",
+            "Node"
+        },
+        termValues: new string[] {
+            "ActiveProjectFlavor:{349C5851-65DF-11DA-9384-00065B846F21}",
+            "ActiveProjectFlavor:{E24C65DC-7377-472B-9ABA-BC803B73C61A}",
+            "ActiveProjectCapability:DotNetCoreWeb",
+            "ActiveProjectCapability:DependencyPackageManagement",
+            "ActiveProjectFlavor:{3AF33F2E-1136-4D97-BBB7-1795711AC8B8}" })]
+
     public sealed class LibraryManagerPackage : AsyncPackage
     {
         protected override async Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -214,9 +214,10 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 yield break;
 
             Guid guid = Guid.Empty;
-            solution.GetProjectEnum((uint)flags, ref guid, out IEnumHierarchies enumHierarchies);
-            if (enumHierarchies == null)
+            if (ErrorHandler.Failed(solution.GetProjectEnum((uint)flags, ref guid, out IEnumHierarchies enumHierarchies)) || enumHierarchies == null)
+            {
                 yield break;
+            }
 
             IVsHierarchy[] hierarchy = new IVsHierarchy[1];
             while (enumHierarchies.Next(1, hierarchy, out uint fetched) == VSConstants.S_OK && fetched == 1)
@@ -228,8 +229,12 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         public static Project GetDTEProject(IVsHierarchy hierarchy)
         {
-            hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out object obj);
-            return obj as Project;
+            if (ErrorHandler.Succeeded(hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out object obj)))
+            {
+                return obj as Project;
+            }
+
+            return null;
         }
     }
 

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
         }
 
-        public static bool ProjectContainsConfigFile(Project project)
+        public static bool ProjectContainsManifestFile(Project project)
         {
             string configFilePath = Path.Combine(GetRootFolder(project), Constants.ConfigFileName);
 
@@ -191,7 +191,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             return false;
         }
 
-        public static bool SolutionContainsConfigFile(IVsSolution solution)
+        public static bool SolutionContainsManifestFile(IVsSolution solution)
         {
             IEnumerable<IVsHierarchy> hierarchies = GetProjectsInSolution(solution, __VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION);
 
@@ -199,7 +199,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             {
                 Project project = GetDTEProject(hierarchy);
 
-                if (project != null && ProjectContainsConfigFile(project))
+                if (project != null && ProjectContainsManifestFile(project))
                 {
                     return true;
                 }

--- a/src/LibraryManager.Vsix/VSCommandTable.vsct
+++ b/src/LibraryManager.Vsix/VSCommandTable.vsct
@@ -72,6 +72,8 @@
                 <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_BUILD"/>
                 <Icon guid="ImageCatalogGuid" id="JSWebScript" />
                 <CommandFlag>IconIsMoniker</CommandFlag>
+                <CommandFlag>DefaultInvisible</CommandFlag>
+                <CommandFlag>DynamicVisibility</CommandFlag>
                 <Strings>
                     <ButtonText>Restore Client-Side Libraries</ButtonText>
                     <CanonicalName>RestoreClientSideLibraries</CanonicalName>


### PR DESCRIPTION
- package is loaded every time current selection in the active hierarchy has a name that matches "library.json"
"Restore Client Side libraries" context menu for solution should not be visible/enabled when there are not library.json files