### PR TITLE
Remove PreviewMouseDown handler

### DIFF
--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -14,7 +14,6 @@
                  xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
                  Title="{x:Static resources:Text.AddClientSideLibrary}"
                  Height="350" Width="500"
-                 PreviewMouseDown="ThemedWindow_PreviewMouseDown"
                  ShowInTaskbar="False"
                  ResizeMode="CanResizeWithGrip"
                  WindowStartupLocation="CenterOwner">

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -160,15 +160,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI
             FocusManager.SetFocusedElement(LibrarySearchBox, LibrarySearchBox);
         }
 
-        private void ThemedWindow_PreviewMouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (!LibrarySearchBox.IsMouseOver && !LibrarySearchBox.IsMouseOverFlyout)
-            {
-                TraversalRequest request = new TraversalRequest(FocusNavigationDirection.Next);
-                MoveFocus(request);
-            }
-        }
-
         private void IncludeAllLibraryFilesRb_Checked(object sender, RoutedEventArgs e)
         {
             LibraryFilesToInstallTreeView.IsEnabled = false;


### PR DESCRIPTION
This is not required as I made changes to use default tab navigation order here:
https://github.com/aspnet/LibraryManager/commit/a4e7ce8b60fab50dba2c370fb799b2166c44bbc9

This actually breaks provider selection using mouse.