### PR TITLE
Fix for 586227 - LibMan: null ref exception when editing library prop…

### DIFF
--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -51,7 +51,10 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 yield break;
             }
 
-            int caretPosition = context.Session.TextView.Caret.Position.BufferPosition - member.Value.Start - 1;
+            // member.Value is null when there is no value yet, e.g. when typing a space at "library":|
+            // where | represents caret position. In this case, set caretPosition to "1" to short circuit execution of this function
+            // and return no entries (member.UnquotedValueText will be empty string in that case).
+            int caretPosition = member.Value != null ? context.Session.TextView.Caret.Position.BufferPosition - member.Value.Start - 1 : 1;
 
             if (caretPosition > member.UnquotedValueText.Length)
             {


### PR DESCRIPTION
…erty

If you are typing everything from scratch rather than using completion, you won't get "" in the value of the "library" (library id), and member.Value is null. E.g. if typing a space after

"library":

you'd have null member.Value and would get nullref exception. The fix is to check for that and set caretPosition to 1 in that case so the code below will short circuit/return no entries.