### PR TITLE
Fixing FileNotFoundException when trying to load Nuget.VisualStudio.

### DIFF
--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -426,7 +426,9 @@
     <ItemGroup>
       <ReferencePath Condition="
               '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'
+              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'
               or '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
+              or '%(FileName)' == 'Nuget.VisualStudio'
               ">
         <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -425,9 +425,9 @@
     </ItemGroup>
     <ItemGroup>
       <ReferencePath Condition="
-              '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'
+              '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
               or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'
-              or '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
+              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'
               or '%(FileName)' == 'Nuget.VisualStudio'
               ">
         <EmbedInteropTypes>true</EmbedInteropTypes>


### PR DESCRIPTION
Fixing FileNotFoundException when trying to load Nuget.VisualStudio. 
This failure started happening after we moved to packageReferences. Updating the version of the package fixes the issue.