### PR TITLE
Fixing multiple output window issue.

### DIFF
--- a/src/LibraryManager.Vsix/Contracts/Dependencies.cs
+++ b/src/LibraryManager.Vsix/Contracts/Dependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -32,7 +33,8 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
             if (!_cache.ContainsKey(configFilePath))
             {
-                var hostInteraction = new HostInteraction(configFilePath);
+                PerProjectLogger perProjectLogger = new PerProjectLogger(configFilePath);
+                HostInteraction hostInteraction = new HostInteraction(configFilePath, perProjectLogger);
                 _cache[configFilePath] = new Dependencies(hostInteraction);
             }
 

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -12,15 +12,16 @@ namespace Microsoft.Web.LibraryManager.Vsix
 {
     internal class HostInteraction : IHostInteraction
     {
-        public HostInteraction(string configFilePath)
+        public HostInteraction(string configFilePath, ILogger logger)
         {
             string cwd = Path.GetDirectoryName(configFilePath);
             WorkingDirectory = cwd;
+            Logger = logger;
         }
 
         public string WorkingDirectory { get; }
         public string CacheDirectory => Constants.CacheFolder;
-        public ILogger Logger { get; } = new Logger();
+        public ILogger Logger { get; internal set; } 
 
         public async Task<bool> WriteFileAsync(string path, Func<Stream> content, ILibraryInstallationState state, CancellationToken cancellationToken)
         {

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -1,23 +1,21 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
-    internal class Logger : ILogger
+    internal static class Logger
     {
+        private static Guid _outputPaneGuid = new Guid("cce35aef-ace6-4371-b1e1-8efa3cdc8324");
         private static IVsOutputWindowPane _pane;
         private static readonly IVsOutputWindow _output = VsHelpers.GetService<SVsOutputWindow, IVsOutputWindow>();
         private static readonly IVsActivityLog _activityLog = VsHelpers.GetService<SVsActivityLog, IVsActivityLog>();
         private static readonly IVsStatusbar _statusbar = VsHelpers.GetService<SVsStatusbar, IVsStatusbar>();
 
-        public void Log(string message, LogLevel level)
-        {
-            LogEvent(message, level);
-        }
 
         public static void LogEvent(string message, LogLevel level)
         {
@@ -75,9 +73,17 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
             if (_pane == null)
             {
-                var guid = Guid.NewGuid();
-                _output.CreatePane(ref guid, Vsix.Name, 1, 1);
-                _output.GetPane(ref guid, out _pane);
+                if (_output != null)
+                {
+                    if (ErrorHandler.Failed(_output.GetPane(ref _outputPaneGuid, out _pane)) &&
+                        ErrorHandler.Succeeded(_output.CreatePane(ref _outputPaneGuid, Vsix.Name, 0, 0)))
+                    {
+                        if (ErrorHandler.Succeeded(_output.GetPane(ref _outputPaneGuid, out _pane)))
+                        {
+                            _pane.Activate();
+                        }
+                    }
+                }
             }
 
             return _pane != null;

--- a/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
+++ b/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Web.LibraryManager.Contracts;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Contracts
+{
+    internal class PerProjectLogger : ILogger
+    {
+        private string _configFileName;
+        private string _projectName;
+
+        private string ProjectName
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_projectName))
+                {
+                    string projectName = VsHelpers.GetDTEProjectFromConfig(_configFileName)?.Name;
+                    _projectName = string.IsNullOrEmpty(projectName) ? string.Empty : $" ({projectName})";
+                }
+
+                return _projectName;
+            }
+        }
+
+        public PerProjectLogger(string configFileName)
+        {
+            _configFileName = configFileName;
+        }
+
+        public void Log(string message, LogLevel level)
+        {
+            Logger.LogEvent($"{message}{ProjectName}", level);
+        }
+    }
+}

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
             catch (Exception ex)
             {
-                Logger.LogEvent(ex.ToString(), Contracts.LogLevel.Error);
+                Logger.LogEvent(ex.ToString(), Microsoft.Web.LibraryManager.Contracts.LogLevel.Error);
             }
         }
     }

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Contracts\HostInteraction.cs" />
     <Compile Include="Contracts\LibraryInstallationState.cs" />
     <Compile Include="Contracts\Logger.cs" />
+    <Compile Include="Contracts\PerProjectLogger.cs" />
     <Compile Include="ErrorList\DisplayError.cs" />
     <Compile Include="ErrorList\ErrorList.cs" />
     <Compile Include="ErrorList\SinkManager.cs" />
@@ -416,20 +417,12 @@
        strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->
   <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
     <ItemGroup>
-      <ReferencePath Condition="
-              '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.10.0'
-              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'
-              ">
+      <ReferencePath Condition="&#xD;&#xA;              '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.10.0'&#xD;&#xA;              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'&#xD;&#xA;              ">
         <EmbedInteropTypes>false</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>
     <ItemGroup>
-      <ReferencePath Condition="
-              '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
-              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'
-              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'
-              or '%(FileName)' == 'Nuget.VisualStudio'
-              ">
+      <ReferencePath Condition="&#xD;&#xA;              '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'&#xD;&#xA;              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'&#xD;&#xA;              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'&#xD;&#xA;              or '%(FileName)' == 'Nuget.VisualStudio'&#xD;&#xA;              ">
         <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using EnvDTE;
-using EnvDTE80;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -80,7 +80,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
             catch (Exception ex)
             {
-                Logger.LogEvent(ex.ToString(), Contracts.LogLevel.Error);
+                Logger.LogEvent(ex.ToString(), Microsoft.Web.LibraryManager.Contracts.LogLevel.Error);
                 System.Diagnostics.Debug.Write(ex);
             }
         }
@@ -304,7 +304,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
             catch (Exception ex)
             {
-                Logger.LogEvent(ex.ToString(), Contracts.LogLevel.Error);
+                Logger.LogEvent(ex.ToString(), LibraryManager.Contracts.LogLevel.Error);
                 System.Diagnostics.Debug.Write(ex);
             }
 


### PR DESCRIPTION
Internal bug 568432 - LibMan: multiple "Microsoft Library Manager" entries in the Output window when there are multiple library restore operations happening