### PR TITLE
Fixing bug 568284 (nullref on Clean command).

### DIFF
--- a/src/LibraryManager.Contracts/IProvider.cs
+++ b/src/LibraryManager.Contracts/IProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
 
         /// <summary>
         /// Installs a library as specified in the <paramref name="desiredState"/> parameter.
-        /// </summary>  
+        /// </summary>
         /// <param name="desiredState">The details about the library to install.</param>
         /// <param name="cancellationToken">A token that allows for the operation to be cancelled.</param>
         /// <returns>The <see cref="ILibraryInstallationResult"/> from the installation process.</returns>

--- a/src/LibraryManager.Contracts/IProvider.cs
+++ b/src/LibraryManager.Contracts/IProvider.cs
@@ -31,11 +31,19 @@ namespace Microsoft.Web.LibraryManager.Contracts
 
         /// <summary>
         /// Installs a library as specified in the <paramref name="desiredState"/> parameter.
-        /// </summary>
+        /// </summary>  
         /// <param name="desiredState">The details about the library to install.</param>
         /// <param name="cancellationToken">A token that allows for the operation to be cancelled.</param>
         /// <returns>The <see cref="ILibraryInstallationResult"/> from the installation process.</returns>
         Task<ILibraryInstallationResult> InstallAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Updates library state using catalog if needed
+        /// </summary>
+        /// <param name="desiredState"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<ILibraryInstallationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets the <see cref="ILibraryCatalog"/> for the <see cref="IProvider"/>. May be <code>null</code> if no catalog is supported.

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using EnvDTE;
-using Microsoft.Web.LibraryManager.Contracts;
 using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using EnvDTE;
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -80,9 +80,10 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
                     Logger.Log(string.Format(LibraryManager.Resources.Text.FileDeleted, relativeFilePath), LogLevel.Operation);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     Logger.Log(string.Format(LibraryManager.Resources.Text.FileDeleteFail, relativeFilePath), LogLevel.Operation);
+                    Telemetry.TrackException("deletefilefailed", ex);
                 }
             }
         }

--- a/src/LibraryManager.Vsix/ErrorList/ErrorList.cs
+++ b/src/LibraryManager.Vsix/ErrorList/ErrorList.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.Telemetry;
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -37,7 +38,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                     foreach (IError error in result.Errors)
                     {
                         Logger.LogEvent(error.Message, LogLevel.Operation);
-                        Telemetry.TrackOperation("error", new KeyValuePair<string, object>("code", error.Code));
+                        Telemetry.TrackOperation("error", TelemetryResult.Failure, new KeyValuePair<string, object>("code", error.Code));
                     }
                 }
             }

