### PR TITLE
Fixing unecessary check for validation of InstallationState

### DIFF
--- a/src/LibraryManager.Vsix/Json/JsonHelpers.cs
+++ b/src/LibraryManager.Vsix/Json/JsonHelpers.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             installationState = state;
 
-            return !string.IsNullOrEmpty(installationState.ProviderId) && !string.IsNullOrEmpty(installationState.DestinationPath);
+            return !string.IsNullOrEmpty(installationState.ProviderId);
         }
     }
 }


### PR DESCRIPTION
Bug 588017: LibMan: library property completion does not work if there is no defaultPath specified
This is a regression introduced during the schema change PR.