### PR TITLE
- Adding helpers to get selected ProjectItem and selected ProjectItem…

### DIFF
--- a/src/LibraryManager.Build/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Build/Contracts/HostInteraction.cs
@@ -66,9 +66,11 @@ namespace Microsoft.Web.LibraryManager.Build
 
                 try
                 {
-                    File.Delete(absoluteFile);
-
-                    Logger.Log(string.Format(Resources.Text.FileDeleted, relativeFilePath), LogLevel.Operation);
+                    if (File.Exists(absoluteFile))
+                    {
+                        File.Delete(absoluteFile);
+                        Logger.Log(string.Format(Resources.Text.FileDeleted, relativeFilePath), LogLevel.Operation);
+                    }
                 }
                 catch (Exception)
                 {

--- a/src/LibraryManager.Vsix/Commands/CleanCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/CleanCommand.cs
@@ -45,12 +45,9 @@ namespace Microsoft.Web.LibraryManager.Vsix
             var button = (OleMenuCommand)sender;
             button.Visible = button.Enabled = false;
 
-            if (VsHelpers.DTE.SelectedItems.MultiSelect)
-                return;
+            ProjectItem item = VsHelpers.GetSelectedProjectItem();
 
-            ProjectItem item = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem;
-
-            if (item.Name.Equals(Constants.ConfigFileName, StringComparison.OrdinalIgnoreCase))
+            if (item != null && item.Name.Equals(Constants.ConfigFileName, StringComparison.OrdinalIgnoreCase))
             {
                 button.Visible = true;
                 button.Enabled = KnownUIContexts.SolutionExistsAndNotBuildingAndNotDebuggingContext.IsActive;
@@ -59,7 +56,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         private async void ExecuteAsync(object sender, EventArgs e)
         {
-            ProjectItem configProjectItem = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem;
+            ProjectItem configProjectItem = VsHelpers.GetSelectedProjectItem();
 
             if (configProjectItem != null)
                 await LibraryHelpers.CleanAsync(configProjectItem);

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             OleMenuCommand button = (OleMenuCommand)sender;
             button.Visible = button.Enabled = false;
 
-            ProjectItem item = VsHelpers.DTE.SelectedItems.Item(1)?.ProjectItem;
+            ProjectItem item = VsHelpers.GetSelectedItem();
 
             if (item?.ContainingProject == null || !item.ContainingProject.IsSupported())
             {
@@ -52,17 +52,25 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
             Telemetry.TrackUserTask("installdialogopened");
 
-            ProjectItem item = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem;
-            string target = item.FileNames[1];
+            ProjectItem item = VsHelpers.GetSelectedItem();
 
-            Project project = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem.ContainingProject;
-            string rootFolder = project.GetRootFolder();
+            if (item != null)
+            {
+                string target = item.FileNames[1];
 
-            string configFilePath = Path.Combine(rootFolder, Constants.ConfigFileName);
-            IDependencies dependencies = Dependencies.FromConfigFile(configFilePath);
+                Project project = VsHelpers.GetSelectedItemProject();
 
-            UI.InstallDialog dialog = new UI.InstallDialog(dependencies, configFilePath, target);
-            dialog.ShowDialog();
+                if (project != null)
+                {
+                    string rootFolder = project.GetRootFolder();
+
+                    string configFilePath = Path.Combine(rootFolder, Constants.ConfigFileName);
+                    IDependencies dependencies = Dependencies.FromConfigFile(configFilePath);
+
+                    UI.InstallDialog dialog = new UI.InstallDialog(dependencies, configFilePath, target);
+                    dialog.ShowDialog();
+                }
+            }
         }
     }
 }

--- a/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
@@ -44,20 +44,24 @@ namespace Microsoft.Web.LibraryManager.Vsix
         private void Execute(object sender, EventArgs e)
         {
             Telemetry.TrackUserTask("ManageLibraries");
-            Project project = VsHelpers.DTE.SelectedItems.Item(1).Project;
-            string rootFolder = project.GetRootFolder();
 
-            string configFilePath = Path.Combine(rootFolder, Constants.ConfigFileName);
+            Project project = VsHelpers.GetProjectOfSelectedProjectItem();
 
-            if (File.Exists(configFilePath))
+            if (project != null)
             {
-                VsHelpers.DTE.ItemOperations.OpenFile(configFilePath);
-            }
-            else
-            {
-                System.Threading.Tasks.Task.Run(async () =>
+                string rootFolder = project.GetRootFolder();
+
+                string configFilePath = Path.Combine(rootFolder, Constants.ConfigFileName);
+
+                if (File.Exists(configFilePath))
                 {
-                    CancellationToken token = CancellationToken.None;
+                    VsHelpers.DTE.ItemOperations.OpenFile(configFilePath);
+                }
+                else
+                {
+                    System.Threading.Tasks.Task.Run(async () =>
+                    {
+                        CancellationToken token = CancellationToken.None;
 
                     if (!File.Exists(configFilePath))
                     {
@@ -66,14 +70,15 @@ namespace Microsoft.Web.LibraryManager.Vsix
                         manifest.DefaultProvider = "cdnjs";
                         manifest.Version = Manifest.SupportedVersions.Max().ToString();
 
-                        await manifest.SaveAsync(configFilePath, token);
-                        project.AddFileToProject(configFilePath);
+                            await manifest.SaveAsync(configFilePath, token);
+                            project.AddFileToProject(configFilePath);
 
-                        Telemetry.TrackUserTask("ConfigFileCreated");
-                    }
+                            Telemetry.TrackUserTask("ConfigFileCreated");
+                        }
 
-                    VsHelpers.DTE.ItemOperations.OpenFile(configFilePath);
-                });
+                        VsHelpers.DTE.ItemOperations.OpenFile(configFilePath);
+                    });
+                }
             }
         }
     }

