### PR TITLE
Fix prompts for Init and Install CLI commands

### DIFF
--- a/src/libman/Commands/BaseCommand.cs
+++ b/src/libman/Commands/BaseCommand.cs
@@ -165,7 +165,10 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             return manifest;
         }
 
-        protected async Task<Manifest> CreateManifestAsync(string defaultProvider, string defaultDestination, CancellationToken cancellationToken)
+        protected async Task<Manifest> CreateManifestAsync(string defaultProvider,
+            string defaultDestination,
+            EnvironmentSettings settings,
+            CancellationToken cancellationToken)
         {
             if (File.Exists(Settings.ManifestFileName))
             {
@@ -177,7 +180,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             manifest.DefaultDestination = string.IsNullOrEmpty(defaultDestination) ? null : defaultDestination;
 
             defaultProvider = string.IsNullOrEmpty(defaultProvider)
-                ? HostEnvironment.InputReader.GetUserInput($"{nameof(defaultProvider)}:")
+                ? HostEnvironment.InputReader.GetUserInputWithDefault(nameof(settings.DefaultProvider), settings.DefaultProvider)
                 : defaultProvider;
 
             if (ManifestDependencies.GetProvider(defaultProvider) == null)

--- a/src/libman/Commands/InitCommand.cs
+++ b/src/libman/Commands/InitCommand.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
         protected async override Task<int> ExecuteInternalAsync()
         {
-            await CreateManifestAsync(DefaultProvider.Value(), DefaultDestination.Value(), CancellationToken.None);
+            await CreateManifestAsync(DefaultProvider.Value(), DefaultDestination.Value(), Settings, CancellationToken.None);
 
             return 0;
         }

--- a/src/libman/Commands/InstallCommand.cs
+++ b/src/libman/Commands/InstallCommand.cs
@@ -94,14 +94,12 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
         protected override async Task<int> ExecuteInternalAsync()
         {
-            if (File.Exists(Settings.ManifestFileName))
+            if (!File.Exists(Settings.ManifestFileName))
             {
-                _manifest = await GetManifestAsync();
+                await CreateManifestAsync(Provider.Value(), null, Settings, CancellationToken.None);
             }
-            else
-            {
-                _manifest = await CreateManifestAsync(Provider.Value(), null, CancellationToken.None);
-            }
+
+            _manifest = await GetManifestAsync();
 
             ValidateParameters(_manifest);
 

--- a/src/libman/Contracts/ConsoleLogger.cs
+++ b/src/libman/Contracts/ConsoleLogger.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
         {
             lock(_syncObject)
             {
-                Console.Out.WriteLine(fieldName);
+                Console.Out.Write($"{fieldName}: ");
                 return Console.ReadLine();
             }
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="fieldName"></param>
         /// <param name="defaultValue"></param>
@@ -45,11 +45,11 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
         {
             lock (_syncObject)
             {
-                string message = $"{fieldName} [{defaultValue}]:";
-                Console.Out.WriteLine(message);
+                string message = $"{fieldName} [{defaultValue}]: ";
+                Console.Out.Write(message);
                 string value = Console.ReadLine();
 
-                if (string.IsNullOrEmpty(value?.Trim()))
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     value = defaultValue;
                 }
@@ -73,7 +73,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
                     {
                         Console.ForegroundColor = ConsoleColor.Red;
                     }
-                    
+
                     Console.Error.WriteLine(message);
 
                     Console.ResetColor();

--- a/test/libman.Test/LibmanInitTests.cs
+++ b/test/libman.Test/LibmanInitTests.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
         {
             TestInputReader reader = HostEnvironment.InputReader as TestInputReader;
 
-            reader.Inputs.Add("defaultProvider:", "cdnjs");
-            reader.Inputs.Add("defaultDestination:", "wwwroot");
+            reader.Inputs.Add("DefaultProvider", "cdnjs");
+            reader.Inputs.Add("DefaultDestination:", "wwwroot");
 
             InitCommand command = new InitCommand(HostEnvironment);
             command.Configure(null);

--- a/test/libman.Test/LibmanInstallTest.cs
+++ b/test/libman.Test/LibmanInstallTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
         {
             var testInputReader = HostEnvironment.InputReader as TestInputReader;
 
-            testInputReader.Inputs.Add("defaultProvider:", "cdnjs");
+            testInputReader.Inputs.Add("DefaultProvider", "cdnjs");
 
             var command = new InstallCommand(HostEnvironment);
             command.Configure(null);

--- a/test/libman.Test/SampleTestCommand.cs
+++ b/test/libman.Test/SampleTestCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
         {
             if (CreateNewManifest)
             {
-                Manifest = await CreateManifestAsync(DefaultProvider, DefaultDestination, CancellationToken.None);
+                Manifest = await CreateManifestAsync(DefaultProvider, DefaultDestination, Settings, CancellationToken.None);
             }
             else
             {


### PR DESCRIPTION
Changes:
- During init prompt for `DefaultProvider` with a suggested default of `cdnjs` (System default)
- For the prompts, keep the console on the same line instead of forcing the user to the next line.
- During `install` if libman.json doesn't exist, changed the behavior to write the json file to disk and then to read it again, so we get hold of proper defaults to use for validation.