### PR TITLE
Fix missing underscores in library names in the UI

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml
@@ -19,7 +19,7 @@
         <Image x:Name="Glyph" Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Width="32" Height="32" Margin="4 3" VerticalAlignment="Top" />
         <Label x:Name="ItemName" Grid.Row="0" Grid.Column="1" FontWeight="Bold" />
         <Label Grid.Row="1" Grid.Column="1" Grid.RowSpan="2" Margin="0 0 0 3">
-            <AccessText x:Name="Description" TextWrapping="Wrap"  />
+            <TextBlock x:Name="Description" TextWrapping="Wrap"  />
         </Label>
     </Grid>
 </UserControl>

--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml
@@ -27,7 +27,7 @@
                  Padding="2 2 20 2" />
         <!-- Watermark -->
         <Label Opacity=".5" Visibility="{Binding ElementName=ThisControl, Path=IsTextEntryEmpty, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" VerticalAlignment="Top" IsHitTestVisible="False">
-            <AccessText Text="{x:Static res:Text.TypeToSearch}" />
+            <TextBlock Text="{x:Static res:Text.TypeToSearch}" />
         </Label>
 
         <!-- Expand Grip -->
@@ -57,7 +57,7 @@
                 <ListBox.ItemTemplate>
                     <DataTemplate DataType="{x:Type controls:Completion}">
                         <Label ToolTip="{Binding Path=Description, Mode=OneWay}" Padding="0">
-                            <AccessText Text="{Binding Path=DisplayText, Mode=OneWay}" />
+                            <TextBlock Text="{Binding Path=DisplayText, Mode=OneWay}" />
                         </Label>
                     </DataTemplate>
                 </ListBox.ItemTemplate>

--- a/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
@@ -50,7 +50,7 @@
                 <ListBox.ItemTemplate>
                     <DataTemplate DataType="{x:Type controls:Completion}">
                         <Label ToolTip="{Binding Path=Description, Mode=OneWay}" Padding="0">
-                            <AccessText Text="{Binding Path=DisplayText, Mode=OneWay}" />
+                            <TextBlock Text="{Binding Path=DisplayText, Mode=OneWay}" />
                         </Label>
                     </DataTemplate>
                 </ListBox.ItemTemplate>

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -142,7 +142,7 @@
                     </Style.Triggers>
                 </Style>
             </Label.Style>
-            <AccessText Text="{x:Static resources:Text.SelectLibraryToSelectFilesToInstall}" />
+            <TextBlock Text="{x:Static resources:Text.SelectLibraryToSelectFilesToInstall}" />
         </Label>
 
         <DockPanel Grid.Row="3" 


### PR DESCRIPTION
Fixing https://github.com/aspnet/LibraryManager/issues/163 - **Autocomplete of 'jquerycarousel' becomes 'jquery_carousel'**

The issue here was that ```<AccessText>``` was used in our UI instead of ```<TextBlock>``` for some reason. AccessText uses ```_``` character as a special meta-character to specify that the following character is the "access key", so the ```_``` is not normally visible (until you press Alt button). Pressing the access key will invoke OnAccessKey method of the control using AccessText. It doesn't look that functionality was being used at all. I looked through all of our xaml and replaced all uses of AccessText with TextBlock. None of the uses of AccessText were taking advantage of the access key functionality or handling OnAccessKey method.

For more info, see

https://stackoverflow.com/questions/4601801/wpf-listbox-skip-underscore-symbols-in-strings

and

https://stackoverflow.com/questions/35534223/wpf-uses-and-expected-results-of-accesstext-class