--- a/src/LibraryManager.Vsix/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Vsix/Resources/Text.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clean libraries failed.
+        /// </summary>
+        public static string CleanLibrariesFailed {
+            get {
+                return ResourceManager.GetString("CleanLibrariesFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Clean libraries started....
         /// </summary>
         public static string CleanLibrariesStarted {

--- a/src/LibraryManager.Vsix/Resources/Text.resx
+++ b/src/LibraryManager.Vsix/Resources/Text.resx
@@ -162,4 +162,7 @@ Do you want to continue?</value>
   <data name="SelectPackageToSelectFilesToInstall" xml:space="preserve">
     <value>&lt;Choose a package to select files to install&gt;</value>
   </data>
+  <data name="CleanLibrariesFailed" xml:space="preserve">
+    <value>Clean libraries failed</value>
+  </data>
 </root>

--- a/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             sw.Stop();
 
             telResult.Add("time", sw.Elapsed.TotalMilliseconds);
-            Telemetry.TrackUserTask("restore", telResult.Select(i => new KeyValuePair<string, object>(i.Key, i.Value)).ToArray());
+            Telemetry.TrackUserTask("restore", TelemetryResult.None, telResult.Select(i => new KeyValuePair<string, object>(i.Key, i.Value)).ToArray());
 
             if (resultCount > 0)
             {
@@ -133,15 +133,13 @@ namespace Microsoft.Web.LibraryManager.Vsix
             if (results != null && results.All(r => r.Success))
             {
                 Logger.LogEvent(Resources.Text.CleanLibrariesSucceeded + Environment.NewLine, LogLevel.Task);
+                Telemetry.TrackUserTask("clean", TelemetryResult.Success, new KeyValuePair<string, object>("librariesdeleted", results.Count()));
             }
             else
             {
                 Logger.LogEvent(Resources.Text.CleanLibrariesFailed + Environment.NewLine, LogLevel.Task);
+                Telemetry.TrackUserTask("clean", TelemetryResult.Failure, new KeyValuePair<string, object>("librariesfailedtodelete", results.Where(r => !r.Success).Count()));
             }
-
-            // Do we need this? We could log the individual errors for each library instead
-            //TelemetryResult result = configProjectItem != null ? TelemetryResult.Success : TelemetryResult.Failure;
-            //Telemetry.TrackUserTask("clean", new KeyValuePair<string, object>("filesdeleted", filesDeleted));
         }
 
         private static async Task<IEnumerable<ILibraryInstallationResult>> RestoreLibrariesAsync(Manifest manifest, CancellationToken cancellationToken)

--- a/src/LibraryManager.Vsix/Shared/Telemetry.cs
+++ b/src/LibraryManager.Vsix/Shared/Telemetry.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
     {
         private const string _namespace = Constants.TelemetryNamespace;
 
-        public static void TrackUserTask(string name, params KeyValuePair<string, object>[] properties)
+        public static void TrackUserTask(string name, TelemetryResult result = TelemetryResult.None, params KeyValuePair<string, object>[] properties)
         {
             string actualName = name.Replace(" ", "_");
 
-            var task = new UserTaskEvent(_namespace + actualName, TelemetryResult.None);
+            var task = new UserTaskEvent(_namespace + actualName, result);
 
             foreach (KeyValuePair<string, object> property in properties)
             {
@@ -25,10 +25,10 @@ namespace Microsoft.Web.LibraryManager.Vsix
             TelemetryService.DefaultSession.PostEvent(task);
         }
 
-        public static void TrackOperation(string name, params KeyValuePair<string, object>[] properties)
+        public static void TrackOperation(string name, TelemetryResult result = TelemetryResult.None, params KeyValuePair<string, object>[] properties)
         {
             string actualName = name.Replace(" ", "_");
-            var task = new OperationEvent(_namespace + actualName, TelemetryResult.None);
+            var task = new OperationEvent(_namespace + actualName, result);
 
             foreach (KeyValuePair<string, object> property in properties)
             {

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Web.LibraryManager
                     }
                 }
 
-                if (filesDeleted == state.Files.Count())
+                if (state.Files != null && filesDeleted == state.Files.Count())
                 {
                     return LibraryInstallationResult.FromSuccess(updatedStateResult.InstallationState);
                 }

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
@@ -79,30 +79,13 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                 return new LibraryInstallationResult(desiredState, errors.ToArray());
             }
 
-
             try
             {
-                var catalog = (CdnjsCatalog)GetCatalog();
-                ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
+                ILibraryInstallationResult result = await UpdateStateAsync(desiredState, cancellationToken);
 
-                if (library == null)
+                if (!result.Success)
                 {
-                    throw new InvalidLibraryException(desiredState.LibraryId, Id);
-                }
-
-                await HydrateCacheAsync(library, cancellationToken).ConfigureAwait(false);
-
-                var files = desiredState.Files?.ToList();
-                // "Files" is optional on this provider, so when none are specified all should be used
-                if (files == null || files.Count == 0)
-                {
-                    desiredState = new LibraryInstallationState
-                    {
-                        ProviderId = Id,
-                        LibraryId = desiredState.LibraryId,
-                        DestinationPath = desiredState.DestinationPath,
-                        Files = library.Files.Keys.ToList(),
-                    };
+                    return result;
                 }
 
                 foreach (string file in desiredState.Files)
@@ -121,6 +104,56 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                         return new LibraryInstallationResult(desiredState, PredefinedErrors.CouldNotWriteFile(file));
                     }
                 }
+            }
+            catch (Exception ex) when (ex is InvalidLibraryException || ex.InnerException is InvalidLibraryException)
+            {
+                return new LibraryInstallationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.LibraryId, desiredState.ProviderId));
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return new LibraryInstallationResult(desiredState, PredefinedErrors.PathOutsideWorkingDirectory());
+            }
+            catch (Exception ex)
+            {
+                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
+                return new LibraryInstallationResult(desiredState, PredefinedErrors.UnknownException());
+            }
+
+            return LibraryInstallationResult.FromSuccess(desiredState);
+        }
+
+        /// <summary>
+        /// Updates file set on the passed in ILibraryInstallationState in case user selected to have all files included
+        /// </summary>
+        /// <param name="desiredState"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<ILibraryInstallationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (desiredState.Files != null && desiredState.Files.Count > 0)
+                {
+                    return LibraryInstallationResult.FromSuccess(desiredState);
+                }
+
+                var catalog = (CdnjsCatalog)GetCatalog();
+                ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
+
+                if (library == null)
+                {
+                    throw new InvalidLibraryException(desiredState.LibraryId, Id);
+                }
+
+                await HydrateCacheAsync(library, cancellationToken).ConfigureAwait(false);
+
+                desiredState = new LibraryInstallationState
+                {
+                    ProviderId = Id,
+                    LibraryId = desiredState.LibraryId,
+                    DestinationPath = desiredState.DestinationPath,
+                    Files = library.Files.Keys.ToList(),
+                };
             }
             catch (Exception ex) when (ex is InvalidLibraryException || ex.InnerException is InvalidLibraryException)
             {

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
@@ -88,6 +88,8 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                     return result;
                 }
 