--- a/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Web.LibraryManager.Vsix
             if (VsHelpers.DTE.SelectedItems.MultiSelect)
                 return;
 
-            ProjectItem item = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem;
+            ProjectItem item = VsHelpers.GetSelectedProjectItem();
 
-            if (item.Name.Equals(Constants.ConfigFileName, StringComparison.OrdinalIgnoreCase))
+            if (item != null && item.Name.Equals(Constants.ConfigFileName, StringComparison.OrdinalIgnoreCase))
             {
                 button.Visible = true;
                 button.Enabled = KnownUIContexts.SolutionExistsAndNotBuildingAndNotDebuggingContext.IsActive;
@@ -51,7 +51,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         private async void ExecuteAsync(object sender, EventArgs e)
         {
-            ProjectItem configProjectItem = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem;
+            ProjectItem configProjectItem = VsHelpers.GetSelectedProjectItem(); ;
 
             if (configProjectItem != null)
                 await LibraryHelpers.RestoreAsync(configProjectItem.FileNames[1]);

--- a/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 return;
             }
 
-            ProjectItem item = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem;
+            ProjectItem item = VsHelpers.GetSelectedProjectItem();
 
-            if (item.IsConfigFile() && (item.ContainingProject.IsKind(Constants.WAP) || 
+            if (item != null && item.IsConfigFile() && (item.ContainingProject.IsKind(Constants.WAP) || 
                 VsHelpers.IsCapabilityMatch(item.ContainingProject, Constants.DotNetCoreWebCapability)))
             {
                 button.Visible = true;
@@ -76,7 +76,8 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         private void Execute(object sender, EventArgs e)
         {
-            ProjectItem item = VsHelpers.DTE.SelectedItems.Item(1).ProjectItem;
+            ProjectItem item = VsHelpers.GetSelectedProjectItem();
+            Project project = VsHelpers.GetProjectOfSelectedProjectItem();
 
             try
             {
@@ -97,7 +98,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                             foreach (string packageId in packageIds)
                             {
                                 IVsPackageInstaller2 installer = _componentModel.GetService<IVsPackageInstaller2>();
-                                installer.InstallLatestPackage(null, item.ContainingProject, packageId, true, false);
+                                installer.InstallLatestPackage(null, project, packageId, true, false);
                             }
 
                             Telemetry.TrackUserTask("InstallNugetPackage");
@@ -121,7 +122,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                             foreach (string packageId in packageIds)
                             {
                                 IVsPackageUninstaller uninstaller = _componentModel.GetService<IVsPackageUninstaller>();
-                                uninstaller.UninstallPackage(item.ContainingProject, packageId, false);
+                                uninstaller.UninstallPackage(project, packageId, false);
                             }
 
                             Telemetry.TrackUserTask("UninstallNugetPackage");

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -75,8 +75,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
                     }
                     else
                     {
-                        VsHelpers.CheckFileOutOfSourceControl(absoluteFile);
-                        File.Delete(absoluteFile);
+                        if (File.Exists(absoluteFile))
+                        {
+                            VsHelpers.CheckFileOutOfSourceControl(absoluteFile);
+                            File.Delete(absoluteFile);
+                        }
                     }
 
                     Logger.Log(string.Format(LibraryManager.Resources.Text.FileDeleted, relativeFilePath.Replace(Path.DirectorySeparatorChar, '/')), LogLevel.Operation);

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -57,6 +57,32 @@ namespace Microsoft.Web.LibraryManager.Vsix
             };
         }
 
+        internal static ProjectItem GetSelectedProjectItem()
+        {
+            ProjectItem projectItem = null;
+
+            if (DTE?.SelectedItems.Count == 1)
+            {
+                SelectedItem selectedItem = VsHelpers.DTE.SelectedItems.Item(1);
+                projectItem = selectedItem?.ProjectItem;
+            }
+
+            return projectItem;
+        }
+
+        public static Project GetProjectOfSelectedProjectItem()
+        {
+            Project project = null;
+
+            if (DTE?.SelectedItems.Count == 1)
+            {
+                SelectedItem selectedItem = VsHelpers.DTE.SelectedItems.Item(1);
+                project = selectedItem.Project ?? selectedItem.ProjectItem?.ContainingProject;
+            }
+
+            return project;
+        }
+
         public static void AddFileToProject(this Project project, string file, string itemType = null)
         {
             if (IsCapabilityMatch(project, Constants.DotNetCoreWebCapability))

--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 
                 await manifest.SaveAsync(_configFileName, CancellationToken.None).ConfigureAwait(false);
 
-                EnvDTE.Project project = VsHelpers.DTE.SelectedItems.Item(1)?.ProjectItem?.ContainingProject;
+                EnvDTE.Project project = VsHelpers.GetSelectedItemProject();
                 project?.AddFileToProject(_configFileName);
 
                 await LibraryHelpers.RestoreAsync(_configFileName).ConfigureAwait(false);


### PR DESCRIPTION
- Adding helpers to get selected ProjectItem and selected ProjectItem…'s Project.
This also fixes error when invoking "Managing client side libraries" Project menu option and there are no projects selected.
- Adding check to delete files only if exists.