### PR TITLE
Fix parsing of libraryId into name and version.

### DIFF
--- a/LibraryManager.sln
+++ b/LibraryManager.sln
@@ -41,7 +41,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{E67307E3-04FF-498B-97C7-4F508299DF4D}"
 	ProjectSection(SolutionItems) = preProject
 		build\dependencies.props = build\dependencies.props
-		build\testdependencies.props = build\testdependencies.props
+		build\PackageVersions.targets = build\PackageVersions.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{E559F6DC-25C6-4077-B2C5-D5A06357D1BC}"

--- a/src/LibraryManager.Contracts/IProvider.cs
+++ b/src/LibraryManager.Contracts/IProvider.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Web.LibraryManager.Contracts
         IHostInteraction HostInteraction { get; }
 
         /// <summary>
+        /// Indicates whether the provider supports libraries with versions.
+        /// </summary>
+        bool SupportsLibraryVersions { get; }
+
+        /// <summary>
         /// Installs a library as specified in the <paramref name="desiredState"/> parameter.
         /// </summary>
         /// <param name="desiredState">The details about the library to install.</param>

--- a/src/LibraryManager/LibraryInstallationState.cs
+++ b/src/LibraryManager/LibraryInstallationState.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Helpers;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 using Newtonsoft.Json;
 
 namespace Microsoft.Web.LibraryManager
