### PR TITLE
Do not make "Loading..." getting inserted when commited

### DIFF
--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
             else
             {
-                yield return new SimpleCompletionEntry(Resources.Text.Loading, KnownMonikers.Loading, context.Session);
+                yield return new SimpleCompletionEntry(Resources.Text.Loading, string.Empty, KnownMonikers.Loading, context.Session);
 
                 task.ContinueWith((a) =>
                 {

--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
             else
             {
-                yield return new SimpleCompletionEntry(Resources.Text.Loading, KnownMonikers.Loading, context.Session);
+                yield return new SimpleCompletionEntry(Resources.Text.Loading, string.Empty, KnownMonikers.Loading, context.Session);
 
                 task.ContinueWith((a) =>
                 {

--- a/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
         }
 
+        public SimpleCompletionEntry(string text, string insertionText, ImageMoniker moniker, IIntellisenseSession session)
+            : base(text, insertionText, null, null, null, false, session as ICompletionSession)
+        {
+        }
+
         public SimpleCompletionEntry(string text, string insertionText, string description, ImageMoniker moniker, IIntellisenseSession session, int specificVersion = 0)
             : base(text, "\"" + insertionText + "\"", description, null, null, false, session as ICompletionSession)
         {

--- a/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
@@ -24,28 +24,28 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
         }
 
-        public SimpleCompletionEntry(string text, string insertionText, ImageMoniker moniker, IIntellisenseSession session)
-            : base(text, insertionText, null, null, null, false, session as ICompletionSession)
+        public SimpleCompletionEntry(string displayText, string insertionText, ImageMoniker moniker, IIntellisenseSession session)
+            : base(displayText, insertionText, null, null, null, false, session as ICompletionSession)
         {
         }
 
-        public SimpleCompletionEntry(string text, string insertionText, string description, ImageMoniker moniker, IIntellisenseSession session, int specificVersion = 0)
-            : base(text, "\"" + insertionText + "\"", description, null, null, false, session as ICompletionSession)
+        public SimpleCompletionEntry(string displayText, string insertionText, string description, ImageMoniker moniker, IIntellisenseSession session, int specificVersion = 0)
+            : base(displayText, "\"" + insertionText + "\"", description, null, null, false, session as ICompletionSession)
         {
             SetIconMoniker(moniker);
             _specificVersion = specificVersion;
         }
 
-        public SimpleCompletionEntry(string text, string insertionText, string description, ImageMoniker moniker, ITrackingSpan span, IIntellisenseSession session, int specificVersion = 0)
-           : base(text, "\"" + insertionText + "\"", description, null, null, false, session as ICompletionSession)
+        public SimpleCompletionEntry(string displayText, string insertionText, string description, ImageMoniker moniker, ITrackingSpan span, IIntellisenseSession session, int specificVersion = 0)
+           : base(displayText, "\"" + insertionText + "\"", description, null, null, false, session as ICompletionSession)
         {
             SetIconMoniker(moniker);
             ApplicableTo = span;
             _specificVersion = specificVersion;
         }
 
-        public SimpleCompletionEntry(string text, string insertionText, ImageMoniker moniker, ITrackingSpan span, IIntellisenseSession session, int specificVersion = 0)
-         : base(text, "\"" + insertionText + "\"", null, null, null, false, session as ICompletionSession)
+        public SimpleCompletionEntry(string displayText, string insertionText, ImageMoniker moniker, ITrackingSpan span, IIntellisenseSession session, int specificVersion = 0)
+         : base(displayText, "\"" + insertionText + "\"", null, null, null, false, session as ICompletionSession)
         {
             SetIconMoniker(moniker);
             ApplicableTo = span;

--- a/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
+++ b/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
@@ -157,5 +157,22 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.KeyboardCommands.Type("\"library\":");
             LibmanTestsUtility.WaitForCompletionEntries(Editor, expectedCompletionEntries, caseInsensitive: true, timeout: 5000);
         }
+
+        [TestMethod]
+        public void LibmanCompletion_LoadingNotInserted()
+        {
+            _libManConfig.Open();
+            string expectedText = "      \"library\": ";
+
+            Editor.Caret.MoveToExpression("\"libraries\"");
+            Editor.Caret.MoveDown(2);
+            Editor.KeyboardCommands.Type("\"provider\": \"cdnjs\",");
+            Editor.KeyboardCommands.Enter();
+            Editor.KeyboardCommands.Type("\"library\":");
+            Editor.KeyboardCommands.Type("j\t");
+
+            string actualText = Editor.Caret.GetCurrentLineText();
+            Assert.AreEqual(expectedText, actualText);
+        }
     }
 }

--- a/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
+++ b/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
@@ -157,22 +157,5 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.KeyboardCommands.Type("\"library\":");
             LibmanTestsUtility.WaitForCompletionEntries(Editor, expectedCompletionEntries, caseInsensitive: true, timeout: 5000);
         }
-
-        [TestMethod]
-        public void LibmanCompletion_LoadingNotInserted()
-        {
-            _libManConfig.Open();
-            string expectedText = "      \"library\": ";
-
-            Editor.Caret.MoveToExpression("\"libraries\"");
-            Editor.Caret.MoveDown(2);
-            Editor.KeyboardCommands.Type("\"provider\": \"cdnjs\",");
-            Editor.KeyboardCommands.Enter();
-            Editor.KeyboardCommands.Type("\"library\":");
-            Editor.KeyboardCommands.Type("j\t");
-
-            string actualText = Editor.Caret.GetCurrentLineText();
-            Assert.AreEqual(expectedText, actualText);
-        }
     }
 }


### PR DESCRIPTION
Do not make "Loading..." getting inserted when committed (enter or tab) during the time Loading for completion list.