### PR TITLE
Fixing multiple output windows bug

### DIFF
--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -16,11 +17,12 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
             string cwd = Path.GetDirectoryName(configFilePath);
             WorkingDirectory = cwd;
+            Logger = new PerProjectLogger(VsHelpers.GetProjectName(configFilePath));
         }
 
         public string WorkingDirectory { get; }
         public string CacheDirectory => Constants.CacheFolder;
-        public ILogger Logger { get; } = new Logger();
+        public ILogger Logger { get; } 
 
         public async Task<bool> WriteFileAsync(string path, Func<Stream> content, ILibraryInstallationState state, CancellationToken cancellationToken)
         {

--- a/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
+++ b/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Web.LibraryManager.Contracts;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Contracts
+{
+    internal class PerProjectLogger : ILogger
+    {
+        private string _projectName;
+
+        public PerProjectLogger(string projectName)
+        {
+            _projectName = projectName;
+        }
+
+        public void Log(string message, LogLevel level)
+        {
+            Logger.Log($"{message} ({_projectName})", level);
+        }
+    }
+}

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -8,6 +8,7 @@ using Microsoft.Web.Editor.SuggestedActions;
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -64,7 +65,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
             catch (Exception ex)
             {
-                Logger.LogEvent(ex.ToString(), Contracts.LogLevel.Error);
+                Logger.LogEvent(ex.ToString(), LogLevel.Error);
             }
         }
     }

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Contracts\HostInteraction.cs" />
     <Compile Include="Contracts\LibraryInstallationState.cs" />
     <Compile Include="Contracts\Logger.cs" />
+    <Compile Include="Contracts\PerProjectLogger.cs" />
     <Compile Include="ErrorList\DisplayError.cs" />
     <Compile Include="ErrorList\ErrorList.cs" />
     <Compile Include="ErrorList\SinkManager.cs" />

--- a/src/LibraryManager.Vsix/source.extension.vsixmanifest
+++ b/src/LibraryManager.Vsix/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>library, package, client-side, install</Tags>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.6,16.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27428.0,16.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
… was already static. However, all of the web editors code checks for pane existence prior to creating one. Not sure how it can exist if our static is null, but it appears to be possible. So checking for existence before creating seems to fix that.

I still went ahead and added (ProjectName) suffix to messages. However, the current logging design is kinf of iffy. Existing Log was a essentially a static class, but wasn't declared as such because Mads wanted it to implement ILogger interface. So we were actually creating multiple instances of that essentially static class... Really weird. Anyway, I created PerProjectLogger that has instance data now, and converted Logger into the actual static class it was really supposed to be. So PerProjectLogger suffixes messages with project name, while static messages of the Logger don't... It doesn't look horrible, but a bit weird. We can discuss the design more. Below is example output restoring jquery in two different projects in the same solution.

Restoring jquery@3.3.0... (WebApplication1)

1 libraries restored in 0.22 seconds

Restoring jquery@3.3.0... (WebApplication3)

1 libraries restored in 0.07 seconds