@@ -13,11 +13,36 @@ namespace Microsoft.Web.LibraryManager
     /// <seealso cref="Microsoft.Web.LibraryManager.Contracts.ILibraryInstallationState" />
     internal class LibraryInstallationState : ILibraryInstallationState
     {
+
+        private string _providerId;
+
         /// <summary>
         /// The unique identifier of the provider.
         /// </summary>
         [JsonProperty(ManifestConstants.Provider)]
-        public string ProviderId { get; set; }
+        public string ProviderId
+        {
+            get
+            {
+                return _providerId;
+            }
+            set
+            {
+                if (_providerId != value)
+                {
+                    string oldProviderId = _providerId;
+                    _providerId = value;
+                    string originalLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(Name, Version, oldProviderId);
+
+                    (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(
+                        originalLibraryId,
+                        _providerId);
+
+                    Name = name;
+                    Version = version;
+                }
+            }
+        }
 
         /// <summary>
         /// The identifyer to uniquely identify the library
@@ -27,12 +52,13 @@ namespace Microsoft.Web.LibraryManager
         {
              get
              {
-                return LibraryNamingScheme.Instance.GetLibraryId(Name, Version);
+                return LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(Name, Version, _providerId);
              }
              set
              {
-                (string name, string version) = LibraryNamingScheme.Instance.GetLibraryNameAndVersion(
-                    value);
+                (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(
+                    value,
+                    _providerId);
 
                 Name = name;
                 Version = version;

--- a/src/LibraryManager/LibraryNaming/ILibraryNamingScheme.cs
+++ b/src/LibraryManager/LibraryNaming/ILibraryNamingScheme.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Web.LibraryManager.LibraryNaming
+{
+    /// <summary>
+    /// Allows converting libraryId to name and version and vice versa.
+    /// </summary>
+    internal interface ILibraryNamingScheme
+    {
+        /// <summary>
+        /// Splits libraryId into name and version.
+        /// </summary>
+        (string Name, string Version) GetLibraryNameAndVersion(string libraryId);
+
+        /// <summary>
+        /// Gets the libraryId from name and version.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        string GetLibraryId(string name, string version);
+    }
+}

--- a/src/LibraryManager/LibraryNaming/LibraryIdToNameAndVersionConverter.cs
+++ b/src/LibraryManager/LibraryNaming/LibraryIdToNameAndVersionConverter.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Web.LibraryManager.Contracts;
+
+namespace Microsoft.Web.LibraryManager.LibraryNaming
+{
+    /// <summary>
+    /// Defines the way LibraryId is split into name and Version
+    /// </summary>
+    public class LibraryIdToNameAndVersionConverter
+    {
+        /// <summary>
+        /// Singleton instance for the <see cref="LibraryIdToNameAndVersionConverter" />
+        /// </summary>
+        public static LibraryIdToNameAndVersionConverter Instance { get; } = new LibraryIdToNameAndVersionConverter();
+
+        private LibraryIdToNameAndVersionConverter()
+        {
+            _versionedNamingScheme = new VersionedLibraryNamingScheme();
+            _simpleNamingScheme = new SimpleLibraryNamingScheme();
+            _default = _simpleNamingScheme;
+        }
+
+        private readonly object _syncObject = new object();
+        private readonly ILibraryNamingScheme _versionedNamingScheme = new VersionedLibraryNamingScheme();
+        private readonly ILibraryNamingScheme _simpleNamingScheme = new SimpleLibraryNamingScheme();
+        private readonly ILibraryNamingScheme _default;
+
+
+        private IDependencies _dependencies;
+        private Dictionary<string, ILibraryNamingScheme> _perProviderNamingScheme = new Dictionary<string, ILibraryNamingScheme>();
+
+        /// <summary>
+        /// Initializes the LibraryNaming Schemes for the manifest.
+        /// </summary>
+        /// <param name="dependencies"></param>
+        public void Initialize (IDependencies dependencies)
+        {
+            _dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
+
+            lock(_syncObject)
+            {
+                _perProviderNamingScheme.Clear();
+
+                foreach(IProvider p in _dependencies.Providers)
+                {
+                    _perProviderNamingScheme[p.Id] = p.SupportsLibraryVersions ? _versionedNamingScheme : _simpleNamingScheme;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Splits the libraryId into name and version based on the provider.
+        /// </summary>
+        /// <param name="libraryId"></param>
+        /// <param name="providerId"></param>
+        /// <returns></returns>
+        public (string Name, string Version) GetLibraryNameAndVersion(string libraryId, string providerId)
+        {
+            if (!string.IsNullOrEmpty(providerId) && _perProviderNamingScheme.TryGetValue(providerId, out ILibraryNamingScheme _scheme))
+            {
+                return _scheme.GetLibraryNameAndVersion(libraryId);
+            }
+
+            return _default.GetLibraryNameAndVersion(libraryId);
+        }
+
+        /// <summary>
+        /// Gets the libraryId given the name and version, based on the provider.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="version"></param>
+        /// <param name="providerId"></param>
+        /// <returns></returns>
+        public string GetLibraryId(string name, string version, string providerId)
+        {
+            if (!string.IsNullOrEmpty(providerId) && _perProviderNamingScheme.TryGetValue(providerId, out ILibraryNamingScheme _scheme))
+            {
+                return _scheme.GetLibraryId(name, version);
+            }
+
+            return _default.GetLibraryId(name, version);
+        }
+    }
+}

--- a/src/LibraryManager/LibraryNaming/SimpleLibraryNamingScheme.cs
+++ b/src/LibraryManager/LibraryNaming/SimpleLibraryNamingScheme.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Web.LibraryManager.LibraryNaming
+{
+    /// <summary>
+    /// A versionless library naming scheme which treats libraryId as the library name.
+    /// </summary>
+    class SimpleLibraryNamingScheme : ILibraryNamingScheme
+    {
+        /// <inheritDoc />
+        public string GetLibraryId(string name, string version)
+        {
+            return name ?? string.Empty;
+        }
+
+        /// <inheritDoc />
+        public (string Name, string Version) GetLibraryNameAndVersion(string libraryId)
+        {
+            return (libraryId ?? string.Empty, string.Empty);
+        }
+    }
+}

--- a/src/LibraryManager/LibraryNaming/VersionedLibraryNamingScheme.cs
+++ b/src/LibraryManager/LibraryNaming/VersionedLibraryNamingScheme.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.LibraryNaming
             name = libraryId;
             version = string.Empty;
 
-            if (indexOfAt > 0 && indexOfAt < libraryId.Trim().Length - 1)
+            if (indexOfAt > 0 && indexOfAt < libraryId.TrimEnd().Length - 1)
             {
                 name = libraryId.Substring(0, indexOfAt);
                 version = libraryId.Substring(indexOfAt + 1);

--- a/src/LibraryManager/LibraryNaming/VersionedLibraryNamingScheme.cs
+++ b/src/LibraryManager/LibraryNaming/VersionedLibraryNamingScheme.cs
@@ -1,20 +1,12 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Web.LibraryManager.Helpers
+namespace Microsoft.Web.LibraryManager.LibraryNaming
 {
-    /// <summary>
-    /// Defines the way LibraryId is split into name and Version
-    /// </summary>
-    public class LibraryNamingScheme
+    /// <inheritDoc />
+    class VersionedLibraryNamingScheme : ILibraryNamingScheme
     {
         private const char _separator = '@';
-        private LibraryNamingScheme() { }
-
-        /// <summary>
-        /// Singleton instance of the LibraryNamingScheme
-        /// </summary>
-        public static LibraryNamingScheme Instance { get; } = new LibraryNamingScheme();
 
         /// <summary>
         /// Splits libraryId into name and version using '@' as the split char.
@@ -39,10 +31,10 @@ namespace Microsoft.Web.LibraryManager.Helpers
             name = libraryId;
             version = string.Empty;
 
-            if (indexOfAt > 0 && indexOfAt < libraryId.Trim().Length -1)
+            if (indexOfAt > 0 && indexOfAt < libraryId.Trim().Length - 1)
             {
                 name = libraryId.Substring(0, indexOfAt);
-                version = libraryId.Substring(indexOfAt+1);
+                version = libraryId.Substring(indexOfAt + 1);
             }
 
             return (name, version);

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 using Newtonsoft.Json;
 
 namespace Microsoft.Web.LibraryManager
@@ -97,6 +98,7 @@ namespace Microsoft.Web.LibraryManager
         {
             try
             {
+                LibraryIdToNameAndVersionConverter.Instance.Initialize(dependencies);
                 Manifest manifest = JsonConvert.DeserializeObject<Manifest>(json);
                 manifest._dependencies = dependencies;
                 manifest._hostInteraction = dependencies.GetHostInteractions();

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Web.LibraryManager
         {
             try
             {
-                LibraryIdToNameAndVersionConverter.Instance.Initialize(dependencies);
+                LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(dependencies);
                 Manifest manifest = JsonConvert.DeserializeObject<Manifest>(json);
                 manifest._dependencies = dependencies;
                 manifest._hostInteraction = dependencies.GetHostInteractions();

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Helpers;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -134,7 +134,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
         /// <returns></returns>
         public async Task<ILibrary> GetLibraryAsync(string libraryId, CancellationToken cancellationToken)
         {
-            (string name, string version) = LibraryNamingScheme.Instance.GetLibraryNameAndVersion(libraryId);
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId, this._provider.Id);
 
             if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version))
             {
@@ -168,7 +168,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
 
         public async Task<string> GetLatestVersion(string libraryId, bool includePreReleases, CancellationToken cancellationToken)
         {
-            (string name, string version) = LibraryNamingScheme.Instance.GetLibraryNameAndVersion(libraryId);
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId,  this._provider.Id);
 
             if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version))
             {

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                         var completion = new CompletionItem
                         {
                             DisplayText = version,
-                            InsertionText = $"{name}@{version}",
+                            InsertionText = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(name, version, _provider.Id),
                         };
 
                         completions.Add(completion);
@@ -134,7 +134,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
         /// <returns></returns>
         public async Task<ILibrary> GetLibraryAsync(string libraryId, CancellationToken cancellationToken)
         {
-            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId, this._provider.Id);
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId, _provider.Id);
 
             if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version))
             {
@@ -168,7 +168,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
 
         public async Task<string> GetLatestVersion(string libraryId, bool includePreReleases, CancellationToken cancellationToken)
         {
-            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId,  this._provider.Id);
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId, _provider.Id);
 
             if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version))
             {
@@ -271,7 +271,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
         {
             IEnumerable<Asset> assets = await GetAssetsAsync(groupName, cancellationToken).ConfigureAwait(false);
 
-            return assets?.Select(a => $"{groupName}@{a.Version}");
+            return assets?.Select(a => LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(groupName, a.Version, _provider.Id));
         }
 
         private async Task<IEnumerable<Asset>> GetAssetsAsync(string groupName, CancellationToken cancellationToken)

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Helpers;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Resources;
 
 namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
@@ -59,6 +59,11 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
         {
             get { return Path.Combine(HostInteraction.CacheDirectory, Id); }
         }
+
+        /// <summary>
+        /// Supports libraries with versions.
+        /// </summary>
+        public bool SupportsLibraryVersions => true;
 
         /// <summary>
         /// Gets the <see cref="T:Microsoft.Web.LibraryManager.Contracts.ILibraryCatalog" /> for the <see cref="T:Microsoft.Web.LibraryManager.Contracts.IProvider" />. May be <code>null</code> if no catalog is supported.

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
         public string LibraryIdHintText { get; } = Text.FileSystemLibraryIdHintText;
 
         /// <summary>
+        /// Does not support libraries with versions.
+        /// </summary>
+        public bool SupportsLibraryVersions => false;
+
+        /// <summary>
         /// Gets the <see cref="T:Microsoft.Web.LibraryManager.Contracts.ILibraryCatalog" /> for the <see cref="T:Microsoft.Web.LibraryManager.Contracts.IProvider" />. May be <code>null</code> if no catalog is supported.
         /// </summary>
         /// <returns></returns>

--- a/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Helpers;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
@@ -14,7 +14,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
     {
         public const string CacheFileName = "cache.json";
         public const string LibraryFileListUrlFormat = "http://unpkg.com/{0}/?meta";
-        public const string LatestLibraryVersonUrl = "http://unpkg.com/{0}/package.json"; 
+        public const string LatestLibraryVersonUrl = "http://unpkg.com/{0}/package.json";
         private UnpkgProvider _provider;
         private CacheService _cacheService;
         private string _cacheFile;
@@ -34,7 +34,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 
             try
             {
-                (string name, string version) = LibraryNamingScheme.Instance.GetLibraryNameAndVersion(libraryId);
+                (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId, _provider.Id);
                 string latestLibraryVersionUrl = string.Format(LatestLibraryVersonUrl, name);
 
                 JObject packageObject = await WebRequestHandler.Instance.GetJsonObjectViaGetAsync(latestLibraryVersionUrl, cancellationToken);
@@ -55,7 +55,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 
         public async Task<ILibrary> GetLibraryAsync(string libraryId, CancellationToken cancellationToken)
         {
-            (string name, string version) = LibraryNamingScheme.Instance.GetLibraryNameAndVersion(libraryId);
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId, _provider.Id);
 
             if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version))
             {
@@ -107,7 +107,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
         {
             // Parse JSON document returned by unpkg.com/libraryname@version/?meta
             // It looks something like
-            // { 
+            // {
             //   "type" : "directory",
             //   "path" : "/"
             //   "files" : [
@@ -176,7 +176,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 
             List<CompletionItem> completions = new List<CompletionItem>();
 
-            (string name, string version) = LibraryNamingScheme.Instance.GetLibraryNameAndVersion(libraryNameStart);
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryNameStart, _provider.Id);
 
             try
             {

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Helpers;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 {
@@ -42,6 +42,8 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
         }
 
         public string LibraryIdHintText => Resources.Text.UnpkgProviderHintText;
+
+        public bool SupportsLibraryVersions => true;
 
         public async Task<ILibraryOperationResult> InstallAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
         {

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -1,11 +1,13 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 {

--- a/src/libman/Commands/UpdateCommand.cs
+++ b/src/libman/Commands/UpdateCommand.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Helpers;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Tools.Commands
 {
@@ -91,7 +91,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
             if (ToVersion.HasValue())
             {
-                newLibraryId = LibraryNamingScheme.Instance.GetLibraryId(libraryToUpdate.Name, ToVersion.Value());
+                newLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(libraryToUpdate.Name, ToVersion.Value(), libraryToUpdate.ProviderId);
             }
             else
             {

--- a/test/LibraryManager.Mocks/Provider.cs
+++ b/test/LibraryManager.Mocks/Provider.cs
@@ -59,6 +59,11 @@ namespace Microsoft.Web.LibraryManager.Mocks
         public virtual ILibraryOperationResult Result { get; set; }
 
         /// <summary>
+        /// Indicates whether libraries with versions are supported.
+        /// </summary>
+        public bool SupportsLibraryVersions { get; set; }
+
+        /// <summary>
         /// Gets the <see cref="T:LibraryManager.Contracts.ILibraryCatalog" /> for the <see cref="T:LibraryManager.Contracts.IProvider" />. May be <code>null</code> if no catalog is supported.
         /// </summary>
         /// <returns></returns>

--- a/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
+++ b/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Test
 
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory(), new UnpkgProviderFactory());
-            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_dependencies);
         }
 
         [DataTestMethod]

--- a/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
+++ b/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Mocks;
+using Microsoft.Web.LibraryManager.Providers.Cdnjs;
+using Microsoft.Web.LibraryManager.Providers.FileSystem;
+using Microsoft.Web.LibraryManager.Providers.Unpkg;
+
+namespace Microsoft.Web.LibraryManager.Test
+{
+    [TestClass]
+    public class LibraryIdToNameAndVersionConverterTest
+    {
+        private string _filePath;
+        private string _cacheFolder;
+        private string _projectFolder;
+        private IDependencies _dependencies;
+        private HostInteraction _hostInteraction;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _cacheFolder = Environment.ExpandEnvironmentVariables(@"%localappdata%\Microsoft\Library\");
+            _projectFolder = Path.Combine(Path.GetTempPath(), "LibraryManager");
+            _filePath = Path.Combine(_projectFolder, "libman.json");
+
+            _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
+            _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory(), new UnpkgProviderFactory());
+            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
+        }
+
+        [DataTestMethod]
+        [DataRow("jquery@3.3.1", "cdnjs" ,"jquery", "3.3.1")]
+        [DataRow("@angular/cli@1.0.0", "unpkg","@angular/cli", "1.0.0")]
+        [DataRow("@MyLibraryWithoutVersion", "cdnjs", "@MyLibraryWithoutVersion", "")]
+        [DataRow("Library@Version", "filesystem", "Library@Version", "")]
+        [DataRow("Partial@", "cdnjs", "Partial@", "")]
+        [DataRow("Partial@Version", "unknown", "Partial@Version", "")]  // Default is simple naming scheme
+        public void GetLibraryNameAndVersion(string libraryId, string providerId, string name, string version)
+        {
+            (string actualName, string actualVersion) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(libraryId, providerId);
+
+            Assert.AreEqual(name, actualName);
+            Assert.AreEqual(version, actualVersion);
+        }
+
+
+
+        [DataTestMethod]
+        [DataRow("jquery@3.3.1", "cdnjs", "jquery", "3.3.1")]
+        [DataRow("@angular/cli@1.0.0", "unpkg", "@angular/cli", "1.0.0")]
+        [DataRow("@MyLibraryWithoutVersion", "cdnjs", "@MyLibraryWithoutVersion", "")]
+        [DataRow("Library@Version", "filesystem", "Library@Version", "")]
+        [DataRow("Partial@", "cdnjs", "Partial@", "")]
+        [DataRow("Partial@Version", "unknown", "Partial@Version", "")]  // Default is simple naming scheme
+        public void GetLibraryId(string libraryId, string providerId, string name, string version)
+        {
+            string actualLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(name, version, providerId);
+
+            Assert.AreEqual(libraryId, actualLibraryId);
+        }
+    }
+}

--- a/test/LibraryManager.Test/LibraryInstallationStateTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationStateTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Web.LibraryManager.Test
 
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory(), new UnpkgProviderFactory());
-            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_dependencies);
         }
 
         [TestMethod]

--- a/test/LibraryManager.Test/LibraryInstallationStateTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationStateTest.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Mocks;
-using Microsoft.Web.LibraryManager.Providers.Cdnjs;
-using Microsoft.Web.LibraryManager.Providers.FileSystem;
-using Microsoft.Web.LibraryManager.Providers.Unpkg;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Mocks;
+using Microsoft.Web.LibraryManager.Providers.Cdnjs;
+using Microsoft.Web.LibraryManager.Providers.FileSystem;
+using Microsoft.Web.LibraryManager.Providers.Unpkg;
 
 namespace Microsoft.Web.LibraryManager.Test
 {
@@ -33,6 +34,7 @@ namespace Microsoft.Web.LibraryManager.Test
 
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory(), new UnpkgProviderFactory());
+            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
         }
 
         [TestMethod]
@@ -148,8 +150,8 @@ namespace Microsoft.Web.LibraryManager.Test
 
             ILibraryOperationResult result = await state.IsValidAsync(_dependencies);
 
-            // IsValidAsync does not validate library files 
-            // Issue https://github.com/aspnet/LibraryManager/issues/254 should fix that 
+            // IsValidAsync does not validate library files
+            // Issue https://github.com/aspnet/LibraryManager/issues/254 should fix that
             Assert.IsTrue(result.Success);
         }
 

--- a/test/LibraryManager.Test/ManifestTest.cs
+++ b/test/LibraryManager.Test/ManifestTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Web.LibraryManager.Test
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory());
 
-            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_dependencies);
             Directory.CreateDirectory(_projectFolder);
             File.WriteAllText(_filePath, _doc);
         }

--- a/test/LibraryManager.Test/ManifestTest.cs
+++ b/test/LibraryManager.Test/ManifestTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.Cdnjs;
 using Microsoft.Web.LibraryManager.Providers.FileSystem;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Test
 {
@@ -33,6 +34,7 @@ namespace Microsoft.Web.LibraryManager.Test
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory());
 
+            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
             Directory.CreateDirectory(_projectFolder);
             File.WriteAllText(_filePath, _doc);
         }

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             var hostInteraction = new HostInteraction(projectFolder, cacheFolder);
             var dependencies = new Dependencies(hostInteraction, new CdnjsProviderFactory());
 
-            LibraryIdToNameAndVersionConverter.Instance.Initialize(dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(dependencies);
 
             _provider = dependencies.GetProvider("cdnjs");
             _catalog = _provider.GetCatalog();

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Mocks;
-using Microsoft.Web.LibraryManager.Providers.Cdnjs;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Mocks;
+using Microsoft.Web.LibraryManager.Providers.Cdnjs;
 
 namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
 {
@@ -27,6 +28,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             string cacheFolder = Environment.ExpandEnvironmentVariables(@"%localappdata%\Microsoft\Library\");
             var hostInteraction = new HostInteraction(projectFolder, cacheFolder);
             var dependencies = new Dependencies(hostInteraction, new CdnjsProviderFactory());
+
+            LibraryIdToNameAndVersionConverter.Instance.Initialize(dependencies);
 
             _provider = dependencies.GetProvider("cdnjs");
             _catalog = _provider.GetCatalog();

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             var hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(hostInteraction, new CdnjsProviderFactory());
             _provider = _dependencies.GetProvider("cdnjs");
-            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_dependencies);
 
             Directory.CreateDirectory(_projectFolder);
         }

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
@@ -1,15 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.Cdnjs;
 
 namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
@@ -30,6 +31,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             var hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(hostInteraction, new CdnjsProviderFactory());
             _provider = _dependencies.GetProvider("cdnjs");
+            LibraryIdToNameAndVersionConverter.Instance.Initialize(_dependencies);
 
             Directory.CreateDirectory(_projectFolder);
         }

--- a/test/LibraryManager.Test/SimpleLibraryNamingSchemeTest.cs
+++ b/test/LibraryManager.Test/SimpleLibraryNamingSchemeTest.cs
@@ -2,43 +2,43 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Web.LibraryManager.Helpers;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Test
 {
     [TestClass]
-    public class LibraryNamingSchemeTest
+    public class SimpleLibraryNamingSchemeTest
     {
         [DataTestMethod]
-        [DataRow("jquery@3.3.1", "jquery", "3.3.1")]
-        [DataRow("@angular/cli@1.0.0", "@angular/cli","1.0.0")]
-        [DataRow("My@Random@Library@1.0.0-preview3-final", "My@Random@Library", "1.0.0-preview3-final")]
+        [DataRow("jquery@3.3.1", "jquery@3.3.1", "")]
+        [DataRow("@angular/cli", "@angular/cli", "")]
+        [DataRow("My@Random@Library@", "My@Random@Library@", "")]
         [DataRow("@MyLibraryWithoutVersion", "@MyLibraryWithoutVersion", "")]
-        [DataRow("Library@Version", "Library", "Version")]
         [DataRow("Partial@", "Partial@", "")]
         [DataRow(null, "", "")]
         [DataRow("", "", "")]
         public void GetLibraryNameAndVersion(string libraryId, string expectedName, string expectedVersion)
         {
-            (string name, string version) = LibraryNamingScheme.Instance.GetLibraryNameAndVersion(libraryId);
+            var namingScheme = new SimpleLibraryNamingScheme();
+            (string name, string version) = namingScheme.GetLibraryNameAndVersion(libraryId);
 
             Assert.AreEqual(expectedName, name);
             Assert.AreEqual(expectedVersion, version);
         }
 
         [DataTestMethod]
-        [DataRow("jquery", "3.3.1", "jquery@3.3.1")]
-        [DataRow("@angular/cli","1.0.0", "@angular/cli@1.0.0")]
-        [DataRow("My@Random@Library", "1.0.0-preview3-final", "My@Random@Library@1.0.0-preview3-final")]
+        [DataRow("jquery", "3.3.1", "jquery")]
+        [DataRow("@angular/cli", "1.0.0", "@angular/cli")]
+        [DataRow("My@Random@Library", "1.0.0-preview3-final", "My@Random@Library")]
         [DataRow("@MyLibraryWithoutVersion", "", "@MyLibraryWithoutVersion")]
-        [DataRow("Library", "Version", "Library@Version")]
         [DataRow("", "", "")]
         [DataRow(null, null, "")]
         [DataRow("Partial", "", "Partial")]
         [DataRow("Partial@", "", "Partial@")]
         public void GetLibraryId(string name, string version, string expectedLibraryId)
         {
-            string libraryId = LibraryNamingScheme.Instance.GetLibraryId(name, version);
+            var namingScheme = new SimpleLibraryNamingScheme();
+            string libraryId = namingScheme.GetLibraryId(name, version);
 
             Assert.AreEqual(expectedLibraryId, libraryId);
         }

--- a/test/LibraryManager.Test/VersionedLibraryNamingSchemeTest.cs
+++ b/test/LibraryManager.Test/VersionedLibraryNamingSchemeTest.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+
+namespace Microsoft.Web.LibraryManager.Test
+{
+    [TestClass]
+    public class VersionedLibraryNamingSchemeTest
+    {
+        [DataTestMethod]
+        [DataRow("jquery@3.3.1", "jquery", "3.3.1")]
+        [DataRow("@angular/cli@1.0.0", "@angular/cli", "1.0.0")]
+        [DataRow("My@Random@Library@1.0.0-preview3-final", "My@Random@Library", "1.0.0-preview3-final")]
+        [DataRow("@MyLibraryWithoutVersion", "@MyLibraryWithoutVersion", "")]
+        [DataRow("Library@Version", "Library", "Version")]
+        [DataRow("Partial@", "Partial@", "")]
+        [DataRow(null, "", "")]
+        [DataRow("", "", "")]
+        public void GetLibraryNameAndVersion(string libraryId, string expectedName, string expectedVersion)
+        {
+            var namingScheme = new VersionedLibraryNamingScheme();
+            (string name, string version) = namingScheme.GetLibraryNameAndVersion(libraryId);
+
+            Assert.AreEqual(expectedName, name);
+            Assert.AreEqual(expectedVersion, version);
+        }
+
+        [DataTestMethod]
+        [DataRow("jquery", "3.3.1", "jquery@3.3.1")]
+        [DataRow("@angular/cli", "1.0.0", "@angular/cli@1.0.0")]
+        [DataRow("My@Random@Library", "1.0.0-preview3-final", "My@Random@Library@1.0.0-preview3-final")]
+        [DataRow("@MyLibraryWithoutVersion", "", "@MyLibraryWithoutVersion")]
+        [DataRow("Library", "Version", "Library@Version")]
+        [DataRow("", "", "")]
+        [DataRow(null, null, "")]
+        [DataRow("Partial", "", "Partial")]
+        [DataRow("Partial@", "", "Partial@")]
+        public void GetLibraryId(string name, string version, string expectedLibraryId)
+        {
+            var namingScheme = new VersionedLibraryNamingScheme();
+            string libraryId = namingScheme.GetLibraryId(name, version);
+
+            Assert.AreEqual(expectedLibraryId, libraryId);
+        }
+    }
+}


### PR DESCRIPTION
- Introduce two naming schemes: Versioned and Simple
- Providers specify version support
- Based on provider either versioned or simple naming scheme is used