### PR TITLE
Dev/raquela/bug fixes

### DIFF
--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Editor;
-using Microsoft.VisualStudio.Language.Intellisense;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.TextManager.Interop;
-using Microsoft.VisualStudio.Utilities;
-using Microsoft.Web.LibraryManager.Contracts;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -15,6 +8,13 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Json
 {
@@ -104,15 +104,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
         private async Task<IEnumerable<FileIdentifier>> GetFilesWithVersionsAsync(ILibraryInstallationState state)
         {
             ILibraryCatalog catalog = _dependencies.GetProvider(state.ProviderId)?.GetCatalog();
+            ILibrary library = await catalog?.GetLibraryAsync(state.LibraryId, CancellationToken.None);
             IEnumerable<FileIdentifier> filesWithVersions = new List<FileIdentifier>();
 
-            if (catalog != null)
+            if (library != null && library.Files != null)
             {
-                ILibrary library = await catalog?.GetLibraryAsync(state.LibraryId, CancellationToken.None);
-                IEnumerable<string> libraryStateFiles = state?.Files?.Where(f => library.Files.Keys.Contains(f));
-                if (libraryStateFiles != null && libraryStateFiles.Any())
+                IEnumerable<string> desiredStateFiles = state?.Files?.Where(f => library.Files.Keys.Contains(f));
+                if (desiredStateFiles != null && desiredStateFiles.Any())
                 {
-                    filesWithVersions = libraryStateFiles.Select(f => new FileIdentifier(Path.Combine(state.DestinationPath, f), library.Version));
+                    filesWithVersions = desiredStateFiles.Select(f => new FileIdentifier(Path.Combine(state.DestinationPath, f), library.Version));
                 }
             }
 

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
             if (catalog != null)
             {
                 ILibrary library = await catalog?.GetLibraryAsync(state.LibraryId, CancellationToken.None);
-                filesWithVersions = library?.Files.Select(f => new FileIdentifier(Path.Combine(state.DestinationPath, f.Key), library.Version));
+                filesWithVersions = library?.Files?.Select(f => new FileIdentifier(Path.Combine(state.DestinationPath, f.Key), library.Version)) ?? filesWithVersions;
             }
 
             return filesWithVersions;

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
             try
             {
 
-                var catalog = (CdnjsCatalog)GetCatalog();
+                ILibraryCatalog catalog = GetCatalog();
                 ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
 
                 if (library == null)

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
         /// </returns>
         public async Task<ILibraryInstallationResult> InstallAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return LibraryInstallationResult.FromCancelled(desiredState);
+            }
+
             if (!desiredState.IsValid(out IEnumerable<IError> errors))
             {
                 return new LibraryInstallationResult(desiredState, errors.ToArray());
@@ -65,6 +70,15 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 
             try
             {
+                ILibraryInstallationResult result = await UpdateStateAsync(desiredState, cancellationToken);
+
+                if (!result.Success)
+                {
+                    return result;
+                }
+
+                desiredState = result.InstallationState;
+
                 foreach (string file in desiredState.Files)
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -82,6 +96,55 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
                     }
                 }
             }
+            catch (UnauthorizedAccessException)
+            {
+                return new LibraryInstallationResult(desiredState, PredefinedErrors.PathOutsideWorkingDirectory());
+            }
+            catch (Exception ex)
+            {
+                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
+                return new LibraryInstallationResult(desiredState, PredefinedErrors.UnknownException());
+            }
+
+            return LibraryInstallationResult.FromSuccess(desiredState);
+        }
+
+        /// <summary>
+        /// Updates file set on the passed in ILibraryInstallationState in case user selected to have all files included
+        /// </summary>
+        /// <param name="desiredState"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<ILibraryInstallationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return LibraryInstallationResult.FromCancelled(desiredState);
+            }
+
+            try
+            {
+                var catalog = (FileSystemCatalog)GetCatalog();
+                ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
+
+                if (library == null)
+                {
+                    throw new InvalidLibraryException(desiredState.LibraryId, Id);
+                }
+
+                if (desiredState.Files != null && desiredState.Files.Count > 0)
+                {
+                    return LibraryInstallationResult.FromSuccess(desiredState);
+                }
+
+                desiredState = new LibraryInstallationState
+                {
+                    ProviderId = Id,
+                    LibraryId = desiredState.LibraryId,
+                    DestinationPath = desiredState.DestinationPath,
+                    Files = library.Files.Keys.ToList(),
+                };
+            }
             catch (Exception ex) when (ex is InvalidLibraryException || ex.InnerException is InvalidLibraryException)
             {
                 return new LibraryInstallationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.LibraryId, desiredState.ProviderId));
@@ -97,17 +160,6 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
             }
 
             return LibraryInstallationResult.FromSuccess(desiredState);
-        }
-
-        /// <summary>
-        /// No-op for FileSystemProvider
-        /// </summary>
-        /// <param name="desiredState"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Task<ILibraryInstallationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<ILibraryInstallationResult>(LibraryInstallationResult.FromSuccess(desiredState));
         }
 
         private async Task<Stream> GetStreamAsync(ILibraryInstallationState state, string file, CancellationToken cancellationToken)

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 
             try
             {
-                var catalog = (FileSystemCatalog)GetCatalog();
+                ILibraryCatalog catalog = GetCatalog();
                 ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
 
                 if (library == null)


### PR DESCRIPTION
578139: LibMan: restore fails on a valid manifest
586286: LibMan: library files are not properly deleted when updating a library to have Files property

To summarize these changes, basically we need to populate the “Files” property (call UpdateStateAsync) when deleting the files before restoring on “File Save”. We were only doing that during install which was causing unwanted files left behind after restore.
We also needed to implement the UpdateStateAsync for FileSystem so we can also populate the Files property when user specifies a folder as  a library.  
