### PR TITLE
Fix incomplete file download

### DIFF
--- a/src/LibraryManager.Build/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Build/Contracts/HostInteraction.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Web.LibraryManager.Build
 
             using (Stream stream = content.Invoke())
             {
-                if (stream == null || !await FileHelpers.WriteToFileAsync(absolutePath.FullName, stream, cancellationToken).ConfigureAwait(false))
+                if (stream == null || !await FileHelpers.SafeWriteToFileAsync(absolutePath.FullName, stream, cancellationToken).ConfigureAwait(false))
                 {
                     return false;
                 }

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 }
 
                 await VsHelpers.CheckFileOutOfSourceControlAsync(absolutePath.FullName);
-                await FileHelpers.WriteToFileAsync(absolutePath.FullName, stream, cancellationToken);
+                await FileHelpers.SafeWriteToFileAsync(absolutePath.FullName, stream, cancellationToken);
             }
 
             Logger.Log(string.Format(LibraryManager.Resources.Text.FileWrittenToDisk, relativePath.Replace(Path.DirectorySeparatorChar, '/')), LogLevel.Operation);

--- a/src/LibraryManager/CacheService/CacheService.cs
+++ b/src/LibraryManager/CacheService/CacheService.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Web.LibraryManager
         {
             using (Stream libraryStream = await _requestHandler.GetStreamAsync(url, cancellationToken))
             {
-                await FileHelpers.WriteToFileAsync(fileName, libraryStream, cancellationToken);
+                await FileHelpers.SafeWriteToFileAsync(fileName, libraryStream, cancellationToken);
             }
         }
 

--- a/src/libman/Contracts/HostInteraction.cs
+++ b/src/libman/Contracts/HostInteraction.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
 
             using (Stream stream = content.Invoke())
             {
-                if (stream == null || !await FileHelpers.WriteToFileAsync(absolutePath.FullName, stream, cancellationToken).ConfigureAwait(false))
+                if (stream == null || !await FileHelpers.SafeWriteToFileAsync(absolutePath.FullName, stream, cancellationToken).ConfigureAwait(false))
                 {
                     return false;
                 }


### PR DESCRIPTION
Fix for internal bug 612818 [LibMan] Download huge file and quit VS: partial download orphaned.

The fix is to 

1. Save file stream to a temporary file first
2. Once all stream content is saved locally, move the temp file to the destination file
3. Clean up temporary file/folder

This should greatly reduce the likelihood of ending up with a  corrupt/partially downloaded file if the user exits VS before file  download is complete.