### PR TITLE
 Reporting validation errors before calling operations

### DIFF
--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -55,30 +55,27 @@ namespace Microsoft.Web.LibraryManager.Build
                 FlushLogger(logger);
                 return false;
             }
-            else
+            
+            IEnumerable<ILibraryOperationResult> validationResults = manifest.GetValidationResultsAsync(token).Result;
+            if (!validationResults.All(r => r.Success))
             {
-                IEnumerable<ILibraryOperationResult> validationResults = manifest.GetValidationResultsAsync(token).Result;
-                if (!validationResults.All(r => r.Success))
-                {
-                    sw.Stop();
+                sw.Stop();
 
-                    LogErrors(validationResults.SelectMany(r =>r.Errors));
+                LogErrors(validationResults.SelectMany(r =>r.Errors));
 
-                    return false;
-                }
-                else
-                {
-                    IEnumerable<ILibraryOperationResult> results = manifest.RestoreAsync(token).Result;
-
-                    sw.Stop();
-
-                    FlushLogger(logger);
-                    PopulateFilesWritten(results, dependencies.GetHostInteractions());
-                    LogResults(sw, results);
-
-                    return !Log.HasLoggedErrors;
-                }
+                return false;
             }
+
+            IEnumerable<ILibraryOperationResult> results = manifest.RestoreAsync(token).Result;
+
+            sw.Stop();
+
+            FlushLogger(logger);
+            PopulateFilesWritten(results, dependencies.GetHostInteractions());
+            LogResults(sw, results);
+
+            return !Log.HasLoggedErrors;
+
         }
 
         // This is done to fix the issue with async/await in a synchronous Execute() method

--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -51,16 +51,17 @@ namespace Microsoft.Web.LibraryManager.Build
 
             if (manifest == null)
             {
-                logger.Log(PredefinedErrors.ManifestMalformed().Message, LogLevel.Error);
+                sw.Stop();
+                LogErrors(new[] { PredefinedErrors.ManifestMalformed() });
                 FlushLogger(logger);
+
                 return false;
             }
-            
+
             IEnumerable<ILibraryOperationResult> validationResults = manifest.GetValidationResultsAsync(token).Result;
             if (!validationResults.All(r => r.Success))
             {
                 sw.Stop();
-
                 LogErrors(validationResults.SelectMany(r =>r.Errors));
 
                 return false;
@@ -69,7 +70,6 @@ namespace Microsoft.Web.LibraryManager.Build
             IEnumerable<ILibraryOperationResult> results = manifest.RestoreAsync(token).Result;
 
             sw.Stop();
-
             FlushLogger(logger);
             PopulateFilesWritten(results, dependencies.GetHostInteractions());
             LogResults(sw, results);

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -52,16 +52,21 @@ namespace Microsoft.Web.LibraryManager.Vsix
             LogEvent(LogMessageGenerator.GetOperationHeaderString(operationType, libraryId), LogLevel.Task);
         }
 
+        public static void LogEventsFooter(OperationType operationType, TimeSpan elapsedTime)
+        {
+            LogEvent(string.Format(LibraryManager.Resources.Text.TimeElapsed, elapsedTime), LogLevel.Operation);
+            LogEvent(LibraryManager.Resources.Text.SummaryEndLine + Environment.NewLine, LogLevel.Operation);
+        }
+
         public static void LogEventsSummary(IEnumerable<ILibraryOperationResult> totalResults, OperationType operationType, TimeSpan elapsedTime, bool endOfMessage = true)
         {
             LogErrors(totalResults);
             LogEvent(LogMessageGenerator.GetSummaryHeaderString(operationType, null), LogLevel.Task);
             LogOperationSummary(totalResults, operationType, elapsedTime);
-            LogEvent(string.Format(LibraryManager.Resources.Text.TimeElapsed, elapsedTime), LogLevel.Operation);
 
             if (endOfMessage)
             {
-                LogEvent(LibraryManager.Resources.Text.SummaryEndLine + Environment.NewLine, LogLevel.Operation);
+                LogEventsFooter(operationType, elapsedTime);
             }
         }
 
@@ -69,12 +74,6 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
             List<string> errorStrings = GetErrorStrings(results);
             LogErrorsSummary(errorStrings, operationType, endOfMessage);
-        }
-
-        public static void ClearOutputWindow()
-        {
-            // Don't access _outputWindowPane through the property here so that we don't force creation
-            ThreadHelper.Generic.BeginInvoke(() => _outputWindowPane?.Clear());
         }
 
         /// <summary>
@@ -90,12 +89,17 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 LogEvent(error, LogLevel.Operation);
             }
 
-            LogEvent(LogMessageGenerator.GetErrorsHeaderString(operationType, null) + Environment.NewLine, LogLevel.Task);
+            LogEvent(LogMessageGenerator.GetErrorsHeaderString(operationType, null), LogLevel.Task);
 
             if (endOfMessage)
             {
                 LogEvent(LibraryManager.Resources.Text.SummaryEndLine + Environment.NewLine, LogLevel.Operation);
             }
+        }
+        public static void ClearOutputWindow()
+        {
+            // Don't access _outputWindowPane through the property here so that we don't force creation
+            ThreadHelper.Generic.BeginInvoke(() => _outputWindowPane?.Clear());
         }
 
         private static IVsOutputWindowPane OutputWindowPane

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -78,13 +78,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
         public static void LogEventsSummary(IEnumerable<ILibraryOperationResult> totalResults, OperationType operationType, TimeSpan elapsedTime, bool endOfMessage = true)
         {
             LogErrors(totalResults);
-
-            string summaryHeader = LogMessageGenerator.GetSummaryHeaderString(operationType, null);
-            if (!string.IsNullOrEmpty(summaryHeader))
-            {
-                LogEvent(LogMessageGenerator.GetSummaryHeaderString(operationType, null), LogLevel.Task);
-            }
-
+            LogEvent(LogMessageGenerator.GetSummaryHeaderString(operationType, null), LogLevel.Task);
             LogOperationSummary(totalResults, operationType, elapsedTime);
 
             if (endOfMessage)

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -47,17 +47,34 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
         }
 
+        /// <summary>
+        /// Logs the header of the summary of an operation
+        /// </summary>
+        /// <param name="operationType"></param>
+        /// <param name="libraryId"></param>
         public static void LogEventsHeader(OperationType operationType, string libraryId)
         {
             LogEvent(LogMessageGenerator.GetOperationHeaderString(operationType, libraryId), LogLevel.Task);
         }
 
