### PR TITLE
Fixes InstallationTarget for 15.6

### DIFF
--- a/src/LibraryManager.Vsix/source.extension.vsixmanifest
+++ b/src/LibraryManager.Vsix/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
         <Tags>library, package, client-side, install</Tags>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.6,16.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27428.0,16.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Even though VS has started using the Minor version value, VSIXes still need to use 15.0.<build> to target a specific release.