### PR TITLE
Made change to get the JSONEditorDocuemnt from text buffer

### DIFF
--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 return;
             }
 
-            var doc = JSONEditorDocument.FromTextView(_textView);
+            var doc = JSONEditorDocument.FromTextBuffer(_textView.TextBuffer);
             JSONParseItem parseItem = doc?.JSONDocument.ItemBeforePosition(_textView.Caret.Position.BufferPosition);
 
             if (parseItem == null)

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 return;
             }
 
-            var doc = JSONEditorDocument.FromTextBuffer(_textView.TextBuffer);
+            var doc = JSONEditorDocument.FromTextBuffer(_textView.TextDataModel.DocumentBuffer);
             JSONParseItem parseItem = doc?.JSONDocument.ItemBeforePosition(_textView.Caret.Position.BufferPosition);
 
             if (parseItem == null)


### PR DESCRIPTION
**What was the change?**
Made a small change to get the JSONEditorDocument from TextBufer instead of TextView

**Why?**
FromTextView(..) was made internal recently. Using public API instead - FromTextBuffer(..) instead

**How was it tested?**
Verified that completion works for the below:
- Files
- Library
- Path
- Provider
