### PR TITLE
Added logic to get ItemBeforePosition, NextSibling, PreviousSibling for completion

### DIFF
--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
 
             var doc = JSONEditorDocument.FromTextBuffer(_textView.TextDataModel.DocumentBuffer);
-            JSONParseItem parseItem = doc?.JSONDocument.ItemBeforePosition(_textView.Caret.Position.BufferPosition);
+            JSONParseItem parseItem = GetItemBeforePosition(_textView.Caret.Position.BufferPosition, doc);
 
             if (parseItem == null)
             {
@@ -143,6 +143,59 @@ namespace Microsoft.Web.LibraryManager.Vsix
             {
                 VsHelpers.DTE.ExecuteCommand("Edit.ListMembers");
             }
+        }
+
+        private JSONParseItem GetItemBeforePosition(int pos, JSONEditorDocument document)
+        {
+            JSONParseItem item = null;
+            JSONParseItemList children = document.JSONDocument.Children;
+            int start = 0;
+
+            if (children.Any())
+            {
+                start = children[0].Start;
+            }
+
+            if (start < pos)
+            {
+                int i = FindInsertIndex(children, pos, beforeExisting: true) - 1;
+
+                if (i >= 0)
+                {
+                    item = children[i];
+
+                    if (item is JSONComplexItem)
+                    {
+                        // Recurse to find the deepest item
+                        item = GetItemBeforePosition(item.Start, document);
+                    }
+                }
+            }
+
+            return item;
+        }
+
+        private int FindInsertIndex(JSONParseItemList jsonParseItems, int rangeStart, bool beforeExisting)
+        {
+            int min = 0;
+            int max = jsonParseItems.Count - 1;
+
+            while (min <= max)
+            {
+                int mid = (min + max) / 2;
+                int start = jsonParseItems[mid].Start;
+
+                if (rangeStart < start || (beforeExisting && rangeStart == start))
+                {
+                    max = mid - 1;
+                }
+                else
+                {
+                    min = mid + 1;
+                }
+            }
+
+            return max + 1;
         }
 
         public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -123,6 +123,12 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
 
             var doc = JSONEditorDocument.FromTextBuffer(_textView.TextDataModel.DocumentBuffer);
+
+            if (doc == null)
+            {
+                return;
+            }
+
             JSONParseItem parseItem = GetItemBeforePosition(_textView.Caret.Position.BufferPosition, doc);
 
             if (parseItem == null)

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -8,6 +8,7 @@ using Microsoft.Web.Editor.SuggestedActions;
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.JSON.Core.Parser;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -46,8 +47,8 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 using (ITextEdit edit = TextBuffer.CreateEdit())
                 {
                     var arrayElement = _provider.LibraryObject.Parent as JSONArrayElement;
-                    var prev = arrayElement.PreviousSibling as JSONArrayElement;
-                    var next = arrayElement.NextSibling as JSONArrayElement;
+                    var prev = GetPreviousSibling(arrayElement) as JSONArrayElement;
+                    var next = GetNextSibling(arrayElement) as JSONArrayElement;
 
                     int start = TextBuffer.CurrentSnapshot.GetLineFromPosition(arrayElement.Start).Start;
                     int end = TextBuffer.CurrentSnapshot.GetLineFromPosition(arrayElement.AfterEnd).EndIncludingLineBreak;
@@ -66,6 +67,18 @@ namespace Microsoft.Web.LibraryManager.Vsix
             {
                 Logger.LogEvent(ex.ToString(), Microsoft.Web.LibraryManager.Contracts.LogLevel.Error);
             }
+        }
+
+        private JSONParseItem GetPreviousSibling(JSONArrayElement arrayElement)
+        {
+            JSONComplexItem parent = arrayElement.Parent;
+            return parent != null ? parent.PreviousChild(arrayElement) : null;
+        }
+
+        private JSONParseItem GetNextSibling(JSONArrayElement arrayElement)
+        {
+            JSONComplexItem parent = arrayElement.Parent;
+            return parent != null ? parent.NextChild(arrayElement) : null;
         }
     }
 }

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -72,13 +72,37 @@ namespace Microsoft.Web.LibraryManager.Vsix
         private JSONParseItem GetPreviousSibling(JSONArrayElement arrayElement)
         {
             JSONComplexItem parent = arrayElement.Parent;
-            return parent != null ? parent.PreviousChild(arrayElement) : null;
+            return parent != null ? GetPreviousChild(arrayElement, parent.Children) : null;
         }
 
         private JSONParseItem GetNextSibling(JSONArrayElement arrayElement)
         {
             JSONComplexItem parent = arrayElement.Parent;
-            return parent != null ? parent.NextChild(arrayElement) : null;
+            return parent != null ? GetNextChild(arrayElement, parent.Children) : null;
+        }
+
+        private JSONParseItem GetPreviousChild(JSONParseItem child, JSONParseItemList children)
+        {
+            int index = (child != null) ? children.IndexOf(child) : -1;
+
+            if (index > 0)
+            {
+                return children[index - 1];
+            }
+
+            return null;
+        }
+
+        private JSONParseItem GetNextChild(JSONParseItem child, JSONParseItemList children)
+        {
+            int index = (child != null) ? children.IndexOf(child) : -1;
+
+            if (index != -1 && index + 1 < children.Count)
+            {
+                return children[index + 1];
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
We were consuming some APIs from WTE which I marked internal few months back. Since LibMan is the only one using these APIs, I added logic to get the necessary information here.