### PR TITLE
Dev/yalyu/filesystem library exception

### DIFF
--- a/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
@@ -96,20 +96,19 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 
                 return Task.FromResult(set);
             }
-            catch (Exception ex)
+            catch (ArgumentException)
             {
                 // Do not provide completion for invalid forms but allow user to type them.
-                if (ex is ArgumentException)
+                var set = new CompletionSet
                 {
-                    var set = new CompletionSet
-                    {
-                        Start = 0,
-                        Length = value.Length
-                    };
+                    Start = 0,
+                    Length = value.Length
+                };
 
-                    return Task.FromResult(set);
-                }
-
+                return Task.FromResult(set);
+            }
+            catch
+            {
                 throw new InvalidLibraryException(value, _provider.Id);
             }
         }

--- a/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
@@ -96,8 +97,20 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 
                 return Task.FromResult(set);
             }
-            catch
+            catch (Exception ex)
             {
+                // Do not provide completion for invalid forms but allow user to type them.
+                if (ex is ArgumentException)
+                {
+                    var set = new CompletionSet
+                    {
+                        Start = 0,
+                        Length = value.Length
+                    };
+
+                    return Task.FromResult(set);
+                }
+
                 throw new InvalidLibraryException(value, _provider.Id);
             }
         }


### PR DESCRIPTION
Allow the user to type invalid path but we will return an empty completion set.
Resolve https://github.com/aspnet/LibraryManager/issues/223