+        /// <summary>
+        /// Logs the footer message of the summary of an operation
+        /// </summary>
+        /// <param name="operationType"></param>
+        /// <param name="elapsedTime"></param>
         public static void LogEventsFooter(OperationType operationType, TimeSpan elapsedTime)
         {
             LogEvent(string.Format(LibraryManager.Resources.Text.TimeElapsed, elapsedTime), LogLevel.Operation);
             LogEvent(LibraryManager.Resources.Text.SummaryEndLine + Environment.NewLine, LogLevel.Operation);
         }
 
+        /// <summary>
+        /// Logs the summary messages for a given <see cref="OperationType"/>
+        /// </summary>
+        /// <param name="totalResults"></param>
+        /// <param name="operationType"></param>
+        /// <param name="elapsedTime"></param>
+        /// <param name="endOfMessage"></param>
         public static void LogEventsSummary(IEnumerable<ILibraryOperationResult> totalResults, OperationType operationType, TimeSpan elapsedTime, bool endOfMessage = true)
         {
             LogErrors(totalResults);
@@ -70,14 +87,8 @@ namespace Microsoft.Web.LibraryManager.Vsix
             }
         }
 
-        public static void LogErrorsSummary(IEnumerable<ILibraryOperationResult> results, OperationType operationType, bool endOfMessage = true)
-        {
-            List<string> errorStrings = GetErrorStrings(results);
-            LogErrorsSummary(errorStrings, operationType, endOfMessage);
-        }
-
         /// <summary>
-        /// Logs error messages for a given <see cref="OperationType"/>
+        /// Logs errors messages for a given <see cref="OperationType"/>
         /// </summary>
         /// <param name="errorMessages">Messages to be logged</param>
         /// <param name="operationType"><see cref="OperationType"/></param>
@@ -96,6 +107,19 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 LogEvent(LibraryManager.Resources.Text.SummaryEndLine + Environment.NewLine, LogLevel.Operation);
             }
         }