+                desiredState = result.InstallationState;
+
                 foreach (string file in desiredState.Files)
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -104,10 +106,6 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                         return new LibraryInstallationResult(desiredState, PredefinedErrors.CouldNotWriteFile(file));
                     }
                 }
-            }
-            catch (Exception ex) when (ex is InvalidLibraryException || ex.InnerException is InvalidLibraryException)
-            {
-                return new LibraryInstallationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.LibraryId, desiredState.ProviderId));
             }
             catch (UnauthorizedAccessException)
             {
@@ -130,6 +128,11 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
         /// <returns></returns>
         public async Task<ILibraryInstallationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return LibraryInstallationResult.FromCancelled(desiredState);
+            }
+
             try
             {
                 if (desiredState.Files != null && desiredState.Files.Count > 0)

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
@@ -99,6 +99,17 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
             return LibraryInstallationResult.FromSuccess(desiredState);
         }
 
+        /// <summary>
+        /// No-op for FileSystemProvider
+        /// </summary>
+        /// <param name="desiredState"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<ILibraryInstallationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<ILibraryInstallationResult>(LibraryInstallationResult.FromSuccess(desiredState));
+        }
+
         private async Task<Stream> GetStreamAsync(ILibraryInstallationState state, string file, CancellationToken cancellationToken)
         {
             string sourceFile = state.LibraryId;

--- a/src/LibraryManager/Resources/Text.Designer.cs
+++ b/src/LibraryManager/Resources/Text.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Text {
@@ -94,6 +94,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         public static string LibrariesRestored {
             get {
                 return ResourceManager.GetString("LibrariesRestored", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update library information for {0}.
+        /// </summary>
+        public static string LibraryInfoUpdateFailed {
+            get {
+                return ResourceManager.GetString("LibraryInfoUpdateFailed", resourceCulture);
             }
         }
         

--- a/src/LibraryManager/Resources/Text.resx
+++ b/src/LibraryManager/Resources/Text.resx
@@ -147,4 +147,7 @@
     <value>Library restore was unsuccessfull</value>
     <comment>Status message</comment>
   </data>
+  <data name="LibraryInfoUpdateFailed" xml:space="preserve">
+    <value>Failed to update library information for {0}</value>
+  </data>
 </root>

--- a/test/LibraryManager.Mocks/Provider.cs
+++ b/test/LibraryManager.Mocks/Provider.cs
@@ -71,5 +71,16 @@ namespace Microsoft.Web.LibraryManager.Mocks
         {
             return Task.FromResult(Result);
         }
+
+        /// <summary>
+        /// No-op
+        /// </summary>
+        /// <param name="desiredState"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public virtual Task<ILibraryInstallationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Result);
+        }
     }
 }


### PR DESCRIPTION
It's a bit ugly but I think it's OK for preview 3. Not sure if we should propagate the update failure out and fail the entire Clean operation (may have cleaned some but not all libraries - success or failure?).

We should test the FileSystem provider though as well. The code says Files should be required, not sure if it's enforced.