### PR TITLE
Fix for bug 568371 (changes in library version are ignored)

### DIFF
--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
                         File.Delete(absoluteFile);
                     }
 
-                    Logger.Log(string.Format(LibraryManager.Resources.Text.FileDeleted, relativeFilePath), LogLevel.Operation);
+                    Logger.Log(string.Format(LibraryManager.Resources.Text.FileDeleted, relativeFilePath.Replace(Path.DirectorySeparatorChar, '/')), LogLevel.Operation);
                 }
                 catch (Exception)
                 {
-                    Logger.Log(string.Format(LibraryManager.Resources.Text.FileDeleteFail, relativeFilePath), LogLevel.Operation);
+                    Logger.Log(string.Format(LibraryManager.Resources.Text.FileDeleteFail, relativeFilePath.Replace(Path.DirectorySeparatorChar, '/')), LogLevel.Operation);
                 }
             }
         }

--- a/src/LibraryManager.Vsix/Json/FileIdentifier.cs
+++ b/src/LibraryManager.Vsix/Json/FileIdentifier.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Json
+{
+    /// <summary>
+    /// Represents a unique identifier for a version of a library file 
+    /// </summary>
+    internal class FileIdentifier : IEquatable<FileIdentifier>
+    {
+        public string Path { get; }
+        public string Version { get; }
+
+        public FileIdentifier(string path, string version)
+        {
+            Path = path;
+            Version = version;
+        }
+
+        public bool Equals(FileIdentifier other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return Path.Equals(other.Path, StringComparison.OrdinalIgnoreCase) && 
+                   Version.Equals(other.Version, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
 
         private async Task RemoveFilesAsync(Manifest newManifest)
         {
-            IEnumerable<string> prevFiles = await GetAllManifestFilesAsync(_manifest).ConfigureAwait(false);
-            IEnumerable<string> newFiles = await GetAllManifestFilesAsync(newManifest).ConfigureAwait(false);
-            IEnumerable<string> filesToRemove = prevFiles.Where(f => !newFiles.Contains(f));
+            IEnumerable<string> prevFiles = await GetAllManifestFilesWithVersionsAsync(_manifest).ConfigureAwait(false);
+            IEnumerable<string> newFiles = await GetAllManifestFilesWithVersionsAsync(newManifest).ConfigureAwait(false);
+            IEnumerable<string> filesToRemove = prevFiles.Where(f => !newFiles.Contains(f)).Select(f => f.Substring(0, f.LastIndexOf(Path.DirectorySeparatorChar)));
 
             if (filesToRemove.Any())
             {
@@ -72,13 +72,22 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
             }
         }
 
-        private async Task<IEnumerable<string>> GetAllManifestFilesAsync(Manifest manifest)
+        /// <summary>
+        /// Returns file path of all files in the manifest suffixed with library version number.
+        /// For example, if library jQuery 3.3.0 specifies path "lib\js", then file jQuery.js would
+        /// get returned as lib\js\jQuery.js\3.3.0
+        /// </summary>
+        /// <param name="manifest">Library manifest to use</param>
+        /// <returns>Version-suffixed relative file paths for all libraries in the manifest</returns>
+        private async Task<IEnumerable<string>> GetAllManifestFilesWithVersionsAsync(Manifest manifest)
         {
             var files = new List<string>();
 
             foreach (ILibraryInstallationState state in manifest.Libraries.Where(l => l.IsValid(out var errors)))
             {
-                IEnumerable<string> stateFiles = await GetFilesAsync(state).ConfigureAwait(false);
+                IEnumerable<string> stateFiles = await GetFilesWithVersionsAsync(state).ConfigureAwait(false);
+
+                // TODO: {alexgav} - n-square query? Might be a concern
                 IEnumerable<string> filesToAdd = stateFiles
                     .Select(f => Path.Combine(state.DestinationPath, f))
                     .Where(f => !files.Contains(f));
@@ -89,7 +98,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
             return files;
         }
 
-        private async Task<IEnumerable<string>> GetFilesAsync(ILibraryInstallationState state)
+        private async Task<IEnumerable<string>> GetFilesWithVersionsAsync(ILibraryInstallationState state)
         {
             if (state.Files == null)
             {
@@ -98,7 +107,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                 if (catalog != null)
                 {
                     ILibrary library = await catalog?.GetLibraryAsync(state.LibraryId, CancellationToken.None);
-                    return library?.Files.Keys.ToList();
+                    return library?.Files.Keys.Select((f) => Path.Combine(f, library.Version)).ToList();
                 }
             }
 

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" />
-  <Import Project ="..\..\LibraryManager.Settings.targets" />
+  <Import Project="..\..\LibraryManager.Settings.targets" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -102,6 +102,7 @@
     <Compile Include="Json\Completion\PathCompletionProvider.cs" />
     <Compile Include="Json\Completion\ProviderCompletionProvider.cs" />
     <Compile Include="Json\Completion\CompletionController.cs" />
+    <Compile Include="Json\FileIdentifier.cs" />
     <Compile Include="Json\JsonHelpers.cs" />
     <Compile Include="Json\SuggestedActions\UpdateSuggestedAction.cs" />
     <Compile Include="Json\SuggestedActions\UpdateSuggestedActionSet.cs" />


### PR DESCRIPTION
Code wans't using library version number when doing comparison of files from the old and new libraries, only relative installation path (which has no version info in it). Adding version info temporarily for comparison (then removing prior to installation). A bit dirty. Please comment if you think we want a cleaner fix (use a class / tuple with file path and version number as fields rather than just a path?)