### PR TITLE
Issues Running RestoreTask in LibraryManager.Build

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.targets
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard1.3\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
+        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard1.5\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
         <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net46\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
     </PropertyGroup>
 

--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -13,7 +13,7 @@ using System.Threading;
 
 namespace Microsoft.Web.LibraryManager.Build
 {
-    internal class RestoreTask : Task
+    public class RestoreTask : Task
     {
         [Required]
         public string FileName { get; set; }


### PR DESCRIPTION
Current LibraryManager.Build NuGet package doesn't work when building via command line using "dotnet build". Error is:

```
Could not load file or assembly 'C:\Users\myhomedir\.nuget\packages\microsoft.web.librarymanager.build\1.0.20\build\..\tools\netstandard1.3\Microsoft.Web.LibraryManager.Build.dll'. The system cannot find the path specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask. [C:\Users\myhomedir\Source\Repos\BirdLogOld\BirdLog.Website\BirdLog.Website.csproj]
```

Also the error message said the task requires a public class that inherits from ITask so I needed to make RestoreTask public.

If this requires more discussion, feel free to reject this and I can enter this into an issue. 👍 