### PR TITLE
Fixing incorrect library name IntelliSense

### DIFF
--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -12,12 +12,15 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.LibraryManager.Contracts;
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
     public class CompletionController : IOleCommandTarget
     {
+        internal const string RetriggerCompletion = "LibManForceRetrigger";
+
         private ITextView _textView;
         private IOleCommandTarget _nextCommandTarget;
         private ICompletionBroker _broker;
@@ -95,10 +98,26 @@ namespace Microsoft.Web.LibraryManager.Vsix
             _lastTyped = DateTime.Now;
             int delay = force ? 50 : _delay;
 
+            // Don't leave "stale" completion session up while the user is typing, or else we could
+            // get completion from a stale session.
+            ICompletionSession completionSession = _broker.GetSessions(_textView).FirstOrDefault();
+            if (completionSession != null && completionSession.Properties.TryGetProperty<bool>(RetriggerCompletion, out bool retrigger) && retrigger)
+            {
+                completionSession.Dismiss();
+            }
+
             await System.Threading.Tasks.Task.Delay(delay);
 
             // Prevents retriggering from happening while typing fast
             if (_lastTyped.AddMilliseconds(delay) > DateTime.Now)
+            {
+                return;
+            }
+
+            // Completion may have gotten invoked via by Web Editor OnPostTypeChar(). Don't invoke again, or else we get flikering completion list
+            // TODO:Review the design here post-preview 4 and make sure this completion controller doesn't clash with Web Editors JSON completion controller
+            completionSession = _broker.GetSessions(_textView).FirstOrDefault();
+            if (completionSession != null && completionSession.Properties.TryGetProperty<bool>(RetriggerCompletion, out retrigger))
             {
                 return;
             }

--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -64,6 +64,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
             Task<CompletionSet> task = catalog.GetLibraryCompletionSetAsync(member.UnquotedValueText, caretPosition);
             int count = 0;
 
+            if (!context.Session.Properties.ContainsProperty(CompletionController.RetriggerCompletion))
+            {
+                context.Session.Properties.AddProperty(CompletionController.RetriggerCompletion, true);
+            }
+
             if (task.IsCompleted)
             {
                 CompletionSet set = task.Result;

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -38,9 +38,8 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
         public void VsTextViewCreated(IVsTextView textViewAdapter)
         {
             IWpfTextView textView = EditorAdaptersFactoryService.GetWpfTextView(textViewAdapter);
-            new CompletionController(textViewAdapter, textView, CompletionBroker);
 
-            if (!DocumentService.TryGetTextDocument(textView.TextBuffer, out var doc))
+            if (!DocumentService.TryGetTextDocument(textView.TextBuffer, out ITextDocument doc))
             {
                 return;
             }
@@ -51,6 +50,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
             {
                 return;
             }
+
+            new CompletionController(textViewAdapter, textView, CompletionBroker);
+
 
             _dependencies = Dependencies.FromConfigFile(doc.FilePath);
             _manifest = Manifest.FromFileAsync(doc.FilePath, _dependencies, CancellationToken.None).Result;


### PR DESCRIPTION
Fixing bug 568369 - [LibMan] IntelliSense too slow in library.json

Library name completion is slow because we are getting library names from a network request. We should look into caching them both to speed up completion and to enable offline scenarios (at least somewhat). For now the fix is scoped to avoiding the wrong completion of library name. It was possible to get completely wrong library name completion because we were leaving completion list up while the user was typing new characters of library name. The list wasn't getting either dismissed or filtered. In general, CompletionController needs design review and will possibly be re-written. For now I'm adding a workaround to make it work similar to NPM package.json library name completion, where we immediately dimiss completion list as soon as the next library name character is typed. Once the user stops typing, we make a network request and bring up completions matching the part of the library name typed in so far.

I'm scoping the fix down to the library names only for now, as this is what the bug pointed out.