### PR TITLE
Close dialog when install button is clicked

### DIFF
--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -201,7 +201,8 @@
                     Width="65" 
                     DockPanel.Dock="Right"
                     Margin="0 0 6 0" IsDefault="True" 
-                    Command="{Binding InstallPackageCommand}">
+                    Command="{Binding InstallPackageCommand}"
+                    Click="InstallButton_Clicked">
             </Button>
         </DockPanel>
     </Grid>

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -189,5 +189,10 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI
                 LibrarySearchBox.RefreshSearch();
             }
         }
+
+        private void InstallButton_Clicked(object sender, RoutedEventArgs e)
+        {
+            CloseDialog(true);
+        }
     }
 }


### PR DESCRIPTION
Close dialog when install button is clicked to prevent UI hangs for unPkg provider.