### PR TITLE
Fix CLI install via unpkg

### DIFF
--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.VisualStudio.Language.Intellisense;
-using Microsoft.Web.Editor.SuggestedActions;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.Web.Editor.SuggestedActions;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -75,17 +76,21 @@ namespace Microsoft.Web.LibraryManager.Vsix
         private async Task<List<ISuggestedAction>> GetListOfActionsAsync(ILibraryCatalog catalog, CancellationToken cancellationToken)
         {
             var list = new List<ISuggestedAction>();
+            string latestStableVersion = await catalog.GetLatestVersion(_provider.InstallationState.LibraryId, false, cancellationToken).ConfigureAwait(false);
+            string latestStable = LibraryNamingScheme.Instance.GetLibraryId(
+                            _provider.InstallationState.Name,
+                            latestStableVersion);
 
-            string latestStable = await catalog.GetLatestVersion(_provider.InstallationState.LibraryId, false, cancellationToken).ConfigureAwait(false);
-
-            if (!string.IsNullOrEmpty(latestStable) && latestStable != _provider.InstallationState.LibraryId)
+            if (!string.IsNullOrEmpty(latestStableVersion) && latestStable != _provider.InstallationState.LibraryId)
             {
                 list.Add(new UpdateSuggestedAction(_provider, latestStable, $"Stable: {latestStable}"));
             }
 
-            string latestPre = await catalog.GetLatestVersion(_provider.InstallationState.LibraryId, true, cancellationToken).ConfigureAwait(false);
+            string latestPreVersion = await catalog.GetLatestVersion(_provider.InstallationState.LibraryId, true, cancellationToken).ConfigureAwait(false);
+            string latestPre = LibraryNamingScheme.Instance.GetLibraryId(_provider.InstallationState.Name,
+                            latestPreVersion);
 
-            if (!string.IsNullOrEmpty(latestPre) && latestPre != _provider.InstallationState.LibraryId && latestPre != latestStable)
+            if (!string.IsNullOrEmpty(latestPreVersion) && latestPre != _provider.InstallationState.LibraryId && latestPre != latestStable)
             {
                 list.Add(new UpdateSuggestedAction(_provider, latestPre, $"Pre-release: {latestPre}"));
             }

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
@@ -195,9 +195,9 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                 first = ids.First(id => id.Substring(name.Length).Any(c => !char.IsLetter(c)));
             }
 
-            if (!string.IsNullOrEmpty(first) && ids.IndexOf(first) < ids.IndexOf(libraryId))
+            if (!string.IsNullOrEmpty(first))
             {
-                return first;
+                return LibraryNamingScheme.Instance.GetLibraryNameAndVersion(first).Version;
             }
 
             return null;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
         /// </returns>
         public Task<string> GetLatestVersion(string libraryId, bool includePreReleases, CancellationToken cancellationToken)
         {
-            return Task.FromResult(libraryId);
+            return Task.FromResult(string.Empty);
         }
     }
 }

--- a/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 {
@@ -24,7 +25,9 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 
             if (npmPackageInfo != null)
             {
-                return npmPackageInfo.Versions.Select(semanticVersion => semanticVersion.ToString()).ToArray();
+                return npmPackageInfo.Versions
+                    .OrderByDescending(v => v)
+                    .Select(semanticVersion => LibraryNamingScheme.Instance.GetLibraryId(DisplayName, semanticVersion.ToString()));
             }
 
             return Enumerable.Empty<string>();

--- a/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
             {
                 return npmPackageInfo.Versions
                     .OrderByDescending(v => v)
-                    .Select(semanticVersion => LibraryNamingScheme.Instance.GetLibraryId(DisplayName, semanticVersion.ToString()));
+                    .Select(semanticVersion => LibraryNamingScheme.Instance.GetLibraryId(DisplayName, semanticVersion.ToString()))
+                    .ToList();
             }
 
             return Enumerable.Empty<string>();

--- a/src/libman/Commands/InstallCommand.cs
+++ b/src/libman/Commands/InstallCommand.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 
 namespace Microsoft.Web.LibraryManager.Tools.Commands
 {
@@ -197,7 +198,8 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
                 if (libGroup.DisplayName.Equals(LibraryId.Value, StringComparison.OrdinalIgnoreCase))
                 {
                     // Found a group with an exact match.
-                    string libraryId = libIds.First();
+                    string latestVersion = await ProviderCatalog.GetLatestVersion(libIds.First(), false, cancellationToken);
+                    string libraryId = LibraryNamingScheme.Instance.GetLibraryId(libGroup.DisplayName, latestVersion);
                     ILibrary libraryToInstall = await ProviderCatalog.GetLibraryAsync(libraryId, cancellationToken);
 
                     return (libraryId, libraryToInstall);

--- a/src/libman/Commands/UpdateCommand.cs
+++ b/src/libman/Commands/UpdateCommand.cs
@@ -95,7 +95,11 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             }
             else
             {
-                newLibraryId = await GetLatestVersionAsync(libraryToUpdate, CancellationToken.None);
+                string latestVersion = await GetLatestVersionAsync(libraryToUpdate, CancellationToken.None);
+                if (!string.IsNullOrEmpty(latestVersion))
+                {
+                    newLibraryId = LibraryNamingScheme.Instance.GetLibraryId(libraryToUpdate.Name, latestVersion);
+                }
             }
 
             if (newLibraryId == null || newLibraryId == libraryToUpdate.LibraryId)

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -133,13 +133,9 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
 
             Assert.IsNotNull(result);
 
-            string[] latest = result.Split('@');
             string[] existing = libraryId.Split('@');
 
-            Assert.AreEqual(2, latest.Length);
-
-            Assert.AreNotEqual(libraryId, result);
-            Assert.AreEqual(existing[0], latest[0]);
+            Assert.AreNotEqual(existing[1], result);
         }
 
         [TestMethod]
@@ -151,14 +147,9 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
 
             Assert.IsNotNull(result);
 
-            string[] latest = result.Split('@');
             string[] existing = libraryId.Split('@');
 
-            Assert.AreEqual(2, latest.Length);
-
-            Assert.AreNotEqual(libraryId, result);
-            Assert.AreEqual(existing[0], latest[0]);
-            Assert.IsTrue(latest[0].Any(c => char.IsLetter(c)));
+            Assert.AreNotEqual(existing[1], result);
         }
     }
 }

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemCatalogTest.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
 
             Assert.IsNotNull(result);
             Assert.IsTrue(result.IsCompleted);
-            Assert.AreEqual(libraryId, result.Result);
+            Assert.AreEqual(string.Empty, result.Result);
 
         }
     }


### PR DESCRIPTION
Fixes #157 

- Makes unpkg and cdnjs providers consistent:
  - `GetLatestVersion()` now returns only the version part for both cdnjs and unpkg
  - `Catalog.GetLibraryIds()` now returns the full libraryIds for unpkg
- FileSystem provider returns empty string for `GetLatestVersion()`
- `UpdateSuggestedActionSet` combines the library's `displayname` and `latestVersion` to show the update suggestion.
