### PR TITLE
Remove auto load from LibMan package

### DIFF
--- a/src/LibraryManager.Vsix/LibraryManagerPackage.cs
+++ b/src/LibraryManager.Vsix/LibraryManagerPackage.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Web.LibraryManager.Vsix
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    [ProvideAutoLoad(PackageGuids.guidUiContextString)]
     [ProvideUIContextRule(PackageGuids.guidUiContextConfigFileString,
         name: "ConfigFile",
         expression: "(WAP | WebSite | DotNetCoreWeb ) & Config",


### PR DESCRIPTION
We now have the PackageLoader that determines the need to load LibMan to avoid loading this package unnecessarily. 