### PR TITLE
Bug 577597 fix

### DIFF
--- a/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryHelpers.cs
@@ -85,8 +85,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
                 foreach (ILibraryInstallationResult result in results)
                 {
-                    telResult.TryGetValue(result.InstallationState.ProviderId, out double count);
-                    telResult[result.InstallationState.ProviderId] = count + 1;
+                    if (result.InstallationState.ProviderId != null)
+                    {
+                        telResult.TryGetValue(result.InstallationState.ProviderId, out double count);
+                        telResult[result.InstallationState.ProviderId] = count + 1;
+                    }
                 }
             }
 


### PR DESCRIPTION
VS crashes on restore when manifest does not have a provider specified