### PR TITLE
Add name and version to ILibraryInsallationState

### DIFF
--- a/src/LibraryManager.Contracts/ILibraryInstallationState.cs
+++ b/src/LibraryManager.Contracts/ILibraryInstallationState.cs
@@ -16,6 +16,16 @@ namespace Microsoft.Web.LibraryManager.Contracts
         string LibraryId { get; }
 
         /// <summary>
+        /// The name of the library.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Version of the library.
+        /// </summary>
+        string Version { get; }
+
+        /// <summary>
         /// The unique identifier of the provider.
         /// </summary>
         string ProviderId { get; }

--- a/src/LibraryManager/Helpers/LibraryNamingScheme.cs
+++ b/src/LibraryManager/Helpers/LibraryNamingScheme.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Web.LibraryManager.Helpers
+{
+    /// <summary>
+    /// Defines the way LibraryId is split into name and Version
+    /// </summary>
+    public class LibraryNamingScheme
+    {
+        private const char _separator = '@';
+        private LibraryNamingScheme() { }
+
+        /// <summary>
+        /// Singleton instance of the LibraryNamingScheme
+        /// </summary>
+        public static LibraryNamingScheme Instance { get; } = new LibraryNamingScheme();
+
+        /// <summary>
+        /// Splits libraryId into name and version using '@' as the split char.
+        /// Only the last appearance of '@' is used to split the libraryId.
+        /// Note: If libraryId starts with '@' and has no other occurences of '@',
+        /// the entire libraryId is considered to be the name and version is considered to be
+        /// empty.
+        /// </summary>
+        /// <param name="libraryId"></param>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        public void GetLibraryNameAndVersion(string libraryId, out string name, out string version)
+        {
+            if (string.IsNullOrEmpty(libraryId))
+            {
+                name = string.Empty; 
+                version = string.Empty;
+
+                return;
+            }
+
+            int indexOfAt = libraryId.LastIndexOf(_separator);
+
+            name = libraryId;
+            version = string.Empty;
+
+            if (indexOfAt > 0 && indexOfAt < libraryId.Trim().Length -1)
+            {
+                name = libraryId.Substring(0, indexOfAt);
+                version = libraryId.Substring(indexOfAt+1);
+            }
+        }
+
+        /// <summary>
+        /// Generates a libraryId by concatenating name and version.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        public string GetLibraryId(string name, string version)
+        {
+            if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(version))
+            {
+                return string.Empty;
+            }
+
+            return string.IsNullOrWhiteSpace(version)
+                ? name
+                : $"{name}{_separator}{version}";
+            
+        }
+    }
+}

--- a/src/LibraryManager/LibraryInstallationState.cs
+++ b/src/LibraryManager/LibraryInstallationState.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
-using Newtonsoft.Json;
 using System.Collections.Generic;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
+using Newtonsoft.Json;
 
 namespace Microsoft.Web.LibraryManager
 {
@@ -22,7 +23,23 @@ namespace Microsoft.Web.LibraryManager
         /// The identifyer to uniquely identify the library
         /// </summary>
         [JsonProperty(ManifestConstants.Library)]
-        public string LibraryId { get; set; }
+        public string LibraryId
+        {
+             get
+             {
+                return LibraryNamingScheme.Instance.GetLibraryId(Name, Version);
+             }
+             set
+             {
+                LibraryNamingScheme.Instance.GetLibraryNameAndVersion(
+                    value,
+                    out string name,
+                    out string version);
+
+                Name = name;
+                Version = version;
+             }
+        }
 
         /// <summary>
         /// The path relative to the working directory to copy the files to.
@@ -47,6 +64,18 @@ namespace Microsoft.Web.LibraryManager
         /// </summary>
         [JsonIgnore]
         public bool IsUsingDefaultDestination { get; set; }
+
+        /// <summary>
+        /// Name of the library.
+        /// </summary>
+        [JsonIgnore]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Version of the library.
+        /// </summary>
+        [JsonIgnore]
+        public string Version { get; set; }
 
         /// <summary>Internal use only</summary>
         public static LibraryInstallationState FromInterface(ILibraryInstallationState state, 

--- a/test/LibraryManager.Mocks/LibraryInstallationState.cs
+++ b/test/LibraryManager.Mocks/LibraryInstallationState.cs
@@ -31,5 +31,15 @@ namespace Microsoft.Web.LibraryManager.Mocks
         /// The path relative to the working directory to copy the files to.
         /// </summary>
         public virtual string DestinationPath { get; set; }
+
+        /// <summary>
+        /// Name of the library.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Version of the library.
+        /// </summary>
+        public string Version { get; set; }
     }
 }

--- a/test/LibraryManager.Test/LibraryNamingSchemeTest.cs
+++ b/test/LibraryManager.Test/LibraryNamingSchemeTest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Helpers;
+
+namespace Microsoft.Web.LibraryManager.Test
+{
+    [TestClass]
+    public class LibraryNamingSchemeTest
+    {
+        [DataTestMethod]
+        [DataRow("jquery@3.3.1", "jquery", "3.3.1")]
+        [DataRow("@angular/cli@1.0.0", "@angular/cli","1.0.0")]
+        [DataRow("My@Random@Library@1.0.0-preview3-final", "My@Random@Library", "1.0.0-preview3-final")]
+        [DataRow("@MyLibraryWithoutVersion", "@MyLibraryWithoutVersion", "")]
+        [DataRow("Library@Version", "Library", "Version")]
+        [DataRow(null, "", "")]
+        [DataRow("", "", "")]
+        public void GetLibraryNameAndVersion(string libraryId, string expectedName, string expectedVersion)
+        {
+            LibraryNamingScheme.Instance.GetLibraryNameAndVersion(libraryId, out string name, out string version);
+
+            Assert.AreEqual(expectedName, name);
+            Assert.AreEqual(expectedVersion, version);
+        }
+
+        [DataTestMethod]
+        [DataRow("jquery", "3.3.1", "jquery@3.3.1")]
+        [DataRow("@angular/cli","1.0.0", "@angular/cli@1.0.0")]
+        [DataRow("My@Random@Library", "1.0.0-preview3-final", "My@Random@Library@1.0.0-preview3-final")]
+        [DataRow("@MyLibraryWithoutVersion", "", "@MyLibraryWithoutVersion")]
+        [DataRow("Library", "Version", "Library@Version")]
+        [DataRow("", "", "")]
+        public void GetLibraryId(string name, string version, string expectedLibraryId)
+        {
+            string libraryId = LibraryNamingScheme.Instance.GetLibraryId(name, version);
+
+            Assert.AreEqual(expectedLibraryId, libraryId);
+        }
+    }
+}


### PR DESCRIPTION
- Adds `Name` and `Version` properties to `ILibraryInstallationState`
- Adds a naming scheme which splits `LibraryId` into `Name` and `Version` (and combines them back) using `@` as the split character