+
+        /// <summary>
+        /// Logs errors messages for a given <see cref="OperationType"/>
+        /// </summary>
+        /// <param name="results">Operation results</param>
+        /// <param name="operationType"><see cref="OperationType"/></param>
+        /// <param name="endOfMessage">Whether or not to log end of message lines</param>
+        public static void LogErrorsSummary(IEnumerable<ILibraryOperationResult> results, OperationType operationType, bool endOfMessage = true)
+        {
+            List<string> errorStrings = GetErrorStrings(results);
+            LogErrorsSummary(errorStrings, operationType, endOfMessage);
+        }
+
         public static void ClearOutputWindow()
         {
             // Don't access _outputWindowPane through the property here so that we don't force creation

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
         public static void LogEventsSummary(IEnumerable<ILibraryOperationResult> totalResults, OperationType operationType, TimeSpan elapsedTime, bool endOfMessage = true)
         {
             LogErrors(totalResults);
-            LogEvent(LogMessageGenerator.GetSummaryHeaderString(operationType, null), LogLevel.Task);
+            LogEvent(LogMessageGenerator.GetSummaryHeaderString(operationType), LogLevel.Task);
             LogOperationSummary(totalResults, operationType, elapsedTime);
 
             if (endOfMessage)
@@ -100,7 +100,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 LogEvent(error, LogLevel.Operation);
             }
 
-            LogEvent(LogMessageGenerator.GetErrorsHeaderString(operationType, null), LogLevel.Task);
+            LogEvent(LogMessageGenerator.GetErrorsHeaderString(operationType), LogLevel.Task);
 
             if (endOfMessage)
             {

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -78,7 +78,13 @@ namespace Microsoft.Web.LibraryManager.Vsix
         public static void LogEventsSummary(IEnumerable<ILibraryOperationResult> totalResults, OperationType operationType, TimeSpan elapsedTime, bool endOfMessage = true)
         {
             LogErrors(totalResults);
-            LogEvent(LogMessageGenerator.GetSummaryHeaderString(operationType, null), LogLevel.Task);
+
+            string summaryHeader = LogMessageGenerator.GetSummaryHeaderString(operationType, null);
+            if (!string.IsNullOrEmpty(summaryHeader))
+            {
+                LogEvent(LogMessageGenerator.GetSummaryHeaderString(operationType, null), LogLevel.Task);
+            }
+
             LogOperationSummary(totalResults, operationType, elapsedTime);
 
             if (endOfMessage)

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -95,7 +95,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                 {
                     try
                     {
-                        Logger.LogEventsHeader(OperationType.Restore, string.Empty);
                         var newManifest = Manifest.FromJson(textDocument.TextBuffer.CurrentSnapshot.GetText(), _dependencies);
                         IEnumerable<ILibraryOperationResult> results = await LibrariesValidator.GetManifestErrorsAsync(newManifest, _dependencies, CancellationToken.None).ConfigureAwait(false);
 

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -95,13 +95,14 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                 {
                     try
                     {
+                        Logger.LogEventsHeader(OperationType.Restore, string.Empty);
                         var newManifest = Manifest.FromJson(textDocument.TextBuffer.CurrentSnapshot.GetText(), _dependencies);
                         IEnumerable<ILibraryOperationResult> results = await LibrariesValidator.GetManifestErrorsAsync(newManifest, _dependencies, CancellationToken.None).ConfigureAwait(false);
 
                         if (!results.All(r => r.Success))
                         {
                             AddErrorsToList(results);
-                            Logger.LogErrors(results);
+                            Logger.LogErrorsSummary(results, OperationType.Restore);
                             Telemetry.LogErrors("Fail-ManifestFileSaveWithErrors", results);
                         }
                         else
@@ -116,8 +117,8 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                             else
                             {
                                 string textMessage = string.Concat(Environment.NewLine, LibraryManager.Resources.Text.Restore_OperationHasErrors, Environment.NewLine);
+                                Logger.LogErrorsSummary(new[] { textMessage }, OperationType.Restore);
                                 Telemetry.TrackUserTask("Fail-RemovedUnwantedFiles", TelemetryResult.Failure);
-                                Logger.LogEvent(textMessage, LogLevel.Task);
                             }
                         }
                     }

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                 {
                     try
                     {
+                        Logger.LogEventsHeader(OperationType.Restore, string.Empty);
                         var newManifest = Manifest.FromJson(textDocument.TextBuffer.CurrentSnapshot.GetText(), _dependencies);
                         IEnumerable<ILibraryOperationResult> results = await LibrariesValidator.GetManifestErrorsAsync(newManifest, _dependencies, CancellationToken.None).ConfigureAwait(false);
 

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -179,15 +179,26 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
                 if (manifest != null)
                 {
-                    IHostInteraction hostInteraction = dependencies.GetHostInteractions();
-                    results = await manifest.CleanAsync(async (filesPaths) => await hostInteraction.DeleteFilesAsync(filesPaths, cancellationToken), cancellationToken);
+                    IEnumerable<ILibraryOperationResult> validationResults = await LibrariesValidator.GetManifestErrorsAsync(manifest, dependencies, cancellationToken).ConfigureAwait(false);
+
+                    if (!validationResults.All(r => r.Success))
+                    {
+                        sw.Stop();
+                        AddErrorsToErrorList(project?.Name, configFileName, validationResults);
+                        Logger.LogErrorsSummary(validationResults, OperationType.Clean);
+                        Telemetry.LogErrors($"FailValidation_{OperationType.Clean}", validationResults);
+                    }
+                    else
+                    {
+                        IHostInteraction hostInteraction = dependencies.GetHostInteractions();
+                        results = await manifest.CleanAsync(async (filesPaths) => await hostInteraction.DeleteFilesAsync(filesPaths, cancellationToken), cancellationToken);
+
+                        sw.Stop();
+                        AddErrorsToErrorList(project?.Name, configFileName, results);
+                        Logger.LogEventsSummary(results, OperationType.Clean, sw.Elapsed);
+                        Telemetry.LogEventsSummary(results, OperationType.Clean, sw.Elapsed);
+                    }
                 }
-
-                sw.Stop();
-
-                AddErrorsToErrorList(project?.Name, configFileName, results);
-                Logger.LogEventsSummary(results, OperationType.Clean, sw.Elapsed);
-                Telemetry.LogEventsSummary(results, OperationType.Clean, sw.Elapsed);
             }
             catch (OperationCanceledException ex)
             {
@@ -200,33 +211,40 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
             Logger.LogEventsHeader(OperationType.Restore, string.Empty);
 
-            List<ILibraryOperationResult> totalResults = new List<ILibraryOperationResult>();
-
             try
             {
-                Stopwatch sw = new Stopwatch();
-                sw.Start();
-
                 foreach (KeyValuePair<string, Manifest> manifest in manifests)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
+                    IDependencies dependencies = Dependencies.FromConfigFile(manifest.Key);
                     Project project = VsHelpers.GetDTEProjectFromConfig(manifest.Key);
+                    Stopwatch sw = new Stopwatch();
+                    sw.Start();
 
                     Logger.LogEvent(string.Format(LibraryManager.Resources.Text.Restore_LibrariesForProject, project?.Name), LogLevel.Operation);
 
-                    IEnumerable<ILibraryOperationResult> results = await RestoreLibrariesAsync(manifest.Value, cancellationToken).ConfigureAwait(false);
+                    IEnumerable<ILibraryOperationResult> validationResults = await LibrariesValidator.GetManifestErrorsAsync(manifest.Value, dependencies, cancellationToken).ConfigureAwait(false);
+                    if (!validationResults.All(r => r.Success))
+                    {
+                        sw.Stop();
+                        AddErrorsToErrorList(project?.Name, manifest.Key, validationResults);
+                        Logger.LogErrorsSummary(validationResults, OperationType.Restore, false);
+                        Telemetry.LogErrors($"FailValidation_{OperationType.Restore}", validationResults);
+                    }
+                    else
+                    {
+                        IEnumerable<ILibraryOperationResult> results = await RestoreLibrariesAsync(manifest.Value, cancellationToken).ConfigureAwait(false);
+                        await AddFilesToProjectAsync(manifest.Key, project, results.Where(r =>r.Success && !r.UpToDate), cancellationToken).ConfigureAwait(false);
+                        AddErrorsToErrorList(project?.Name, manifest.Key, results);
+                        sw.Stop();
 
-                    await AddFilesToProjectAsync(manifest.Key, project, results.Where(r =>r.Success && !r.UpToDate), cancellationToken).ConfigureAwait(false);
-
-                    AddErrorsToErrorList(project?.Name, manifest.Key, results);
-                    totalResults.AddRange(results);
+                        Logger.LogEventsSummary(results, OperationType.Restore, sw.Elapsed, false);
+                        Telemetry.LogEventsSummary(results, OperationType.Restore, sw.Elapsed);
+                    }
                 }
 
-                sw.Stop();
-
-                Logger.LogEventsSummary(totalResults, OperationType.Restore, sw.Elapsed);
-                Telemetry.LogEventsSummary(totalResults, OperationType.Restore, sw.Elapsed);
+                Logger.LogEvent(LibraryManager.Resources.Text.SummaryEndLine + Environment.NewLine, LogLevel.Operation);
             }
             catch (OperationCanceledException ex)
             {
@@ -265,7 +283,15 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
                 sw.Stop();
 
-                Logger.LogEventsSummary(new List<ILibraryOperationResult> { result }, OperationType.Uninstall, sw.Elapsed);
+                if (result.Errors.Any())
+                {
+                    Logger.LogErrorsSummary(new List<ILibraryOperationResult> { result }, OperationType.Uninstall);
+                }
+                else
+                {
+                    Logger.LogEventsSummary(new List<ILibraryOperationResult> { result }, OperationType.Uninstall, sw.Elapsed);
+                }
+
                 Telemetry.LogEventsSummary(new List<ILibraryOperationResult> { result }, OperationType.Uninstall, sw.Elapsed);
             }
             catch (OperationCanceledException ex)

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -221,6 +221,8 @@ namespace Microsoft.Web.LibraryManager.Vsix
                     swLocal.Start();
                     IDependencies dependencies = Dependencies.FromConfigFile(manifest.Key);
                     Project project = VsHelpers.GetDTEProjectFromConfig(manifest.Key);
+                    Stopwatch sw = new Stopwatch();
+                    sw.Start();
 
                     Logger.LogEvent(string.Format(LibraryManager.Resources.Text.Restore_LibrariesForProject, project?.Name), LogLevel.Operation);
 

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -221,8 +221,6 @@ namespace Microsoft.Web.LibraryManager.Vsix
                     swLocal.Start();
                     IDependencies dependencies = Dependencies.FromConfigFile(manifest.Key);
                     Project project = VsHelpers.GetDTEProjectFromConfig(manifest.Key);
-                    Stopwatch sw = new Stopwatch();
-                    sw.Start();
 
                     Logger.LogEvent(string.Format(LibraryManager.Resources.Text.Restore_LibrariesForProject, project?.Name), LogLevel.Operation);
 

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Web.LibraryManager.Logging
         /// <summary>
         /// Gets the summary header string for an operation.
         /// </summary>
-        public static string GetSummaryHeaderString(OperationType operationType, string libraryId)
+        public static string GetSummaryHeaderString(OperationType operationType)
         {
             switch (operationType)
             {
@@ -170,7 +170,7 @@ namespace Microsoft.Web.LibraryManager.Logging
         /// <summary>
         /// Gets the summary header string for an errored operation/ failed operation.
         /// </summary>
-        public static string GetErrorsHeaderString(OperationType operationType, string libraryId)
+        public static string GetErrorsHeaderString(OperationType operationType)
         {
             switch (operationType)
             {

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -120,16 +120,16 @@ namespace Microsoft.Web.LibraryManager.Logging
             switch (operationType)
             {
                 case OperationType.Restore:
-                    return LibraryManager.Resources.Text.Restore_OperationStarted;
+                    return Resources.Text.Restore_OperationStarted;
 
                 case OperationType.Clean:
-                    return LibraryManager.Resources.Text.Clean_OperationStarted;
+                    return Resources.Text.Clean_OperationStarted;
 
                 case OperationType.Uninstall:
-                    return string.Format(LibraryManager.Resources.Text.Uninstall_LibraryStarted, libraryId ?? string.Empty);
+                    return string.Format(Resources.Text.Uninstall_LibraryStarted, libraryId ?? string.Empty);
 
                 case OperationType.Upgrade:
-                    return string.Format(LibraryManager.Resources.Text.Update_LibraryStarted, libraryId ?? string.Empty);
+                    return string.Format(Resources.Text.Update_LibraryStarted, libraryId ?? string.Empty);
 
                 default:
                     return string.Empty;
@@ -144,16 +144,40 @@ namespace Microsoft.Web.LibraryManager.Logging
             switch (operationType)
             {
                 case OperationType.Restore:
-                    return LibraryManager.Resources.Text.Restore_OperationCompleted;
+                    return Resources.Text.Restore_OperationCompleted;
 
                 case OperationType.Clean:
-                    return LibraryManager.Resources.Text.Clean_OperationCompleted;
+                    return Resources.Text.Clean_OperationCompleted;
 
                 case OperationType.Uninstall:
-                    return string.Format(LibraryManager.Resources.Text.Uninstall_LibrarySucceeded, libraryId ?? string.Empty);
+                    return string.Empty;
 
                 case OperationType.Upgrade:
-                    return string.Format(LibraryManager.Resources.Text.Update_LibrarySucceeded, libraryId ?? string.Empty);
+                    return string.Empty;
+
+                default:
+                    return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the summary header string for an operation.
+        /// </summary>
+        public static string GetErrorsHeaderString(OperationType operationType, string libraryId)
+        {
+            switch (operationType)
+            {
+                case OperationType.Restore:
+                    return Resources.Text.Restore_OperationCompletedWithErrors;
+
+                case OperationType.Clean:
+                    return Resources.Text.Clean_OperationCompletedWithErrors;
+
+                case OperationType.Uninstall:
+                    return Resources.Text.Uninstall_OperationCompletedWithErrors;
+
+                case OperationType.Upgrade:
+                    return Resources.Text.Upgrade_OperationCompletedWithErrors;
 
                 default:
                     return string.Empty;

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -17,11 +17,17 @@ namespace Microsoft.Web.LibraryManager.Logging
         /// <summary>
         /// Gets a partial success string for the given operation.
         /// </summary>
-        public static string GetPartialSuccessString(OperationType operation, int successfulResults, int failedResults, int cancelledResults, TimeSpan timeSpan)
+        public static string GetPartialSuccessString(OperationType operation,
+            int successfulResults,
+            int failedResults,
+            int cancelledResults,
+            int uptodateResults,
+            TimeSpan timeSpan)
         {
             string successString = Resources.Text.Restore_NumberOfLibrariesSucceeded;
             string failedString = Resources.Text.Restore_NumberOfLibrariesFailed;
             string cancelledString = Resources.Text.Restore_NumberOfLibrariesCancelled;
+            string uptodateString = Resources.Text.Restore_NumberOfLibrariesUptodate;
 
             // Partial success only applies to Restore and Clean operations.
             // All other bulk operations are treated as restore.
@@ -36,6 +42,7 @@ namespace Microsoft.Web.LibraryManager.Logging
             message = successfulResults > 0 ? message + string.Format(successString, successfulResults, Math.Round(timeSpan.TotalSeconds, 2)) + Environment.NewLine : message;
             message = failedResults > 0 ? message + string.Format(failedString, failedResults) + Environment.NewLine : message;
             message = cancelledResults > 0 ? message + string.Format(cancelledString, cancelledResults) + Environment.NewLine : message;
+            message = uptodateResults > 0 ? message + string.Format(uptodateString, uptodateResults) + Environment.NewLine : message;
 
             return message;
         }
@@ -226,7 +233,8 @@ namespace Microsoft.Web.LibraryManager.Logging
                 }
                 else
                 {
-                    messageText = LogMessageGenerator.GetPartialSuccessString(operation, successfulResults.Count(), failedResults.Count(), cancelledRessults.Count(), elapsedTime);
+                    messageText = LogMessageGenerator.GetPartialSuccessString(operation,
+                        successfulResults.Count(), failedResults.Count(), cancelledRessults.Count(), upToDateResults.Count(), elapsedTime);
                 }
 
                 return messageText;

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -156,6 +156,12 @@ namespace Microsoft.Web.LibraryManager.Logging
                 case OperationType.Clean:
                     return Resources.Text.Clean_OperationCompleted;
 
+                case OperationType.Uninstall:
+                    return Resources.Text.Uninstall_OperationCompleted;
+
+                case OperationType.Upgrade:
+                    return Resources.Text.Upgrade_OperationCompleted;
+
                 default:
                     return string.Empty;
             }

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Web.LibraryManager.Logging
         }
 
         /// <summary>
-        /// Gets the summary header string for an operation.
+        /// Gets the summary header string for an errored operation/ failed operation.
         /// </summary>
         public static string GetErrorsHeaderString(OperationType operationType, string libraryId)
         {

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -156,12 +156,6 @@ namespace Microsoft.Web.LibraryManager.Logging
                 case OperationType.Clean:
                     return Resources.Text.Clean_OperationCompleted;
 
-                case OperationType.Uninstall:
-                    return string.Empty;
-
-                case OperationType.Upgrade:
-                    return string.Empty;
-
                 default:
                     return string.Empty;
             }

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -323,11 +323,6 @@ namespace Microsoft.Web.LibraryManager
         {
             IEnumerable<ILibraryOperationResult> validationResults = await LibrariesValidator.GetManifestErrorsAsync(this, _dependencies, cancellationToken).ConfigureAwait(false);
 
-            if (!validationResults.All(r => r.Success))
-            {
-                return validationResults;
-            }
-
             return validationResults;
         }
 

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -109,7 +109,6 @@ namespace Microsoft.Web.LibraryManager
             }
             catch (Exception)
             {
-                dependencies.GetHostInteractions().Logger.Log(PredefinedErrors.ManifestMalformed().Message, LogLevel.Task);
                 return null;
             }
         }

--- a/src/LibraryManager/Resources/Text.Designer.cs
+++ b/src/LibraryManager/Resources/Text.Designer.cs
@@ -295,6 +295,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} libraries are up-to-date.
+        /// </summary>
+        public static string Restore_NumberOfLibrariesUptodate {
+            get {
+                return ResourceManager.GetString("Restore_NumberOfLibrariesUptodate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Restore operation has been cancelled.
         /// </summary>
         public static string Restore_OperationCancelled {

--- a/src/LibraryManager/Resources/Text.Designer.cs
+++ b/src/LibraryManager/Resources/Text.Designer.cs
@@ -115,6 +115,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clean operation completed with errors.
+        /// </summary>
+        public static string Clean_OperationCompletedWithErrors {
+            get {
+                return ResourceManager.GetString("Clean_OperationCompletedWithErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Clean operation failed for {0} libraries.
         /// </summary>
         public static string Clean_OperationFailed {
@@ -304,6 +313,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restore operation completed with errors.
+        /// </summary>
+        public static string Restore_OperationCompletedWithErrors {
+            get {
+                return ResourceManager.GetString("Restore_OperationCompletedWithErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Restore operation failed for {0} libraries.
         /// </summary>
         public static string Restore_OperationFailed {
@@ -394,6 +412,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Uninstall operation completed with errors.
+        /// </summary>
+        public static string Uninstall_OperationCompletedWithErrors {
+            get {
+                return ResourceManager.GetString("Uninstall_OperationCompletedWithErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Example: &lt;library&gt;@&lt;version&gt;.
         /// </summary>
         public static string UnpkgProviderHintText {
@@ -435,6 +462,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         public static string Update_LibrarySucceeded {
             get {
                 return ResourceManager.GetString("Update_LibrarySucceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upgrade operation completed with errors.
+        /// </summary>
+        public static string Upgrade_OperationCompletedWithErrors {
+            get {
+                return ResourceManager.GetString("Upgrade_OperationCompletedWithErrors", resourceCulture);
             }
         }
     }

--- a/src/LibraryManager/Resources/Text.Designer.cs
+++ b/src/LibraryManager/Resources/Text.Designer.cs
@@ -421,6 +421,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Uninstall operation completed.
+        /// </summary>
+        public static string Uninstall_OperationCompleted {
+            get {
+                return ResourceManager.GetString("Uninstall_OperationCompleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Uninstall operation completed with errors.
         /// </summary>
         public static string Uninstall_OperationCompletedWithErrors {
@@ -471,6 +480,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         public static string Update_LibrarySucceeded {
             get {
                 return ResourceManager.GetString("Update_LibrarySucceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upgrade operation completed.
+        /// </summary>
+        public static string Upgrade_OperationCompleted {
+            get {
+                return ResourceManager.GetString("Upgrade_OperationCompleted", resourceCulture);
             }
         }
         

--- a/src/LibraryManager/Resources/Text.resx
+++ b/src/LibraryManager/Resources/Text.resx
@@ -265,4 +265,10 @@
   <data name="Restore_NumberOfLibrariesUptodate" xml:space="preserve">
     <value>{0} libraries are up-to-date</value>
   </data>
+  <data name="Uninstall_OperationCompleted" xml:space="preserve">
+    <value>Uninstall operation completed</value>
+  </data>
+  <data name="Upgrade_OperationCompleted" xml:space="preserve">
+    <value>Upgrade operation completed</value>
+  </data>
 </root>

--- a/src/LibraryManager/Resources/Text.resx
+++ b/src/LibraryManager/Resources/Text.resx
@@ -250,4 +250,16 @@
   <data name="LibraryDetail_Unavailable" xml:space="preserve">
     <value>Unavailable</value>
   </data>
+  <data name="Clean_OperationCompletedWithErrors" xml:space="preserve">
+    <value>Clean operation completed with errors</value>
+  </data>
+  <data name="Restore_OperationCompletedWithErrors" xml:space="preserve">
+    <value>Restore operation completed with errors</value>
+  </data>
+  <data name="Uninstall_OperationCompletedWithErrors" xml:space="preserve">
+    <value>Uninstall operation completed with errors</value>
+  </data>
+  <data name="Upgrade_OperationCompletedWithErrors" xml:space="preserve">
+    <value>Upgrade operation completed with errors</value>
+  </data>
 </root>

--- a/src/LibraryManager/Resources/Text.resx
+++ b/src/LibraryManager/Resources/Text.resx
@@ -262,4 +262,7 @@
   <data name="Upgrade_OperationCompletedWithErrors" xml:space="preserve">
     <value>Upgrade operation completed with errors</value>
   </data>
+  <data name="Restore_NumberOfLibrariesUptodate" xml:space="preserve">
+    <value>{0} libraries are up-to-date</value>
+  </data>
 </root>

--- a/src/libman/Commands/BaseCommand.cs
+++ b/src/libman/Commands/BaseCommand.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
         {
             foreach (IError error in errors)
             {
-                Logger.Log(error.Message, LogLevel.Error);
+                Logger.Log(string.Format("[{0}]: {1}", error.Code, error.Message), LogLevel.Error);
             }
         }
     }

--- a/src/libman/Commands/BaseCommand.cs
+++ b/src/libman/Commands/BaseCommand.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
             if (manifest == null)
             {
-                Logger.Log(PredefinedErrors.ManifestMalformed().Message, LogLevel.Task);
+                Logger.Log(PredefinedErrors.ManifestMalformed().Message, LogLevel.Error);
                 throw new InvalidOperationException(Resources.Text.FixManifestFile);
             }
 

--- a/src/libman/Commands/BaseCommand.cs
+++ b/src/libman/Commands/BaseCommand.cs
@@ -207,5 +207,13 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
                 Logger.Log(messageText, LogLevel.Operation);
             }
         }
+
+        protected void LogErrors(IEnumerable<IError> errors)
+        {
+            foreach (IError error in errors)
+            {
+                Logger.Log(error.Message, LogLevel.Error);
+            }
+        }
     }
 }

--- a/src/libman/Commands/BaseCommand.cs
+++ b/src/libman/Commands/BaseCommand.cs
@@ -160,6 +160,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
             if (manifest == null)
             {
+                Logger.Log(PredefinedErrors.ManifestMalformed().Message, LogLevel.Task);
                 throw new InvalidOperationException(Resources.Text.FixManifestFile);
             }
 

--- a/src/libman/Commands/CleanCommand.cs
+++ b/src/libman/Commands/CleanCommand.cs
@@ -30,13 +30,23 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
             Manifest manifest = await GetManifestAsync();
             Task<bool> deleteFileAction(IEnumerable<string> s) => HostInteractions.DeleteFilesAsync(s, CancellationToken.None);
+            IEnumerable<ILibraryOperationResult> validationResults = await manifest.GetValidationResultsAsync(CancellationToken.None);
 
-            IEnumerable<ILibraryOperationResult> results = await manifest.CleanAsync(deleteFileAction, CancellationToken.None);
+            if (!validationResults.All(r => r.Success))
+            {
+                sw.Stop();
+                LogErrors(validationResults.SelectMany(r => r.Errors));
 
-            sw.Stop();
-            LogResultsSummary(results, OperationType.Clean, sw.Elapsed);
-            return 0;
+                return 0;
+            }
+            else
+            {
+                IEnumerable<ILibraryOperationResult> results = await manifest.CleanAsync(deleteFileAction, CancellationToken.None);
+
+                sw.Stop();
+                LogResultsSummary(results, OperationType.Clean, sw.Elapsed);
+                return 0;
+            }
         }
-
     }
 }

--- a/src/libman/Commands/CleanCommand.cs
+++ b/src/libman/Commands/CleanCommand.cs
@@ -39,14 +39,12 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
                 return 0;
             }
-            else
-            {
-                IEnumerable<ILibraryOperationResult> results = await manifest.CleanAsync(deleteFileAction, CancellationToken.None);
 
-                sw.Stop();
-                LogResultsSummary(results, OperationType.Clean, sw.Elapsed);
-                return 0;
-            }
+            IEnumerable<ILibraryOperationResult> results = await manifest.CleanAsync(deleteFileAction, CancellationToken.None);
+            sw.Stop();
+            LogResultsSummary(results, OperationType.Clean, sw.Elapsed);
+
+            return 0;
         }
     }
 }

--- a/src/libman/Commands/RestoreCommand.cs
+++ b/src/libman/Commands/RestoreCommand.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
@@ -27,12 +28,24 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             sw.Start();
 
             Manifest manifest = await GetManifestAsync();
-            IEnumerable<ILibraryOperationResult> results = await ManifestRestorer.RestoreManifestAsync(manifest, Logger, CancellationToken.None);
+            IEnumerable<ILibraryOperationResult> validationResults = await manifest.GetValidationResultsAsync(CancellationToken.None);
 
-            sw.Stop();
-            LogResultsSummary(results, OperationType.Restore, sw.Elapsed);
+            if (!validationResults.All(r => r.Success))
+            {
+                sw.Stop();
+                LogErrors(validationResults.SelectMany(r => r.Errors));
 
-            return 0;
+                return 0;
+            }
+            else
+            {
+                IEnumerable<ILibraryOperationResult> results = await ManifestRestorer.RestoreManifestAsync(manifest, Logger, CancellationToken.None);
+
+                sw.Stop();
+                LogResultsSummary(results, OperationType.Restore, sw.Elapsed);
+
+                return 0;
+            }
         }
     }
 }

--- a/src/libman/Commands/RestoreCommand.cs
+++ b/src/libman/Commands/RestoreCommand.cs
@@ -37,15 +37,12 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
                 return 0;
             }
-            else
-            {
-                IEnumerable<ILibraryOperationResult> results = await ManifestRestorer.RestoreManifestAsync(manifest, Logger, CancellationToken.None);
 
-                sw.Stop();
-                LogResultsSummary(results, OperationType.Restore, sw.Elapsed);
+            IEnumerable<ILibraryOperationResult> results = await ManifestRestorer.RestoreManifestAsync(manifest, Logger, CancellationToken.None);
+            sw.Stop();
+            LogResultsSummary(results, OperationType.Restore, sw.Elapsed);
 
-                return 0;
-            }
+            return 0;
         }
     }
 }

--- a/src/libman/Commands/UpdateCommand.cs
+++ b/src/libman/Commands/UpdateCommand.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
                 if (installedLibraries == null || !installedLibraries.Any())
                 {
-                    Logger.Log(string.Format(Resources.NoLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
+                    Logger.Log(string.Format(Resources.Text.NoLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
                     return 0;
                 }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
                 if (installedLibraries.Count() > 1)
                 {
-                    Logger.Log(string.Format(Resources.MoreThanOneLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
+                    Logger.Log(string.Format(Resources.Text.MoreThanOneLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
 
                     libraryToUpdate = LibraryResolver.ResolveLibraryByUserChoice(installedLibraries, HostEnvironment);
                 }
@@ -114,7 +114,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
                 if (newLibraryId == null || newLibraryId == libraryToUpdate.LibraryId)
                 {
-                    Logger.Log(string.Format(Resources.LatestVersionAlreadyInstalled, libraryToUpdate.LibraryId), LogLevel.Operation);
+                    Logger.Log(string.Format(Resources.Text.LatestVersionAlreadyInstalled, libraryToUpdate.LibraryId), LogLevel.Operation);
                     return 0;
                 }
 
@@ -149,17 +149,17 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
                 if (result.Success)
                 {
                     await manifest.SaveAsync(HostEnvironment.EnvironmentSettings.ManifestFileName, CancellationToken.None);
-                    Logger.Log(string.Format(Resources.LibraryUpdated, oldLibraryName, newLibraryId), LogLevel.Operation);
+                    Logger.Log(string.Format(Resources.Text.LibraryUpdated, oldLibraryName, newLibraryId), LogLevel.Operation);
                 }
                 else if (result.Errors != null)
                 {
                     if (ToVersion.HasValue())
                     {
-                        Logger.Log(string.Format(Resources.UpdateLibraryFailed, oldLibraryName, ToVersion.Value()), LogLevel.Error);
+                        Logger.Log(string.Format(Resources.Text.UpdateLibraryFailed, oldLibraryName, ToVersion.Value()), LogLevel.Error);
                     }
                     else
                     {
-                        Logger.Log(string.Format(Resources.UpdateLibraryToLatestFailed, oldLibraryName), LogLevel.Error);
+                        Logger.Log(string.Format(Resources.Text.UpdateLibraryToLatestFailed, oldLibraryName), LogLevel.Error);
                     }
                     foreach (IError error in result.Errors)
                     {
@@ -169,7 +169,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
                 return 0;
             }
-            
+
         }
 
         private async Task<string> GetLatestVersionAsync(ILibraryInstallationState libraryToUpdate, CancellationToken cancellationToken)

--- a/src/libman/Commands/UpdateCommand.cs
+++ b/src/libman/Commands/UpdateCommand.cs
@@ -66,98 +66,110 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
         protected override async Task<int> ExecuteInternalAsync()
         {
             Manifest manifest = await GetManifestAsync();
-            IEnumerable<ILibraryInstallationState> installedLibraries = ValidateParametersAndGetLibrariesToUpdate(manifest);
+            IEnumerable<ILibraryOperationResult> validationResults = await manifest.GetValidationResultsAsync(CancellationToken.None);
 
-            if (installedLibraries == null || !installedLibraries.Any())
+            if (!validationResults.All(r => r.Success))
             {
-                Logger.Log(string.Format(Resources.Text.NoLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
+                LogErrors(validationResults.SelectMany(r => r.Errors));
+
                 return 0;
-            }
-
-            ILibraryInstallationState libraryToUpdate = null;
-
-            if (installedLibraries.Count() > 1)
-            {
-                Logger.Log(string.Format(Resources.Text.MoreThanOneLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
-
-                libraryToUpdate = LibraryResolver.ResolveLibraryByUserChoice(installedLibraries, HostEnvironment);
             }
             else
             {
-                libraryToUpdate = installedLibraries.First();
-            }
+                IEnumerable<ILibraryInstallationState> installedLibraries = ValidateParametersAndGetLibrariesToUpdate(manifest);
 
-            string newLibraryId = null;
-
-            if (ToVersion.HasValue())
-            {
-                newLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(libraryToUpdate.Name, ToVersion.Value(), libraryToUpdate.ProviderId);
-            }
-            else
-            {
-                string latestVersion = await GetLatestVersionAsync(libraryToUpdate, CancellationToken.None);
-                if (!string.IsNullOrEmpty(latestVersion))
+                if (installedLibraries == null || !installedLibraries.Any())
                 {
-                    newLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(libraryToUpdate.Name, latestVersion, libraryToUpdate.ProviderId);
+                    Logger.Log(string.Format(Resources.NoLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
+                    return 0;
                 }
-            }
 
-            if (newLibraryId == null || newLibraryId == libraryToUpdate.LibraryId)
-            {
-                Logger.Log(string.Format(Resources.Text.LatestVersionAlreadyInstalled, libraryToUpdate.LibraryId), LogLevel.Operation);
-                return 0;
-            }
+                ILibraryInstallationState libraryToUpdate = null;
 
-            Manifest backup = manifest.Clone();
-            string oldLibraryName = libraryToUpdate.Name;
-            manifest.ReplaceLibraryId(libraryToUpdate, newLibraryId);
-
-            // Delete files from old version of the library.
-            await backup.RemoveUnwantedFilesAsync(manifest, CancellationToken.None);
-
-            IEnumerable<ILibraryOperationResult> results = await manifest.RestoreAsync(CancellationToken.None);
-
-            ILibraryOperationResult result = null;
-
-            foreach (ILibraryOperationResult r in results)
-            {
-                if (!r.Success && r.Errors.Any(e => e.Message.Contains(libraryToUpdate.LibraryId)))
+                if (installedLibraries.Count() > 1)
                 {
-                    result = r;
-                    break;
-                }
-                else if (r.Success
-                    && r.InstallationState.LibraryId == libraryToUpdate.LibraryId
-                    && r.InstallationState.ProviderId == libraryToUpdate.ProviderId
-                    && r.InstallationState.DestinationPath == libraryToUpdate.DestinationPath)
-                {
-                    result = r;
-                    break;
-                }
-            }
+                    Logger.Log(string.Format(Resources.MoreThanOneLibraryFoundToUpdate, LibraryName.Value), LogLevel.Operation);
 
-            if (result.Success)
-            {
-                await manifest.SaveAsync(HostEnvironment.EnvironmentSettings.ManifestFileName, CancellationToken.None);
-                Logger.Log(string.Format(Resources.Text.LibraryUpdated, oldLibraryName, newLibraryId), LogLevel.Operation);
-            }
-            else if (result.Errors != null)
-            {
-                if (ToVersion.HasValue())
-                {
-                    Logger.Log(string.Format(Resources.Text.UpdateLibraryFailed, oldLibraryName, ToVersion.Value()), LogLevel.Error);
+                    libraryToUpdate = LibraryResolver.ResolveLibraryByUserChoice(installedLibraries, HostEnvironment);
                 }
                 else
                 {
-                    Logger.Log(string.Format(Resources.Text.UpdateLibraryToLatestFailed, oldLibraryName), LogLevel.Error);
+                    libraryToUpdate = installedLibraries.First();
                 }
-                foreach (IError error in result.Errors)
-                {
-                    Logger.Log(string.Format("[{0}]: {1}", error.Code, error.Message), LogLevel.Error);
-                }
-            }
 
-            return 0;
+                string newLibraryId = null;
+
+                if (ToVersion.HasValue())
+                {
+                    newLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(libraryToUpdate.Name, ToVersion.Value(), libraryToUpdate.ProviderId);
+                }
+                else
+                {
+                    string latestVersion = await GetLatestVersionAsync(libraryToUpdate, CancellationToken.None);
+                    if (!string.IsNullOrEmpty(latestVersion))
+                    {
+                        newLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(libraryToUpdate.Name, latestVersion, libraryToUpdate.ProviderId);
+                    }
+                }
+
+                if (newLibraryId == null || newLibraryId == libraryToUpdate.LibraryId)
+                {
+                    Logger.Log(string.Format(Resources.LatestVersionAlreadyInstalled, libraryToUpdate.LibraryId), LogLevel.Operation);
+                    return 0;
+                }
+
+                Manifest backup = manifest.Clone();
+                string oldLibraryName = libraryToUpdate.Name;
+                manifest.ReplaceLibraryId(libraryToUpdate, newLibraryId);
+
+                // Delete files from old version of the library.
+                await backup.RemoveUnwantedFilesAsync(manifest, CancellationToken.None);
+
+                IEnumerable<ILibraryOperationResult> results = await manifest.RestoreAsync(CancellationToken.None);
+
+                ILibraryOperationResult result = null;
+
+                foreach (ILibraryOperationResult r in results)
+                {
+                    if (!r.Success && r.Errors.Any(e => e.Message.Contains(libraryToUpdate.LibraryId)))
+                    {
+                        result = r;
+                        break;
+                    }
+                    else if (r.Success
+                        && r.InstallationState.LibraryId == libraryToUpdate.LibraryId
+                        && r.InstallationState.ProviderId == libraryToUpdate.ProviderId
+                        && r.InstallationState.DestinationPath == libraryToUpdate.DestinationPath)
+                    {
+                        result = r;
+                        break;
+                    }
+                }
+
+                if (result.Success)
+                {
+                    await manifest.SaveAsync(HostEnvironment.EnvironmentSettings.ManifestFileName, CancellationToken.None);
+                    Logger.Log(string.Format(Resources.LibraryUpdated, oldLibraryName, newLibraryId), LogLevel.Operation);
+                }
+                else if (result.Errors != null)
+                {
+                    if (ToVersion.HasValue())
+                    {
+                        Logger.Log(string.Format(Resources.UpdateLibraryFailed, oldLibraryName, ToVersion.Value()), LogLevel.Error);
+                    }
+                    else
+                    {
+                        Logger.Log(string.Format(Resources.UpdateLibraryToLatestFailed, oldLibraryName), LogLevel.Error);
+                    }
+                    foreach (IError error in result.Errors)
+                    {
+                        Logger.Log(string.Format("[{0}]: {1}", error.Code, error.Message), LogLevel.Error);
+                    }
+                }
+
+                return 0;
+            }
+            
         }
 
         private async Task<string> GetLatestVersionAsync(ILibraryInstallationState libraryToUpdate, CancellationToken cancellationToken)

--- a/test/Microsoft.Web.LibraryManager.Build.Test/RestoreTaskTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Build.Test/RestoreTaskTest.cs
@@ -57,10 +57,10 @@ namespace Microsoft.Web.LibraryManager.Build.Test
             bool success = _task.Execute();
 
             Assert.IsFalse(success);
-            Assert.AreEqual(1, _buildEngine.Warnings.Count);
+            Assert.AreEqual(0, _buildEngine.Warnings.Count);
             Assert.AreEqual(2, _buildEngine.Messages.Count);
-            Assert.AreEqual(0, _buildEngine.Errors.Count);
-            Assert.AreEqual("LIB002", _buildEngine.Warnings.First().Code);
+            Assert.AreEqual(1, _buildEngine.Errors.Count);
+            Assert.AreEqual("LIB002", _buildEngine.Errors.First().Code);
             Assert.IsNull(_task.FilesWritten);
         }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Web.LibraryManager.Build.Test
             bool succuess = _task.Execute();
 
             Assert.IsFalse(succuess);
-            Assert.AreEqual(1, _buildEngine.Warnings.Count);
+            Assert.AreEqual(1, _buildEngine.Errors.Count);
             Assert.AreEqual(2, _buildEngine.Messages.Count);
             Assert.IsNull(_task.FilesWritten);
         }

--- a/test/Microsoft.Web.LibraryManager.Build.Test/RestoreTaskTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Build.Test/RestoreTaskTest.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Web.LibraryManager.Build.Test
 
             bool success = _task.Execute();
 
-            Assert.IsTrue(success);
+            Assert.IsFalse(success);
             Assert.AreEqual(1, _buildEngine.Warnings.Count);
             Assert.AreEqual(2, _buildEngine.Messages.Count);
             Assert.AreEqual(0, _buildEngine.Errors.Count);
             Assert.AreEqual("LIB002", _buildEngine.Warnings.First().Code);
-            Assert.AreEqual(0, _task.FilesWritten.Length);
+            Assert.IsNull(_task.FilesWritten);
         }
 
         [TestMethod]
@@ -72,10 +72,10 @@ namespace Microsoft.Web.LibraryManager.Build.Test
 
             bool succuess = _task.Execute();
 
-            Assert.IsTrue(succuess);
+            Assert.IsFalse(succuess);
             Assert.AreEqual(1, _buildEngine.Warnings.Count);
             Assert.AreEqual(2, _buildEngine.Messages.Count);
-            Assert.AreEqual(0, _task.FilesWritten.Length);
+            Assert.IsNull(_task.FilesWritten);
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR fixes bug #300 

We now call IEnumerable<ILibraryOperationResult> validationResults = await manifest.GetValidationResultsAsync() before all manifest operations. 
We report validation errors if there are any, otherwise proceed with the operation and Log the operation results.

This PR also improves log messages so they are consistent and accurate. 