### PR TITLE
Update error message when manifest file has syntax errors

### DIFF
--- a/src/LibraryManager.Contracts/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Contracts/Resources/Text.Designer.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Web.LibraryManager.Contracts.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The manifest file contains syntax errors.
+        ///   Looks up a localized string similar to Library Manager manifest contains syntax errors. Please fix the errors in libman.json, then try again..
         /// </summary>
         internal static string ErrorManifestMalformed {
             get {

--- a/src/LibraryManager.Contracts/Resources/Text.resx
+++ b/src/LibraryManager.Contracts/Resources/Text.resx
@@ -130,7 +130,7 @@
     <value>The library id is undefined</value>
   </data>
   <data name="ErrorManifestMalformed" xml:space="preserve">
-    <value>The manifest file contains syntax errors</value>
+    <value>Library Manager manifest contains syntax errors. Please fix the errors in libman.json, then try again.</value>
   </data>
   <data name="ErrorNotSupportedVersion" xml:space="preserve">
     <value>Version "{0}" is not supported by this version of Library Manager</value>

--- a/test/libman.Test/BaseCommandTests.cs
+++ b/test/libman.Test/BaseCommandTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             Assert.IsNull(manifest);
             var logger = HostEnvironment.Logger as TestLogger;
 
-            Assert.AreEqual("The manifest file contains syntax errors", logger.Messages[0].Value);
+            Assert.AreEqual("Library Manager manifest contains syntax errors. Please fix the errors in libman.json, then try again.", logger.Messages[0].Value);
         }
     }
 }


### PR DESCRIPTION
Updated error message when manifest file has syntax errors

Note: @justcla signed off on the strings here: https://github.com/aspnet/LibraryManager/pull/319. Updating the test here