### PR TITLE
Change LibraryResolver to resolve using LibraryId or LibraryName

### DIFF
--- a/src/libman/Commands/UninstallCommand.cs
+++ b/src/libman/Commands/UninstallCommand.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
         {
             Manifest manifest = await GetManifestAsync();
 
-            IEnumerable<ILibraryInstallationState> installedLibraries = await ValidateParametersAndGetLibrariesToUninstallAsync(manifest, CancellationToken.None);
+            IEnumerable<ILibraryInstallationState> installedLibraries = ValidateParametersAndGetLibrariesToUninstall(manifest);
 
             if (installedLibraries == null || !installedLibraries.Any())
             {
@@ -91,9 +91,8 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             return 0;
         }
 
-        private async Task<IEnumerable<ILibraryInstallationState>> ValidateParametersAndGetLibrariesToUninstallAsync(
-            Manifest manifest,
-            CancellationToken cancellationToken)
+        private IEnumerable<ILibraryInstallationState> ValidateParametersAndGetLibrariesToUninstall(
+            Manifest manifest)
         {
             var errors = new List<string>();
             if (string.IsNullOrWhiteSpace(LibraryId.Value))
@@ -116,11 +115,9 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
                 throw new InvalidOperationException(string.Join(Environment.NewLine, errors));
             }
 
-            return await LibraryResolver.ResolveAsync(LibraryId.Value,
+            return LibraryResolver.Resolve(LibraryId.Value,
                 manifest,
-                ManifestDependencies,
-                provider,
-                cancellationToken);
+                provider);
         }
 
         public override string Remarks => Resources.UnInstallCommandRemarks;

--- a/test/libman.Test/LibraryResolverTest.cs
+++ b/test/libman.Test/LibraryResolverTest.cs
@@ -35,12 +35,10 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
                 CancellationToken.None);
 
             // Matches jquery for all providers.
-            IReadOnlyList<ILibraryInstallationState> result = await LibraryResolver.ResolveAsync(
+            IReadOnlyList<ILibraryInstallationState> result = LibraryResolver.Resolve(
                 "jquery",
                 manifest,
-                _dependencies,
-                null,
-                CancellationToken.None);
+                null);
 
             Assert.AreEqual(3, result.Count);
 
@@ -49,12 +47,10 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             Assert.AreEqual("jquery@2.2.0", result[2].LibraryId);
 
             // Matches jquery for cdnjs provider
-            result = await LibraryResolver.ResolveAsync(
+            result = LibraryResolver.Resolve(
                 "jquery",
                 manifest,
-                _dependencies,
-                _dependencies.GetProvider("cdnjs"),
-                CancellationToken.None);
+                _dependencies.GetProvider("cdnjs"));
 
             Assert.AreEqual(2, result.Count);
 
@@ -62,42 +58,34 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             Assert.AreEqual("jquery@2.2.0", result[1].LibraryId);
 
             // Matches only one result.
-            result = await LibraryResolver.ResolveAsync(
+            result = LibraryResolver.Resolve(
                 "jquery@3.3.1",
                 manifest,
-                _dependencies,
-                null,
-                CancellationToken.None);
+                null);
 
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual("jquery@3.3.1", result[0].LibraryId);
 
             // Does not match library for a different provider.
-            result = await LibraryResolver.ResolveAsync(
+            result = LibraryResolver.Resolve(
                 "jquery@3.3.1",
                 manifest,
-                _dependencies,
-                _dependencies.GetProvider("filesystem"),
-                CancellationToken.None);
+                _dependencies.GetProvider("filesystem"));
 
             Assert.AreEqual(0, result.Count);
 
             // Does not return partial matches.
-            result = await LibraryResolver.ResolveAsync(
+            result = LibraryResolver.Resolve(
                 "jquery@3.3",
                 manifest,
-                _dependencies,
-                null,
-                CancellationToken.None);
+                null);
 
             Assert.AreEqual(0, result.Count);
 
-            result = await LibraryResolver.ResolveAsync(
+            result = LibraryResolver.Resolve(
                 "jquer",
                 manifest,
-                _dependencies,
-                null,
-                CancellationToken.None);
+                null);
 
             Assert.AreEqual(0, result.Count);
 


### PR DESCRIPTION
- `LibraryResolver` No longer uses Catalogs to resolve names to Ids.

Earlier `LibraryResolver` would try to ask each catalog to check if the given term matched display name or library. 
Now since we have information about name and version of each library in the manifest, we no longer need to ask the Catalog. 
