### PR TITLE
Always set IsProductComponent to true

### DIFF
--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -26,7 +26,8 @@
     <TargetVsixContainerName>Microsoft.Web.LibraryManager.vsix</TargetVsixContainerName>
     <ExtensionInstallationRoot>Extensions</ExtensionInstallationRoot>
     <ExtensionInstallationFolder>Microsoft\Web Tools\Library Manager</ExtensionInstallationFolder>
-    <IsProductComponent Condition="'$(IsProductComponent)' == ''">false</IsProductComponent>
+    <!-- IsProductComponent should always be true, as the component ships in VS -->
+    <IsProductComponent>true</IsProductComponent>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>


### PR DESCRIPTION
Since this VSIX ships in VS, we should always set this to true.  This
allows a private build of the VSIX to install over the one included in
VS.

The tradeoff is that a privately built VSIX will not be able to install
on a VS instance which did not install LibraryManager already.