### PR TITLE
Set default provider when installing libraries

### DIFF
--- a/test/LibraryManager.Test/ManifestTest.cs
+++ b/test/LibraryManager.Test/ManifestTest.cs
@@ -346,6 +346,18 @@ namespace Microsoft.Web.LibraryManager.Test
             Assert.AreEqual("LIB018", results.First().Errors[0].Code);
         }
 
+        [TestMethod]
+        public async Task InstallLibraryAsync_SetsDefaultProvider()
+        {
+            var manifest = Manifest.FromJson(_emptyLibmanJson, _dependencies);
+            IEnumerable<ILibraryOperationResult> results = await manifest.InstallLibraryAsync("jquery@3.2.1", "cdnjs", null, "wwwroot", CancellationToken.None);
+
+            Assert.AreEqual("cdnjs", manifest.DefaultProvider);
+            var libraryState = manifest.Libraries.First() as LibraryInstallationState;
+
+            Assert.IsTrue(libraryState.IsUsingDefaultProvider);
+        }
+
         [DataTestMethod]
         [DataRow("1.5")]
         [DataRow("2.0")]
@@ -448,6 +460,11 @@ namespace Microsoft.Web.LibraryManager.Test
       ""{ManifestConstants.Files}"": [ ""jquery.js"" ]
     }},
   ]
+}}
+";
+        private string _emptyLibmanJson = $@"{{
+  ""{ManifestConstants.Version}"": ""1.0"",
+  ""{ManifestConstants.Libraries}"": [ ]
 }}
 ";
     }

--- a/test/libman.Test/LibmanInstallTest.cs
+++ b/test/libman.Test/LibmanInstallTest.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
   ""defaultProvider"": ""cdnjs"",
   ""libraries"": [
     {
-      ""provider"": ""cdnjs"",
       ""library"": ""jquery@3.2.1"",
       ""destination"": ""wwwroot""
     }


### PR DESCRIPTION
When adding a package:
- if the defaultProvider is not set, set it to the current provider
- If the defaultProvider is set and does not match the current provider, set the 'provider' on the library
- If the defaultProvider is set and matches the current provider, do nothing

Follow the same behavior from
- UI Add Library dialog
- CLI install command