### PR TITLE
Fixing file lock bug on save. 

### DIFF
--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -107,22 +107,27 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
 
         private void OnFileSaved(object sender, TextDocumentFileActionEventArgs e)
         {
-            if (e.FileActionType == FileActionTypes.ContentSavedToDisk)
+            var textDocument = (ITextDocument) sender;
+
+            if (e.FileActionType == FileActionTypes.ContentSavedToDisk && textDocument != null)
             {
                 Task.Run(async () =>
                 {
                     try
                     {
-                        Manifest newManifest = await Manifest.FromFileAsync(e.FilePath, _dependencies, CancellationToken.None).ConfigureAwait(false);
+                        Manifest newManifest = Manifest.FromJson(textDocument.TextBuffer.CurrentSnapshot.GetText(), _dependencies);
                         await RemoveFilesAsync(newManifest).ConfigureAwait(false);
 
                         _manifest = newManifest;
 
-                        await LibraryHelpers.RestoreAsync(e.FilePath, CancellationToken.None).ConfigureAwait(false);
+                        await LibraryHelpers.RestoreAsync(textDocument.FilePath, _manifest, CancellationToken.None).ConfigureAwait(false);
                         Telemetry.TrackOperation("restoresave");
                     }
                     catch (Exception ex)
                     {
+                        string textMessage = string.Concat(Environment.NewLine, LibraryManager.Resources.Text.RestoreHasErrors, Environment.NewLine);
+
+                        Logger.LogEvent(textMessage, LogLevel.Task);
                         Logger.LogEvent(ex.ToString(), LogLevel.Error);
                         Telemetry.TrackException("restoresavefailed", ex);
                     }

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
 
         private void OnFileSaved(object sender, TextDocumentFileActionEventArgs e)
         {
-            var textDocument = (ITextDocument) sender;
+            var textDocument = sender as ITextDocument;
 
             if (e.FileActionType == FileActionTypes.ContentSavedToDisk && textDocument != null)
             {

--- a/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         public static async Task RestoreAsync(string configFilePath, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var dependencies = Dependencies.FromConfigFile(configFilePath);
+            Dependencies dependencies = Dependencies.FromConfigFile(configFilePath);
             Manifest manifest = await Manifest.FromFileAsync(configFilePath, dependencies, cancellationToken).ConfigureAwait(false);
 
             await RestoreAsync(new Dictionary<string, Manifest>() { [configFilePath] = manifest }, cancellationToken).ConfigureAwait(false);
@@ -52,7 +52,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             foreach (string configFilePath in configFilePaths)
             {
-                var dependencies = Dependencies.FromConfigFile(configFilePath);
+                Dependencies dependencies = Dependencies.FromConfigFile(configFilePath);
                 Manifest manifest = await Manifest.FromFileAsync(configFilePath, dependencies, cancellationToken).ConfigureAwait(false);
 
                 manifests.Add(configFilePath, manifest);
@@ -61,7 +61,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             await RestoreAsync(manifests, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task RestoreAsync(IDictionary<string, Manifest> manifests,CancellationToken cancellationToken = default(CancellationToken))
+        private static async Task RestoreAsync(IDictionary<string, Manifest> manifests, CancellationToken cancellationToken = default(CancellationToken))
         {
             Logger.LogEvent(LibraryManager.Resources.Text.RestoringLibraries, LogLevel.Status);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             bool hasErrors = false;
             var telResult = new Dictionary<string, double>();
 
-            foreach (var manifest in manifests)
+            foreach (KeyValuePair<string, Manifest> manifest in manifests)
             {
                 IEnumerable<ILibraryInstallationResult> results = await RestoreLibrariesAsync(manifest.Value, cancellationToken).ConfigureAwait(false);
 

--- a/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
@@ -35,10 +35,33 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         public static async Task RestoreAsync(string configFilePath, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await RestoreAsync(new[] { configFilePath }, cancellationToken).ConfigureAwait(false);
+            var dependencies = Dependencies.FromConfigFile(configFilePath);
+            Manifest manifest = await Manifest.FromFileAsync(configFilePath, dependencies, cancellationToken).ConfigureAwait(false);
+
+            await RestoreAsync(new Dictionary<string, Manifest>() { [configFilePath] = manifest }, cancellationToken).ConfigureAwait(false);
+        }
+
+        public static async Task RestoreAsync(string configFilePath, Manifest manifest, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await RestoreAsync(new Dictionary<string, Manifest>() { [configFilePath] = manifest } , cancellationToken).ConfigureAwait(false);
         }
 
         public static async Task RestoreAsync(IEnumerable<string> configFilePaths, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Dictionary<string, Manifest> manifests = new Dictionary<string, Manifest>();
+
+            foreach (string configFilePath in configFilePaths)
+            {
+                var dependencies = Dependencies.FromConfigFile(configFilePath);
+                Manifest manifest = await Manifest.FromFileAsync(configFilePath, dependencies, cancellationToken).ConfigureAwait(false);
+
+                manifests.Add(configFilePath, manifest);
+            }
+
+            await RestoreAsync(manifests, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task RestoreAsync(IDictionary<string, Manifest> manifests,CancellationToken cancellationToken = default(CancellationToken))
         {
             Logger.LogEvent(LibraryManager.Resources.Text.RestoringLibraries, LogLevel.Status);
 
@@ -48,13 +71,14 @@ namespace Microsoft.Web.LibraryManager.Vsix
             bool hasErrors = false;
             var telResult = new Dictionary<string, double>();
 
-            foreach (string configFilePath in configFilePaths)
+            foreach (var manifest in manifests)
             {
-                IEnumerable<ILibraryInstallationResult> results = await RestoreLibrariesAsync(configFilePath, cancellationToken).ConfigureAwait(false);
-                Project project = VsHelpers.DTE.Solution?.FindProjectItem(configFilePath)?.ContainingProject;
-                AddFilesToProject(configFilePath, project, results);
+                IEnumerable<ILibraryInstallationResult> results = await RestoreLibrariesAsync(manifest.Value, cancellationToken).ConfigureAwait(false);
 
-                var errorList = new ErrorList(project?.Name, configFilePath);
+                Project project = VsHelpers.DTE.Solution?.FindProjectItem(manifest.Key)?.ContainingProject;
+                AddFilesToProject(manifest.Key, project, results);
+
+                var errorList = new ErrorList(project?.Name, manifest.Key);
                 hasErrors |= errorList.HandleErrors(results);
 
                 resultCount += results.Count();
@@ -112,11 +136,8 @@ namespace Microsoft.Web.LibraryManager.Vsix
             Telemetry.TrackUserTask("clean", new KeyValuePair<string, object>("filesdeleted", filesDeleted));
         }
 
-        private static async Task<IEnumerable<ILibraryInstallationResult>> RestoreLibrariesAsync(string configFilePath, CancellationToken cancellationToken)
+        private static async Task<IEnumerable<ILibraryInstallationResult>> RestoreLibrariesAsync(Manifest manifest, CancellationToken cancellationToken)
         {
-            var dependencies = Dependencies.FromConfigFile(configFilePath);
-
-            Manifest manifest = await Manifest.FromFileAsync(configFilePath, dependencies, cancellationToken).ConfigureAwait(false);
             return await manifest.RestoreAsync(cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
We no longer read the manifest from disk on save but from the the document TextBuffer.