### PR TITLE
Private assets

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -42,7 +42,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\LibraryManager\Microsoft.Web.LibraryManager.csproj" />
+      <ProjectReference Include="..\LibraryManager\Microsoft.Web.LibraryManager.csproj" PrivateAssets="all" />
     </ItemGroup>
 
     <Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">

--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -22,7 +22,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.1012" PrivateAssets="All" />
-        <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="All" />
         <PackageReference Include="System.Runtime.Loader" Version="4.3.0" Condition="'$(TargetFramework)' == 'netstandard1.5'" />
     </ItemGroup>
 

--- a/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
+++ b/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
@@ -26,7 +26,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NerdBank.GitVersioning" Version="2.1.23" />
+        <PackageReference Include="NerdBank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
     </ItemGroup>
 
   <!-- Warning if Multilingual App Toolkit isn't installed -->

--- a/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
+++ b/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
     <ProjectReference Include="..\LibraryManager.Contracts\Microsoft.Web.LibraryManager.Contracts.csproj" />
     <Reference Include="System.ComponentModel.Composition" Condition="'$(TargetFramework)' != 'netstandard1.3'" />


### PR DESCRIPTION
Set PrivateAssets on references to prevent them from leaking into the consuming project for the Build nupkg.