### PR TITLE
Fixing System.Net.Http reference

### DIFF
--- a/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
+++ b/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
@@ -17,10 +17,6 @@
         <PackageLicenseUrl>https://aka.ms/pexunj</PackageLicenseUrl>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpPackageVersion)" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
-    </ItemGroup>
-
   <!-- Warning if Multilingual App Toolkit isn't installed -->
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />
     <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">

--- a/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
+++ b/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
@@ -27,9 +27,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NET45NewtonSoftJsonPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpPackageVersion)" />
     <ProjectReference Include="..\LibraryManager.Contracts\Microsoft.Web.LibraryManager.Contracts.csproj" />
     <Reference Include="System.ComponentModel.Composition" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\Text.Designer.cs">


### PR DESCRIPTION
Fixing

The type initializer for 'Microsoft.Web.LibraryManager.WebRequestHandler' threw an exception. - FileNotFoundException: Could not load file or assembly 'System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.


First of all, Microsoft.Web.LibraryManager.Contracts.csproj has 
 
<PackageReference Include="System.Net.Http" Version="$(SystemNetHttpPackageVersion)" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
 
which it doesn't seem to need. Only Microsoft.Web.LibraryManager.csproj seems to need System.Net.Http.

Second, Microsoft.Web.LibraryManager.csproj  current uses
 
    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpPackageVersion)" />

netstandard20 already includes System.Net.Http from what I can tell, and doesn't need the package. net461 shouldn't use the package and instead should just reference the "normal" framework assembly. So I'm replacing it with
 
    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' != 'netstandard2.0'" />

That seems to get things to the working state. 