### PR TITLE
Fixing restore bug: 578106

### DIFF
--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
 
             if (manifest != null)
             {
-                foreach (ILibraryInstallationState state in manifest.Libraries.Where(l => l.IsValid(out var errors)))
+                foreach (ILibraryInstallationState state in manifest.Libraries.Where(l => l.IsValid(out IEnumerable<IError> errors)))
                 {
                     IEnumerable<FileIdentifier> stateFiles = await GetFilesWithVersionsAsync(state).ConfigureAwait(false);
 
@@ -91,7 +91,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                     }
                 }
             }
-
 
             return files;
         }

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -76,18 +76,22 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
         {
             var files = new List<FileIdentifier>();
 
-            foreach (ILibraryInstallationState state in manifest.Libraries.Where(l => l.IsValid(out var errors)))
+            if (manifest != null)
             {
-                IEnumerable<FileIdentifier> stateFiles = await GetFilesWithVersionsAsync(state).ConfigureAwait(false);
-
-                foreach (FileIdentifier fileIdentifier in stateFiles)
+                foreach (ILibraryInstallationState state in manifest.Libraries.Where(l => l.IsValid(out var errors)))
                 {
-                    if (!files.Contains(fileIdentifier))
+                    IEnumerable<FileIdentifier> stateFiles = await GetFilesWithVersionsAsync(state).ConfigureAwait(false);
+
+                    foreach (FileIdentifier fileIdentifier in stateFiles)
                     {
-                        files.Add(fileIdentifier);
+                        if (!files.Contains(fileIdentifier))
+                        {
+                            files.Add(fileIdentifier);
+                        }
                     }
                 }
             }
+
 
             return files;
         }

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -411,6 +411,28 @@
       </VSIXSourceItem>
     </ItemGroup>
   </Target>
+  <!-- This is a copy of the Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package, but only the list of
+       assemblies that we need. The package includes things like EnvDTE which are reasonable for consumers, but
+       strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->
+  <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="
+              '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.10.0'
+              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'
+              ">
+        <EmbedInteropTypes>false</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+    <ItemGroup>
+      <ReferencePath Condition="
+              '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime'
+              or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime'
+              or '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
+              ">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
@@ -135,10 +135,6 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
 
             try
             {
-                if (desiredState.Files != null && desiredState.Files.Count > 0)
-                {
-                    return LibraryInstallationResult.FromSuccess(desiredState);
-                }
 
                 var catalog = (CdnjsCatalog)GetCatalog();
                 ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
@@ -149,6 +145,11 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                 }
 
                 await HydrateCacheAsync(library, cancellationToken).ConfigureAwait(false);
+
+                if (desiredState.Files != null && desiredState.Files.Count > 0)
+                {
+                    return LibraryInstallationResult.FromSuccess(desiredState);
+                }
 
                 desiredState = new LibraryInstallationState
                 {

--- a/test/LibraryManager.Test/ManifestTest.cs
+++ b/test/LibraryManager.Test/ManifestTest.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Web.LibraryManager.Test
             var manifest = Manifest.FromJson(_docDefaultProvider, _dependencies);
             IEnumerable<ILibraryInstallationResult> result = await manifest.RestoreAsync(CancellationToken.None).ConfigureAwait(false);
 
-            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual(2, result.Count());
             Assert.AreEqual(1, result.Count(v => v.Success));
             Assert.AreEqual(manifest.DefaultProvider, result.First().InstallationState.ProviderId);
         }


### PR DESCRIPTION
- When a libman.json file fails to parse initially, we get a null manifest leading to exceptions