### PR TITLE
Change Provider APIs to use name and version instead of libraryId

### DIFF
--- a/src/LibraryManager.Contracts/ILibraryCatalog.cs
+++ b/src/LibraryManager.Contracts/ILibraryCatalog.cs
@@ -20,12 +20,13 @@ namespace Microsoft.Web.LibraryManager.Contracts
         Task<CompletionSet> GetLibraryCompletionSetAsync(string value, int caretPosition);
 
         /// <summary>
-        /// Gets the library group from the specified <paramref name="libraryId"/>.
+        /// Gets the library group from the specified <paramref name="libraryName"/>.
         /// </summary>
-        /// <param name="libraryId">The unique library identifier.</param>
+        /// <param name="libraryName">The name of the library.</param>
+        /// <param name="version">The version of the library</param>
         /// <param name="cancellationToken">A token that allows the search to be cancelled.</param>
         /// <returns>An instance of <see cref="ILibraryGroup"/> or <code>null</code>.</returns>
-        Task<ILibrary> GetLibraryAsync(string libraryId, CancellationToken cancellationToken);
+        Task<ILibrary> GetLibraryAsync(string libraryName, string version, CancellationToken cancellationToken);
 
         /// <summary>
         /// Searches the catalog for the specified search term.
@@ -38,10 +39,10 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// <summary>
         /// Gets the latest version of the library.
         /// </summary>
-        /// <param name="libraryId">The library identifier.</param>
+        /// <param name="libraryName">The library identifier.</param>
         /// <param name="includePreReleases">if set to <c>true</c> includes pre-releases.</param>
         /// <param name="cancellationToken">A token that allows the search to be cancelled.</param>
         /// <returns>The library identifier of the latest released version.</returns>
-        Task<string> GetLatestVersion(string libraryId, bool includePreReleases, CancellationToken cancellationToken);
+        Task<string> GetLatestVersion(string libraryName, bool includePreReleases, CancellationToken cancellationToken);
     }
 }

--- a/src/LibraryManager.Contracts/ILibraryGroup.cs
+++ b/src/LibraryManager.Contracts/ILibraryGroup.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Web.LibraryManager.Contracts
         string Description { get; }
 
         /// <summary>
-        /// Gets a list of IDs for the different versions of the library.
+        /// Gets a list of versions of the library.
         /// </summary>
         /// <param name="cancellationToken">A token that allows cancellation of the operation.</param>
         /// <returns>A list of library IDs used to display library information to the user.</returns>
-        Task<IEnumerable<string>> GetLibraryIdsAsync(CancellationToken cancellationToken);
+        Task<IEnumerable<string>> GetLibraryVersions(CancellationToken cancellationToken);
     }
 }

--- a/src/LibraryManager.Contracts/ILibraryInstallationState.cs
+++ b/src/LibraryManager.Contracts/ILibraryInstallationState.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Web.LibraryManager.Contracts
     public interface ILibraryInstallationState
     {
         /// <summary>
-        /// The identifyer to uniquely identify the library
-        /// </summary>
-        string LibraryId { get; }
-
-        /// <summary>
         /// The name of the library.
         /// </summary>
         string Name { get; }
@@ -39,5 +34,15 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// The path relative to the working directory to copy the files to.
         /// </summary>
         string DestinationPath { get; }
+
+        /// <summary>
+        /// Indicates whether the library is using the default destination
+        /// </summary>
+        bool IsUsingDefaultDestination { get; }
+
+        /// <summary>
+        /// Indicates whether the library is using the default provider
+        /// </summary>
+        bool IsUsingDefaultProvider { get; }
     }
 }

--- a/src/LibraryManager.Contracts/PredefinedErrors.cs
+++ b/src/LibraryManager.Contracts/PredefinedErrors.cs
@@ -45,6 +45,19 @@ namespace Microsoft.Web.LibraryManager.Contracts
             => new Error("LIB002", string.Format(Text.ErrorUnableToResolveSource, libraryId, providerId));
 
         /// <summary>
+        /// The <see cref="IProvider"/> is unable to resolve the source.
+        /// </summary>
+        /// <param name="libraryName">Name of the library</param>
+        /// <param name="version">Version of the library</param>
+        /// <param name="providerId">The ID of the <see cref="IProvider"/> that could not resolve the resource.</param>
+        /// <returns>The error code LIB002</returns>
+        public static IError UnableToResolveSource(string libraryName, string version, string providerId)
+        {
+            string libraryId = string.IsNullOrEmpty(version) ? libraryName : $"{libraryName}@{version}";
+            return UnableToResolveSource(libraryId, providerId);
+        }
+
+        /// <summary>
         /// The <see cref="IProvider"/> failed to write a file in the <see cref="ILibraryInstallationState.Files"/> array.
         /// </summary>
         /// <param name="file">The file name that failed to be written to disk.</param>

--- a/src/LibraryManager.Vsix/ErrorList/ErrorList.cs
+++ b/src/LibraryManager.Vsix/ErrorList/ErrorList.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -42,7 +43,9 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         private static void AddLineAndColumn(IEnumerable<string> lines, ILibraryInstallationState state, DisplayError[] errors)
         {
-            if (string.IsNullOrEmpty(state?.LibraryId))
+            string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(state?.Name, state?.Version, state?.ProviderId);
+
+            if(string.IsNullOrEmpty(libraryId))
             {
                 return;
             }
@@ -58,7 +61,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                     if (line.Trim() == "{")
                         index = i;
 
-                    if (line.Contains(state.LibraryId))
+                    if (line.Contains(libraryId))
                     {
                         error.Line = index > 0 ? index : i;
                         break;

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             if (!JsonHelpers.TryGetInstallationState(parent, out ILibraryInstallationState state))
                 yield break;
 
-            if (string.IsNullOrEmpty(state.LibraryId))
+            if (string.IsNullOrEmpty(state.Name))
                 yield break;
 
             var dependencies = Dependencies.FromConfigFile(ConfigFilePath);
@@ -49,7 +49,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             if (catalog == null)
                 yield break;
 
-            Task<ILibrary> task = catalog.GetLibraryAsync(state.LibraryId, CancellationToken.None);
+            Task<ILibrary> task = catalog.GetLibraryAsync(state.Name, state.Version, CancellationToken.None);
             FrameworkElement presenter = GetPresenter(context);
             IEnumerable<string> usedFiles = GetUsedFiles(context);
 

--- a/src/LibraryManager.Vsix/Json/JsonHelpers.cs
+++ b/src/LibraryManager.Vsix/Json/JsonHelpers.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.JSON.Core.Parser;
 using Microsoft.JSON.Core.Parser.TreeItems;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Json;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
@@ -64,7 +65,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             return max + 1;
         }
 
-        public static bool TryGetInstallationState(JSONObject parent, out ILibraryInstallationState installationState)
+        public static bool TryGetInstallationState(JSONObject parent, out ILibraryInstallationState installationState, string defaultProvider = null)
         {
             installationState = null;
 
@@ -73,7 +74,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 return false;
             }
 
-            var state = new LibraryInstallationState();
+            var state = new LibraryInstallationStateOnDisk();
 
             foreach (JSONMember child in parent.Children.OfType<JSONMember>())
             {
@@ -124,7 +125,8 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 }
             }
 
-            installationState = state;
+            var converter = new LibraryStateToFileConverter(defaultProvider, defaultDestination: null);
+            installationState = converter.ConvertToLibraryInstallationState(state);
 
             return !string.IsNullOrEmpty(installationState.ProviderId);
         }

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             ConfigFilePath = doc.FilePath;
             LibraryObject = parent;
 
-            return !string.IsNullOrEmpty(InstallationState.LibraryId);
+            return !string.IsNullOrEmpty(InstallationState.Name);
         }
     }
 }

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
@@ -76,23 +76,23 @@ namespace Microsoft.Web.LibraryManager.Vsix
         private async Task<List<ISuggestedAction>> GetListOfActionsAsync(ILibraryCatalog catalog, CancellationToken cancellationToken)
         {
             var list = new List<ISuggestedAction>();
-            string latestStableVersion = await catalog.GetLatestVersion(_provider.InstallationState.LibraryId, false, cancellationToken).ConfigureAwait(false);
+            string latestStableVersion = await catalog.GetLatestVersion(_provider.InstallationState.Name, false, cancellationToken).ConfigureAwait(false);
             string latestStable = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(
                             _provider.InstallationState.Name,
                             latestStableVersion,
                             _provider.InstallationState.ProviderId);
 
-            if (!string.IsNullOrEmpty(latestStableVersion) && latestStable != _provider.InstallationState.LibraryId)
+            if (!string.IsNullOrEmpty(latestStableVersion) && latestStableVersion != _provider.InstallationState.Version)
             {
                 list.Add(new UpdateSuggestedAction(_provider, latestStable, $"Stable: {latestStable}"));
             }
 
-            string latestPreVersion = await catalog.GetLatestVersion(_provider.InstallationState.LibraryId, true, cancellationToken).ConfigureAwait(false);
+            string latestPreVersion = await catalog.GetLatestVersion(_provider.InstallationState.Name, true, cancellationToken).ConfigureAwait(false);
             string latestPre = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(_provider.InstallationState.Name,
                             latestPreVersion,
                             _provider.InstallationState.ProviderId);
 
-            if (!string.IsNullOrEmpty(latestPreVersion) && latestPre != _provider.InstallationState.LibraryId && latestPre != latestStable)
+            if (!string.IsNullOrEmpty(latestPreVersion) && latestPreVersion != _provider.InstallationState.Version && latestPre != latestStable)
             {
                 list.Add(new UpdateSuggestedAction(_provider, latestPre, $"Pre-release: {latestPre}"));
             }

--- a/src/LibraryManager.Vsix/Shared/ILibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/ILibraryCommandService.cs
@@ -9,13 +9,13 @@ using EnvDTE;
 namespace Microsoft.Web.LibraryManager.Vsix
 {
     /// <summary>
-    /// Contains wrapper methods for Manifest operations calls. 
+    /// Contains wrapper methods for Manifest operations calls.
     /// Handles Visual Studio specific behaviors (Task Management, Solution Events listeners and logging)
     /// </summary>
     internal interface ILibraryCommandService
     {
         /// <summary>
-        /// Clean the libraries defined in manifest 
+        /// Clean the libraries defined in manifest
         /// </summary>
         /// <param name="configProjectItem">ProjectItem for the manifest file (libman.json)</param>
         /// <param name="cancellationToken"></param>
@@ -49,13 +49,15 @@ namespace Microsoft.Web.LibraryManager.Vsix
         Task RestoreAsync(string configFilePath, Manifest manifest, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Unsintalls a library from a manifest 
+        /// Unsintalls a library from a manifest
         /// </summary>
         /// <param name="configFilePath">libman.json file path</param>
-        /// <param name="libraryId">library ID</param>
+        /// <param name="libraryName">library ID</param>
+        /// <param name="version">version of the library</param>
+        /// <param name="providerId">Id of the provider for this library</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task UninstallAsync(string configFilePath, string libraryId, CancellationToken cancellationToken);
+        Task UninstallAsync(string configFilePath, string libraryName, string version, string providerId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns true if there is already one operation in progress

--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Vsix.Resources;
 using Microsoft.Web.LibraryManager.Vsix.UI.Controls;
 using Newtonsoft.Json;
@@ -288,7 +289,8 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 
         private void RefreshFileSelections()
         {
-            SelectedProvider.GetCatalog().GetLibraryAsync(_packageId, CancellationToken.None).ContinueWith(x =>
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(_packageId, SelectedProvider.Id);
+            SelectedProvider.GetCatalog().GetLibraryAsync(name, version, CancellationToken.None).ContinueWith(x =>
             {
                 if (x.IsFaulted || x.IsCanceled)
                 {
@@ -364,9 +366,11 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 
         public async Task<bool> IsLibraryInstallationStateValidAsync()
         {
+            (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(PackageId, SelectedProvider.Id);
             LibraryInstallationState libraryInstallationState = new LibraryInstallationState
             {
-                LibraryId = PackageId,
+                Name = name,
+                Version = version,
                 ProviderId = SelectedProvider.Id,
                 DestinationPath = InstallationFolder.DestinationFolder,
                 Files = SelectedFiles?.ToList()
@@ -446,9 +450,11 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
                         manifest.Version = Manifest.SupportedVersions.Max().ToString();
                     }
 
+                    (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(PackageId, SelectedProvider.Id);
                     LibraryInstallationState libraryInstallationState = new LibraryInstallationState
                     {
-                        LibraryId = PackageId,
+                        Name = name,
+                        Version = version,
                         ProviderId = selectedPackage.ProviderId,
                         DestinationPath = InstallationFolder.DestinationFolder,
                     };

--- a/src/LibraryManager/Helpers/Extensions.cs
+++ b/src/LibraryManager/Helpers/Extensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Web.LibraryManager
     public static class Extensions
     {
         /// <summary>
-        /// Validates <see cref="ILibraryInstallationState"/> 
+        /// Validates <see cref="ILibraryInstallationState"/>
         /// </summary>
         /// <param name="state">The <see cref="ILibraryInstallationState"/> to validate.</param>
         /// <param name="dependencies">The <see cref="IDependencies"/> used to validate <see cref="ILibraryInstallationState"/></param>
@@ -46,7 +46,7 @@ namespace Microsoft.Web.LibraryManager
         }
 
         /// <summary>
-        ///  Validates <see cref="ILibraryInstallationState"/> 
+        ///  Validates <see cref="ILibraryInstallationState"/>
         /// </summary>
         /// <param name="state">The <see cref="ILibraryInstallationState"/> to validate.</param>
         /// <param name="provider">The <see cref="IProvider"/> used to validate <see cref="ILibraryInstallationState"/></param>
@@ -63,7 +63,7 @@ namespace Microsoft.Web.LibraryManager
                 return new LibraryOperationResult(state, new[] { PredefinedErrors.ProviderUnknown(provider.Id) });
             }
 
-            if (string.IsNullOrEmpty(state.LibraryId))
+            if (string.IsNullOrEmpty(state.Name))
             {
                 return new LibraryOperationResult(state, new[] { PredefinedErrors.LibraryIdIsUndefined() });
             }
@@ -71,11 +71,11 @@ namespace Microsoft.Web.LibraryManager
             ILibraryCatalog catalog = provider.GetCatalog();
             try
             {
-                await catalog.GetLibraryAsync(state.LibraryId, CancellationToken.None).ConfigureAwait(false);
+                await catalog.GetLibraryAsync(state.Name, state.Version, CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {
-                return new LibraryOperationResult(state, new[] { PredefinedErrors.UnableToResolveSource(state.LibraryId, provider.Id) });
+                return new LibraryOperationResult(state, new[] { PredefinedErrors.UnableToResolveSource(state.Name, state.Version, provider.Id) });
             }
 
             if (string.IsNullOrEmpty(state.DestinationPath))

--- a/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
+++ b/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Microsoft.Web.LibraryManager.Json
+{
+    internal class LibraryInstallationStateOnDisk
+    {
+        [JsonProperty(ManifestConstants.Library)]
+        public string LibraryId { get; set; }
+
+        [JsonProperty(ManifestConstants.Provider)]
+        public string ProviderId { get; set; }
+
+        [JsonProperty(ManifestConstants.Destination)]
+        public string DestinationPath { get; set; }
+
+        [JsonProperty(ManifestConstants.Files)]
+        public IReadOnlyList<string> Files { get; set; }
+    }
+}

--- a/src/LibraryManager/Json/LibraryStateToFileConverter.cs
+++ b/src/LibraryManager/Json/LibraryStateToFileConverter.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+
+namespace Microsoft.Web.LibraryManager.Json
+{
+    internal class LibraryStateToFileConverter
+    {
+        private string _defaultProvider;
+        private string _defaultDestination;
+
+        public LibraryStateToFileConverter(string defaultProvider, string defaultDestination)
+        {
+            _defaultProvider = defaultProvider;
+            _defaultDestination = defaultDestination;
+        }
+
+        public ILibraryInstallationState ConvertToLibraryInstallationState(LibraryInstallationStateOnDisk stateOnDisk)
+        {
+            if (stateOnDisk == null)
+            {
+                return null;
+            }
+
+            string provider = string.IsNullOrEmpty(stateOnDisk.ProviderId) ? _defaultProvider : stateOnDisk.ProviderId;
+            string destination = string.IsNullOrEmpty(stateOnDisk.DestinationPath) ? _defaultDestination : stateOnDisk.DestinationPath;
+
+            var state = new LibraryInstallationState()
+            {
+                IsUsingDefaultDestination = string.IsNullOrEmpty(stateOnDisk.DestinationPath),
+                IsUsingDefaultProvider = string.IsNullOrEmpty(stateOnDisk.ProviderId),
+                ProviderId = provider,
+                DestinationPath = destination,
+                Files = stateOnDisk.Files
+            };
+
+            (state.Name, state.Version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(stateOnDisk.LibraryId, provider);
+
+            return state;
+        }
+
+        public LibraryInstallationStateOnDisk ConvertToLibraryInstallationStateOnDisk(ILibraryInstallationState state)
+        {
+            if (state == null)
+            {
+                return null;
+            }
+
+            string provider = string.IsNullOrEmpty(state.ProviderId) ? _defaultProvider : state.ProviderId;
+            return new LibraryInstallationStateOnDisk()
+            {
+                ProviderId = state.IsUsingDefaultProvider ? null : state.ProviderId,
+                DestinationPath = state.IsUsingDefaultDestination ? null : state.DestinationPath,
+                Files = state.Files,
+                LibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(state.Name, state.Version, provider)
+            };
+        }
+    }
+}

--- a/src/LibraryManager/Json/ManifestOnDisk.cs
+++ b/src/LibraryManager/Json/ManifestOnDisk.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Microsoft.Web.LibraryManager.Json
+{
+    internal class ManifestOnDisk
+    {
+        [JsonProperty(ManifestConstants.Version)]
+        public string Version { get; set; }
+
+        [JsonProperty(ManifestConstants.DefaultProvider)]
+        public string DefaultProvider { get; set; }
+
+        [JsonProperty(ManifestConstants.DefaultDestination)]
+        public string DefaultDestination { get; set; }
+
+        [JsonProperty(ManifestConstants.Libraries)]
+        public IEnumerable<LibraryInstallationStateOnDisk> Libraries { get; set; }
+    }
+}

--- a/src/LibraryManager/Json/ManifestToFileConverter.cs
+++ b/src/LibraryManager/Json/ManifestToFileConverter.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Web.LibraryManager.Contracts;
+
+namespace Microsoft.Web.LibraryManager.Json
+{
+    internal class ManifestToFileConverter
+    {
+        public Manifest ConvertToManifest(ManifestOnDisk manifestOnDisk, IDependencies dependencies)
+        {
+            if (manifestOnDisk == null)
+            {
+                return null;
+            }
+
+            var manifest = new Manifest(dependencies)
+            {
+                Version = manifestOnDisk.Version,
+                DefaultDestination = manifestOnDisk.DefaultDestination,
+                DefaultProvider = manifestOnDisk.DefaultProvider,
+            };
+
+            var libraryStateConverter = new LibraryStateToFileConverter(manifest.DefaultProvider, manifest.DefaultDestination);
+
+            if (manifestOnDisk.Libraries != null)
+            {
+                foreach (LibraryInstallationStateOnDisk lod in manifestOnDisk.Libraries)
+                {
+                    manifest.AddLibrary(libraryStateConverter.ConvertToLibraryInstallationState(lod));
+                }
+            }
+
+            return manifest;
+        }
+
+        public ManifestOnDisk ConvertToManifestOnDisk(Manifest manifest)
+        {
+            if (manifest == null)
+            {
+                return null;
+            }
+
+            var manifestOnDisk = new ManifestOnDisk()
+            {
+                Version = manifest.Version,
+                DefaultDestination = manifest.DefaultDestination,
+                DefaultProvider = manifest.DefaultProvider,
+            };
+
+            var libraries = new List<LibraryInstallationStateOnDisk>();
+            var libraryStateConverter = new LibraryStateToFileConverter(manifest.DefaultProvider, manifest.DefaultDestination);
+
+
+            foreach (ILibraryInstallationState state in manifest.Libraries)
+            {
+                libraries.Add(libraryStateConverter.ConvertToLibraryInstallationStateOnDisk(state));
+            }
+
+            manifestOnDisk.Libraries = libraries;
+
+            return manifestOnDisk;
+        }
+    }
+}

--- a/src/LibraryManager/LibrariesValidator.cs
+++ b/src/LibraryManager/LibrariesValidator.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Web.LibraryManager
     internal static class LibrariesValidator
     {
         /// <summary>
-        /// Returns a collection of <see cref="ILibraryOperationResult"/> that represents the status for validation of each 
-        ///  library 
+        /// Returns a collection of <see cref="ILibraryOperationResult"/> that represents the status for validation of each
+        ///  library
         /// </summary>
         /// <param name="libraries">Set of libraries to be validated</param>
         /// <param name="dependencies"><see cref="IDependencies"/>used to validate the libraries</param>
@@ -102,7 +102,7 @@ namespace Microsoft.Web.LibraryManager
         }
 
         /// <summary>
-        /// Validates the values of each Library property and returns a collection of ILibraryOperationResult for each of them 
+        /// Validates the values of each Library property and returns a collection of ILibraryOperationResult for each of them
         /// </summary>
         /// <param name="libraries"></param>
         /// <param name="dependencies"></param>
@@ -162,7 +162,7 @@ namespace Microsoft.Web.LibraryManager
         }
 
         /// <summary>
-        /// Expands the files property for each library 
+        /// Expands the files property for each library
         /// </summary>
         /// <param name="libraries"></param>
         /// <param name="dependencies"></param>
@@ -205,7 +205,7 @@ namespace Microsoft.Web.LibraryManager
         }
 
         /// <summary>
-        /// Detects files conflicts in between libraries in the given collection 
+        /// Detects files conflicts in between libraries in the given collection
         /// </summary>
         /// <param name="libraries"></param>
         /// <returns>A collection of <see cref="FileConflict"/> for each library conflict</returns>
@@ -248,7 +248,7 @@ namespace Microsoft.Web.LibraryManager
                 var errors = new List<IError>();
                 foreach (FileConflict conflictingLibraryGroup in fileConflicts)
                 {
-                    errors.Add(PredefinedErrors.ConflictingFilesInManifest(conflictingLibraryGroup.File, conflictingLibraryGroup.Libraries.Select(l => l.LibraryId).ToList()));
+                    errors.Add(PredefinedErrors.ConflictingFilesInManifest(conflictingLibraryGroup.File, conflictingLibraryGroup.Libraries.Select(l => l.Name).ToList()));
                 }
 
                 return new LibraryOperationResult(errors.ToArray());

--- a/src/LibraryManager/LibraryInstallationState.cs
+++ b/src/LibraryManager/LibraryInstallationState.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.LibraryNaming;
-using Newtonsoft.Json;
 
 namespace Microsoft.Web.LibraryManager
 {
@@ -13,92 +11,39 @@ namespace Microsoft.Web.LibraryManager
     /// <seealso cref="Microsoft.Web.LibraryManager.Contracts.ILibraryInstallationState" />
     internal class LibraryInstallationState : ILibraryInstallationState
     {
-
-        private string _providerId;
-
         /// <summary>
         /// The unique identifier of the provider.
         /// </summary>
-        [JsonProperty(ManifestConstants.Provider)]
-        public string ProviderId
-        {
-            get
-            {
-                return _providerId;
-            }
-            set
-            {
-                if (_providerId != value)
-                {
-                    string oldProviderId = _providerId;
-                    _providerId = value;
-                    string originalLibraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(Name, Version, oldProviderId);
-
-                    (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(
-                        originalLibraryId,
-                        _providerId);
-
-                    Name = name;
-                    Version = version;
-                }
-            }
-        }
-
-        /// <summary>
-        /// The identifyer to uniquely identify the library
-        /// </summary>
-        [JsonProperty(ManifestConstants.Library)]
-        public string LibraryId
-        {
-             get
-             {
-                return LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(Name, Version, _providerId);
-             }
-             set
-             {
-                (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(
-                    value,
-                    _providerId);
-
-                Name = name;
-                Version = version;
-             }
-        }
+        public string ProviderId { get; set; }
 
         /// <summary>
         /// The path relative to the working directory to copy the files to.
         /// </summary>
-        [JsonProperty(ManifestConstants.Destination)]
         public string DestinationPath { get; set; }
 
         /// <summary>
         /// The list of file names to install
         /// </summary>
-        [JsonProperty(ManifestConstants.Files)]
         public IReadOnlyList<string> Files { get; set; }
 
         /// <summary>
         /// Tells whether the library was installed/ restored using default provider.
         /// </summary>
-        [JsonIgnore]
         public bool IsUsingDefaultProvider { get; set; }
 
         /// <summary>
         /// Tells whether the library was installed/ restored to default destination.
         /// </summary>
-        [JsonIgnore]
         public bool IsUsingDefaultDestination { get; set; }
 
         /// <summary>
         /// Name of the library.
         /// </summary>
-        [JsonIgnore]
         public string Name { get; set; }
 
         /// <summary>
         /// Version of the library.
         /// </summary>
-        [JsonIgnore]
         public string Version { get; set; }
 
         /// <summary>Internal use only</summary>
@@ -111,10 +56,13 @@ namespace Microsoft.Web.LibraryManager
 
             return new LibraryInstallationState
             {
-                LibraryId = state.LibraryId,
+                Name = state.Name,
+                Version = state.Version,
                 ProviderId = normalizedProviderId,
                 Files = state.Files,
-                DestinationPath = normalizedDestinationPath
+                DestinationPath = normalizedDestinationPath,
+                IsUsingDefaultDestination = state.IsUsingDefaultDestination,
+                IsUsingDefaultProvider = state.IsUsingDefaultProvider
             };
         }
     }

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Logging
 {
@@ -249,7 +250,8 @@ namespace Microsoft.Web.LibraryManager.Logging
             {
                 if (totalResults != null && totalResults.Count() == 1)
                 {
-                    return totalResults.First().InstallationState.LibraryId;
+                    ILibraryInstallationState state = totalResults.First().InstallationState;
+                    return LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(state.Name, state.Version, state.ProviderId);
                 }
             }
 

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsLibraryGroup.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsLibraryGroup.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
         [JsonProperty("version")]
         public string Version { get; set; }
 
-        public Task<IEnumerable<string>> GetLibraryIdsAsync(CancellationToken cancellationToken)
+        public Task<IEnumerable<string>> GetLibraryVersions(CancellationToken cancellationToken)
         {
             return DisplayInfosTask?.Invoke(cancellationToken) ?? Task.FromResult<IEnumerable<string>>(new string[0]);
         }

--- a/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
@@ -114,53 +114,54 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
         }
 
         /// <summary>
-        /// Gets the library group from the specified <paramref name="libraryId" />.
+        /// Gets the library group from the specified <paramref name="libraryName" />.
         /// </summary>
-        /// <param name="libraryId">The unique library identifier.</param>
+        /// <param name="libraryName">The name of the library.</param>
+        /// <param name="version">Version of the library. (Ignored for FileSystemProvider)</param>
         /// <param name="cancellationToken">A token that allows the search to be cancelled.</param>
         /// <returns>
         /// An instance of <see cref="T:Microsoft.Web.LibraryManager.Contracts.ILibraryGroup" /> or <code>null</code>.
         /// </returns>
-        public async Task<ILibrary> GetLibraryAsync(string libraryId, CancellationToken cancellationToken)
+        public async Task<ILibrary> GetLibraryAsync(string libraryName, string version, CancellationToken cancellationToken)
         {
             ILibrary library;
 
             try
             {
-                if (string.IsNullOrEmpty(libraryId) || libraryId.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+                if (string.IsNullOrEmpty(libraryName) || libraryName.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
                 {
-                    throw new InvalidLibraryException(libraryId, _provider.Id);
+                    throw new InvalidLibraryException(libraryName, _provider.Id);
                 }
 
-                if (libraryId.Contains("://"))
+                if (libraryName.Contains("://"))
                 {
                     library = new FileSystemLibrary
                     {
-                        Name = libraryId,
+                        Name = libraryName,
                         ProviderId = _provider.Id,
-                        Files = await GetFilesAsync(libraryId).ConfigureAwait(false)
+                        Files = await GetFilesAsync(libraryName).ConfigureAwait(false)
                     };
 
                     return library;
                 }
 
-                string path = Path.Combine(_provider.HostInteraction.WorkingDirectory, libraryId);
+                string path = Path.Combine(_provider.HostInteraction.WorkingDirectory, libraryName);
 
                 if (!_underTest && !File.Exists(path) && !Directory.Exists(path))
                 {
-                    throw new InvalidLibraryException(libraryId, _provider.Id);
+                    throw new InvalidLibraryException(libraryName, _provider.Id);
                 }
 
                 library = new FileSystemLibrary
                 {
-                    Name = libraryId,
+                    Name = libraryName,
                     ProviderId = _provider.Id,
                     Files = await GetFilesAsync(path).ConfigureAwait(false)
                 };
             }
             catch (Exception)
             {
-                throw new InvalidLibraryException(libraryId, _provider.Id);
+                throw new InvalidLibraryException(libraryName, _provider.Id);
             }
 
             return library;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemLibraryGroup.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemLibraryGroup.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 {
@@ -19,11 +20,9 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 
         public string Description => string.Empty;
 
-        public Task<IEnumerable<string>> GetLibraryIdsAsync(CancellationToken cancellationToken)
+        public Task<IEnumerable<string>> GetLibraryVersions(CancellationToken cancellationToken)
         {
-            string[] ids = { DisplayName };
-
-            return Task.FromResult<IEnumerable<string>>(ids);
+            return Task.FromResult<IEnumerable<string>>(Enumerable.Empty<string>());
         }
 
         public override string ToString()

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
@@ -139,11 +139,11 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
             try
             {
                 ILibraryCatalog catalog = GetCatalog();
-                ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
+                ILibrary library = await catalog.GetLibraryAsync(desiredState.Name, desiredState.Version, cancellationToken).ConfigureAwait(false);
 
                 if (library == null)
                 {
-                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.LibraryId, Id));
+                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.Name, Id));
                 }
 
                 if (desiredState.Files != null && desiredState.Files.Count > 0)
@@ -154,14 +154,16 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
                 desiredState = new LibraryInstallationState
                 {
                     ProviderId = Id,
-                    LibraryId = desiredState.LibraryId,
+                    Name = desiredState.Name,
                     DestinationPath = desiredState.DestinationPath,
                     Files = library.Files.Keys.ToList(),
+                    IsUsingDefaultDestination = desiredState.IsUsingDefaultDestination,
+                    IsUsingDefaultProvider = desiredState.IsUsingDefaultProvider
                 };
             }
             catch (InvalidLibraryException)
             {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.LibraryId, desiredState.ProviderId));
+                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.Name, desiredState.ProviderId));
             }
             catch (UnauthorizedAccessException)
             {
@@ -201,7 +203,7 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 
         private async Task<Stream> GetStreamAsync(ILibraryInstallationState state, string file, CancellationToken cancellationToken)
         {
-            string sourceFile = state.LibraryId;
+            string sourceFile = state.Name;
 
             try
             {
@@ -239,7 +241,7 @@ namespace Microsoft.Web.LibraryManager.Providers.FileSystem
             }
             catch (Exception)
             {
-                throw new InvalidLibraryException(state.LibraryId, state.ProviderId);
+                throw new InvalidLibraryException(state.Name, state.ProviderId);
             }
         }
 

--- a/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 {
@@ -22,7 +20,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 
         public string Description { get; }
 
-        public async Task<IEnumerable<string>> GetLibraryIdsAsync(CancellationToken cancellationToken)
+        public async Task<IEnumerable<string>> GetLibraryVersions(CancellationToken cancellationToken)
         {
             NpmPackageInfo npmPackageInfo = await NpmPackageInfoCache.GetPackageInfoAsync(DisplayName, CancellationToken.None);
 
@@ -30,7 +28,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
             {
                 return npmPackageInfo.Versions
                     .OrderByDescending(v => v)
-                    .Select(semanticVersion => LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(DisplayName, semanticVersion.ToString(), UnpkgProvider.IdText))
+                    .Select(semanticVersion => semanticVersion.ToString())
                     .ToList();
             }
 

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 {
@@ -236,14 +237,16 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
                 return LibraryOperationResult.FromCancelled(desiredState);
             }
 
+            string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(desiredState.Name, desiredState.Version, desiredState.ProviderId);
             try
             {
                 ILibraryCatalog catalog = GetCatalog();
-                ILibrary library = await catalog.GetLibraryAsync(desiredState.LibraryId, cancellationToken).ConfigureAwait(false);
+                ILibrary library = await catalog.GetLibraryAsync(desiredState.Name, desiredState.Version, cancellationToken).ConfigureAwait(false);
+
 
                 if (library == null)
                 {
-                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.LibraryId, desiredState.ProviderId));
+                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(libraryId, desiredState.ProviderId));
                 }
 
                 if (desiredState.Files != null && desiredState.Files.Count > 0)
@@ -251,7 +254,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
                     IReadOnlyList<string> invalidFiles = library.GetInvalidFiles(desiredState.Files);
                     if (invalidFiles.Any())
                     {
-                        var invalidFilesError = PredefinedErrors.InvalidFilesInLibrary(desiredState.LibraryId, invalidFiles, library.Files.Keys);
+                        var invalidFilesError = PredefinedErrors.InvalidFilesInLibrary(libraryId, invalidFiles, library.Files.Keys);
                         return new LibraryOperationResult(desiredState, invalidFilesError);
                     }
                     else
@@ -263,14 +266,15 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
                 desiredState = new LibraryInstallationState
                 {
                     ProviderId = Id,
-                    LibraryId = desiredState.LibraryId,
+                    Name = desiredState.Name,
+                    Version = desiredState.Version,
                     DestinationPath = desiredState.DestinationPath,
                     Files = library.Files.Keys.ToList(),
                 };
             }
             catch (InvalidLibraryException)
             {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.LibraryId, desiredState.ProviderId));
+                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(libraryId, desiredState.ProviderId));
             }
             catch (UnauthorizedAccessException)
             {

--- a/src/libman/Commands/UninstallCommand.cs
+++ b/src/libman/Commands/UninstallCommand.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Tools.Commands
 {
@@ -72,16 +73,18 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
             Task<bool> deleteFileAction(IEnumerable<string> s) => HostInteractions.DeleteFilesAsync(s, CancellationToken.None);
 
-            ILibraryOperationResult result = await manifest.UninstallAsync(libraryToUninstall.LibraryId, deleteFileAction, CancellationToken.None);
+            string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(libraryToUninstall.Name, libraryToUninstall.Version, libraryToUninstall.ProviderId);
+
+            ILibraryOperationResult result = await manifest.UninstallAsync(libraryToUninstall.Name, libraryToUninstall.Version, deleteFileAction, CancellationToken.None);
 
             if (result.Success)
             {
                 await manifest.SaveAsync(Settings.ManifestFileName, CancellationToken.None);
-                Logger.Log(string.Format(Resources.Text.UninstalledLibrary, libraryToUninstall.LibraryId), LogLevel.Operation);
+                Logger.Log(string.Format(Resources.Text.UninstalledLibrary, libraryId), LogLevel.Operation);
             }
             else
             {
-                Logger.Log(string.Format(Resources.Text.UninstallFailed, libraryToUninstall.LibraryId), LogLevel.Error);
+                Logger.Log(string.Format(Resources.Text.UninstallFailed, libraryId), LogLevel.Error);
                 foreach (IError error in result.Errors)
                 {
                     Logger.Log($"[{error.Code}]: {error.Message}", LogLevel.Error);

--- a/src/libman/ILibraryInstallationStateExtensions.cs
+++ b/src/libman/ILibraryInstallationStateExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Tools
 {
@@ -24,7 +25,12 @@ namespace Microsoft.Web.LibraryManager.Tools
                 throw new ArgumentNullException(nameof(libraryInstallationState));
             }
 
-            var sb = new StringBuilder("{"+libraryInstallationState.LibraryId);
+            string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(
+                                    libraryInstallationState.Name,
+                                    libraryInstallationState.Version,
+                                    libraryInstallationState.ProviderId);
+
+            var sb = new StringBuilder("{"+libraryId);
 
             if (!string.IsNullOrEmpty(libraryInstallationState.ProviderId))
             {

--- a/test/LibraryManager.Mocks/LibraryCatalog.cs
+++ b/test/LibraryManager.Mocks/LibraryCatalog.cs
@@ -28,12 +28,13 @@ namespace Microsoft.Web.LibraryManager.Mocks
         /// <summary>
         /// Gets the library group from the specified <paramref name="libraryId" />.
         /// </summary>
-        /// <param name="libraryId">The unique library identifier.</param>
+        /// <param name="libraryId">Name of the library</param>
+        /// <param name="version">Version of the library</param>
         /// <param name="cancellationToken">A token that allows the search to be cancelled.</param>
         /// <returns>
         /// An instance of <see cref="T:LibraryManager.Contracts.ILibraryGroup" /> or <code>null</code>.
         /// </returns>
-        public virtual Task<ILibrary> GetLibraryAsync(string libraryId, CancellationToken cancellationToken)
+        public virtual Task<ILibrary> GetLibraryAsync(string libraryId, string version, CancellationToken cancellationToken)
         {
             var library = new Library
             {

--- a/test/LibraryManager.Mocks/LibraryGroup.cs
+++ b/test/LibraryManager.Mocks/LibraryGroup.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Web.LibraryManager.Mocks
         /// <returns>
         /// A list of library IDs used to display library information to the user.
         /// </returns>
-        public virtual Task<IEnumerable<string>> GetLibraryIdsAsync(CancellationToken cancellationToken)
+        public virtual Task<IEnumerable<string>> GetLibraryVersions(CancellationToken cancellationToken)
         {
             string[] ids = { "test" };
             return Task.FromResult<IEnumerable<string>>(ids);

--- a/test/LibraryManager.Mocks/LibraryInstallationState.cs
+++ b/test/LibraryManager.Mocks/LibraryInstallationState.cs
@@ -13,11 +13,6 @@ namespace Microsoft.Web.LibraryManager.Mocks
     public class LibraryInstallationState : ILibraryInstallationState
     {
         /// <summary>
-        /// The identifyer to uniquely identify the library
-        /// </summary>
-        public virtual string LibraryId { get; set; }
-
-        /// <summary>
         /// The unique identifier of the provider.
         /// </summary>
         public virtual string ProviderId { get; set; }
@@ -41,5 +36,15 @@ namespace Microsoft.Web.LibraryManager.Mocks
         /// Version of the library.
         /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// Indicates whether the library is using the default destination
+        /// </summary>
+        public bool IsUsingDefaultDestination { get; set; }
+
+        /// <summary>
+        /// Indicates whether the library is using the default provider.
+        /// </summary>
+        public bool IsUsingDefaultProvider { get; set; }
     }
 }

--- a/test/LibraryManager.Test/LibrariesValidatorTest.cs
+++ b/test/LibraryManager.Test/LibrariesValidatorTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Web.LibraryManager.Test
         public async Task DetectConflictsAsync_ConflictingFiles_SameDestination()
         {
             string expectedErrorCode = "LIB016";
-            string expectedErrorMessage = "Conflicting file \"lib\\package.json\" found in more than one library: jquery@3.1.1, d3@2.1.3";
+            string expectedErrorMessage = "Conflicting file \"lib\\package.json\" found in more than one library: jquery, d3";
             var manifest = Manifest.FromJson(_docDifferentLibraries_SameFiles_SameLocation, _dependencies);
 
             IEnumerable<ILibraryOperationResult> conflicts = await LibrariesValidator.GetManifestErrorsAsync(manifest, _dependencies, CancellationToken.None);
@@ -46,7 +46,7 @@ namespace Microsoft.Web.LibraryManager.Test
             Assert.AreEqual(1, conflictsList.Count);
             Assert.IsTrue(conflictsList[0].Errors.Count == 1);
             Assert.AreEqual(conflictsList[0].Errors[0].Code, expectedErrorCode);
-            Assert.AreEqual(conflictsList[0].Errors[0].Message, expectedErrorMessage);
+            Assert.AreEqual(expectedErrorMessage, conflictsList[0].Errors[0].Message);
         }
 
         [TestMethod]
@@ -215,7 +215,7 @@ namespace Microsoft.Web.LibraryManager.Test
       ""{ManifestConstants.Files}"": [ ""jquery.min.js"" ]
     }},
     {{
-      ""{ManifestConstants.Library}"": ""jquery@3.1.1"",
+      ""{ManifestConstants.Library}"": ""jquery@3.2.1"",
       ""{ManifestConstants.Provider}"": ""cdnjs"",
       ""{ManifestConstants.Destination}"": ""lib2"",
       ""{ManifestConstants.Files}"": [ ""jquery.min.js"" ]

--- a/test/LibraryManager.Test/LibraryInstallationResultTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationResultTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Web.LibraryManager.Test
             return new Mocks.LibraryInstallationState
             {
                 ProviderId = "_prov_",
-                LibraryId = "_lib_",
+                Name = "_lib_",
                 DestinationPath = "_path_",
                 Files = new List<string>() { "a", "b" },
             };

--- a/test/LibraryManager.Test/LibraryInstallationStateTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationStateTest.cs
@@ -43,14 +43,15 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "_prov_",
-                LibraryId = "_lib_",
+                Name = "_lib_",
                 DestinationPath = "_path_",
                 Files = new List<string>() { "a", "b" },
             };
 
             var lis = LibraryInstallationState.FromInterface(state);
             Assert.AreEqual(state.ProviderId, lis.ProviderId);
-            Assert.AreEqual(state.LibraryId, lis.LibraryId);
+            Assert.AreEqual(state.Name, lis.Name);
+            Assert.AreEqual(state.Version, lis.Version);
             Assert.AreEqual(state.DestinationPath, lis.DestinationPath);
             Assert.AreEqual(state.Files, lis.Files);
         }
@@ -73,7 +74,7 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "_prov_",
-                LibraryId = "_lib_",
+                Name = "_lib_",
                 DestinationPath = "_path_",
                 Files = new List<string>() { "a", "b" },
             };
@@ -90,7 +91,7 @@ namespace Microsoft.Web.LibraryManager.Test
         {
             var state = new Mocks.LibraryInstallationState
             {
-                LibraryId = "_lib_",
+                Name = "_lib_",
                 DestinationPath = "_path_",
                 Files = new List<string>() { "a", "b" },
             };
@@ -125,7 +126,7 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "unpkg",
-                LibraryId = "_lib_",
+                Name = "_lib_",
                 DestinationPath = "_path_",
                 Files = new List<string>() { "a", "b" },
             };
@@ -143,7 +144,8 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "unpkg",
-                LibraryId = "jquery@3.3.1",
+                Name = "jquery",
+                Version = "3.3.1",
                 DestinationPath = "_path_",
                 Files = new List<string>() { "a", "b" },
             };
@@ -161,7 +163,7 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = "|lib_",
+                Name = "|lib_",
                 DestinationPath = "_path_",
                 Files = new List<string>() { "a", "b" },
             };
@@ -179,7 +181,7 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = "lib",
+                Name = "lib",
                 DestinationPath = "lib",
             };
 
@@ -196,7 +198,7 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
+                Name = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
                 DestinationPath = "lib",
                 Files = new[] { "foo.png" }
             };
@@ -213,7 +215,7 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new Mocks.LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
+                Name = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
                 DestinationPath = "|lib"
             };
 
@@ -221,7 +223,7 @@ namespace Microsoft.Web.LibraryManager.Test
 
             Assert.IsFalse(result.Success);
             Assert.AreEqual(result.Errors.Count, 1);
-            Assert.AreEqual(result.Errors.First().Code, "LIB012");
+            Assert.AreEqual("LIB012", result.Errors.First().Code);
         }
     }
 }

--- a/test/LibraryManager.Test/ManifestTest.cs
+++ b/test/LibraryManager.Test/ManifestTest.cs
@@ -53,7 +53,8 @@ namespace Microsoft.Web.LibraryManager.Test
             IProvider provider = _dependencies.GetProvider("cdnjs");
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.1.1",
+                Name = "jquery",
+                Version = "3.3.1",
                 ProviderId = "cdnjs",
                 DestinationPath = "lib",
                 Files = new[] { "jquery.min.js" }
@@ -82,7 +83,8 @@ namespace Microsoft.Web.LibraryManager.Test
             IProvider provider = _dependencies.GetProvider("cdnjs");
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.1.1",
+                Name = "jquery",
+                Version = "3.3.1",
                 ProviderId = "cdnjs",
                 DestinationPath = "lib",
                 Files = new[] { "jquery.js", "jquery.min.js" }
@@ -99,7 +101,7 @@ namespace Microsoft.Web.LibraryManager.Test
             Assert.IsTrue(results.Count() == 1);
             Assert.IsTrue(results.First().Success);
 
-            ILibraryOperationResult uninstallResult = await manifest.UninstallAsync(desiredState.LibraryId, (file) => _hostInteraction.DeleteFilesAsync(file, token), token);
+            ILibraryOperationResult uninstallResult = await manifest.UninstallAsync(desiredState.Name, desiredState.Version, (file) => _hostInteraction.DeleteFilesAsync(file, token), token);
 
             Assert.IsFalse(File.Exists(file1));
             Assert.IsFalse(File.Exists(file2));
@@ -116,7 +118,8 @@ namespace Microsoft.Web.LibraryManager.Test
             IProvider provider = _dependencies.GetProvider("cdnjs");
             var state1 = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.1.1",
+                Name = "jquery",
+                Version="3.1.1",
                 ProviderId = "cdnjs",
                 DestinationPath = "lib",
                 Files = new[] { "jquery.js", "jquery.min.js" }
@@ -124,7 +127,8 @@ namespace Microsoft.Web.LibraryManager.Test
 
             var state2 = new LibraryInstallationState
             {
-                LibraryId = "knockout@3.4.2",
+                Name = "knockout",
+                Version= "3.4.2",
                 ProviderId = "cdnjs",
                 DestinationPath = "lib",
                 Files = new[] { "knockout-min.js" }
@@ -206,7 +210,8 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new LibraryInstallationState
             {
                 ProviderId = "cdnjs",
-                LibraryId = "jquery@3.2.1",
+                Name = "jquery",
+                Version = "3.2.1",
                 DestinationPath = path,
                 Files = new[] { "core.js" }
             };
@@ -316,7 +321,8 @@ namespace Microsoft.Web.LibraryManager.Test
 
             var state = new LibraryInstallationState
             {
-                LibraryId = "cdnjs",
+                Name = "cdnjs",
+                Version = "",
                 DestinationPath = "lib",
                 Files = new[] { "knockout-min.js" }
             };
@@ -338,7 +344,8 @@ namespace Microsoft.Web.LibraryManager.Test
 
             var state = new LibraryInstallationState
             {
-                LibraryId = "cdnjs",
+                Name = "cdnjs",
+                Version = "",
                 DestinationPath = "lib",
                 Files = new[] { "knockout-min.js" }
             };
@@ -359,19 +366,19 @@ namespace Microsoft.Web.LibraryManager.Test
             var manifest = Manifest.FromJson("{}", _dependencies);
 
             // Null LibraryId
-            IEnumerable<ILibraryOperationResult> results = await manifest.InstallLibraryAsync(null, "cdnjs", null, "wwwroot", CancellationToken.None);
+            IEnumerable<ILibraryOperationResult> results = await manifest.InstallLibraryAsync(null, null,"cdnjs", null, "wwwroot", CancellationToken.None);
             Assert.IsFalse(results.First().Success);
             Assert.AreEqual(1, results.First().Errors.Count);
             Assert.AreEqual("LIB006", results.First().Errors[0].Code);
 
             // Empty ProviderId
-            results = await manifest.InstallLibraryAsync("jquery@3.2.1", "", null, "wwwroot", CancellationToken.None);
+            results = await manifest.InstallLibraryAsync("jquery", "3.2.1", "", null, "wwwroot", CancellationToken.None);
             Assert.IsFalse(results.First().Success);
             Assert.AreEqual(1, results.First().Errors.Count);
             Assert.AreEqual("LIB007", results.First().Errors[0].Code);
 
             // Null destination
-            results = await manifest.InstallLibraryAsync("jquery@3.2.1", "cdnjs", null, null, CancellationToken.None);
+            results = await manifest.InstallLibraryAsync("jquery", "3.2.1", "cdnjs", null, null, CancellationToken.None);
 
             Assert.IsFalse(results.First().Success);
             Assert.AreEqual(1, results.First().Errors.Count);
@@ -379,24 +386,25 @@ namespace Microsoft.Web.LibraryManager.Test
 
 
             // Valid Options all files.
-            results = await manifest.InstallLibraryAsync("jquery@3.2.1", "cdnjs", null, "wwwroot", CancellationToken.None);
+            results = await manifest.InstallLibraryAsync("jquery", "3.3.1", "cdnjs", null, "wwwroot", CancellationToken.None);
 
             Assert.IsTrue(results.First().Success);
             Assert.AreEqual("wwwroot", results.First().InstallationState.DestinationPath);
-            Assert.AreEqual("jquery@3.2.1", results.First().InstallationState.LibraryId);
+            Assert.AreEqual("jquery", results.First().InstallationState.Name);
+            Assert.AreEqual("3.3.1", results.First().InstallationState.Version);
             Assert.AreEqual("cdnjs", results.First().InstallationState.ProviderId);
             Assert.IsNotNull(results.First().InstallationState.Files);
 
             // Valid parameters and files.
             var files = new List<string>() { "jquery.min.js" };
-            results = await manifest.InstallLibraryAsync("jquery@2.2.0", "cdnjs", files, "wwwroot2", CancellationToken.None);
+            results = await manifest.InstallLibraryAsync("jquery", "2.2.0", "cdnjs", files, "wwwroot2", CancellationToken.None);
             Assert.IsFalse(results.First().Success);
             Assert.AreEqual(1, results.First().Errors.Count);
             Assert.AreEqual("LIB019", results.First().Errors[0].Code);
 
             // Valid parameters invalid files
             files.Add("abc.js");
-            results = await manifest.InstallLibraryAsync("twitter-bootstrap@4.1.1", "cdnjs", files, "wwwroot3", CancellationToken.None);
+            results = await manifest.InstallLibraryAsync("twitter-bootstrap", "4.1.1", "cdnjs", files, "wwwroot3", CancellationToken.None);
             Assert.IsFalse(results.First().Success);
             Assert.AreEqual(1, results.First().Errors.Count);
             Assert.AreEqual("LIB018", results.First().Errors[0].Code);
@@ -406,7 +414,7 @@ namespace Microsoft.Web.LibraryManager.Test
         public async Task InstallLibraryAsync_SetsDefaultProvider()
         {
             var manifest = Manifest.FromJson(_emptyLibmanJson, _dependencies);
-            IEnumerable<ILibraryOperationResult> results = await manifest.InstallLibraryAsync("jquery@3.2.1", "cdnjs", null, "wwwroot", CancellationToken.None);
+            IEnumerable<ILibraryOperationResult> results = await manifest.InstallLibraryAsync("jquery", "3.2.1", "cdnjs", null, "wwwroot", CancellationToken.None);
 
             Assert.AreEqual("cdnjs", manifest.DefaultProvider);
             var libraryState = manifest.Libraries.First() as LibraryInstallationState;
@@ -425,7 +433,8 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new LibraryInstallationState
             {
                 ProviderId = "cdnjs",
-                LibraryId = "jquery@3.2.1",
+                Name = "jquery",
+                Version = "3.2.1",
                 DestinationPath = "lib",
                 Files = new[] { "core.js" }
             };
@@ -450,7 +459,8 @@ namespace Microsoft.Web.LibraryManager.Test
             var state = new LibraryInstallationState
             {
                 ProviderId = "cdnjs",
-                LibraryId = "jquery@3.2.1",
+                Name = "jquery",
+                Version = "3.2.1",
                 DestinationPath = "lib",
                 Files = new[] { "core.js" }
             };

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
 
             IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync(searchTerm, 1, token);
             Assert.AreEqual(1, absolute.Count);
-            IEnumerable<string> libraryId = await absolute[0].GetLibraryIdsAsync(token);
-            Assert.IsTrue(libraryId.Any());
+            IEnumerable<string> versions = await absolute[0].GetLibraryVersions(token);
+            Assert.IsTrue(versions.Any());
 
-            ILibrary library = await _catalog.GetLibraryAsync(libraryId.First(), token);
+            ILibrary library = await _catalog.GetLibraryAsync(absolute[0].DisplayName, versions.First(), token);
             Assert.IsTrue(library.Files.Count > 0);
             Assert.AreEqual(expectedId, library.Name);
             Assert.AreEqual(1, library.Files.Count(f => f.Value));
@@ -86,7 +86,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         public async Task GetLibraryAsync_Success()
         {
             CancellationToken token = CancellationToken.None;
-            ILibrary library = await _catalog.GetLibraryAsync("jquery@3.1.1", token);
+            ILibrary library = await _catalog.GetLibraryAsync("jquery", "3.1.1", token);
 
             Assert.IsNotNull(library);
             Assert.AreEqual("jquery", library.Name);
@@ -97,7 +97,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         public async Task GetLibraryAsync_InvalidLibraryId()
         {
             CancellationToken token = CancellationToken.None;
-            ILibrary library = await _catalog.GetLibraryAsync("invalid_id", token);
+            ILibrary library = await _catalog.GetLibraryAsync("invalid_id", "invalid_version" , token);
         }
 
         [TestMethod]
@@ -131,28 +131,28 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         public async Task GetLatestVersion_LatestExist()
         {
             CancellationToken token = CancellationToken.None;
-            const string libraryId = "twitter-bootstrap@3.3.0";
-            string result = await _catalog.GetLatestVersion(libraryId, false, token);
+            // "twitter-bootstrap@3.3.0"
+            const string libraryName = "twitter-bootstrap";
+            const string oldVersion = "3.3.0";
+            string result = await _catalog.GetLatestVersion(libraryName, false, token);
 
             Assert.IsNotNull(result);
 
-            string[] existing = libraryId.Split('@');
-
-            Assert.AreNotEqual(existing[1], result);
+            Assert.AreNotEqual(oldVersion, result);
         }
 
         [TestMethod]
         public async Task GetLatestVersion_PreRelease()
         {
             CancellationToken token = CancellationToken.None;
-            const string libraryId = "twitter-bootstrap@3.3.0";
-            string result = await _catalog.GetLatestVersion(libraryId, true, token);
+            // "twitter-bootstrap@3.3.0"
+            const string libraryName = "twitter-bootstrap";
+            const string oldVersion = "3.3.0";
+            string result = await _catalog.GetLatestVersion(libraryName, true, token);
 
             Assert.IsNotNull(result);
 
-            string[] existing = libraryId.Split('@');
-
-            Assert.AreNotEqual(existing[1], result);
+            Assert.AreNotEqual(oldVersion, result);
         }
 
         [TestMethod]

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
@@ -58,17 +58,18 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             Assert.IsNotNull(group.Description);
 
             // Get all libraries in group to display version list
-            IEnumerable<string> libraryIds = await group.GetLibraryIdsAsync(CancellationToken.None);
-            Assert.IsTrue(libraryIds.Count() >= 67);
-            Assert.AreEqual("jquery@1.2.3", libraryIds.Last(), "Library version mismatch");
+            IEnumerable<string> versions = await group.GetLibraryVersions(CancellationToken.None);
+            Assert.IsTrue(versions.Count() >= 67);
+            Assert.AreEqual("1.2.3", versions.Last(), "Library version mismatch");
 
             // Get the library to install
-            ILibrary library = await catalog.GetLibraryAsync(libraryIds.First(), CancellationToken.None);
+            ILibrary library = await catalog.GetLibraryAsync(group.DisplayName, versions.First(), CancellationToken.None);
             Assert.AreEqual(group.DisplayName, library.Name);
 
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.1.1",
+                Name = "jquery",
+                Version = "3.1.1",
                 ProviderId = "cdnjs",
                 DestinationPath = "lib",
                 Files = new[] { "jquery.js", "jquery.min.js" }
@@ -94,7 +95,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         {
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "*&(}:@3.1.1",
+                Name = "*&(}:",
+                Version = "3.1.1",
                 ProviderId = "cdnjs",
                 DestinationPath = "lib",
                 Files = new[] { "jquery.min.js" }
@@ -111,7 +113,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "cdnjs",
-                LibraryId = "jquery@1.2.3",
+                Name = "jquery",
+                Version = "1.2.3",
                 DestinationPath = "lib"
             };
 
@@ -132,7 +135,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "cdnjs",
-                LibraryId = "jquery@1.2.3"
+                Name = "jquery",
+                Version = "1.2.3"
             };
 
             // Install library
@@ -148,7 +152,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         {
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@1.2.3",
+                Name = "jquery",
+                Version = "1.2.3",
                 DestinationPath = "lib"
             };
 
@@ -162,7 +167,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         {
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.1.1",
+                Name = "jquery",
+                Version = "3.1.1",
                 ProviderId = "cdnjs",
                 DestinationPath = "lib",
                 Files = new[] { "file1.txt", "file2.txt" }

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemCatalogTest.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
 
             IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync(file, 1, token);
             Assert.AreEqual(1, absolute.Count);
-            IEnumerable<string> info = await absolute[0].GetLibraryIdsAsync(token);
-            Assert.AreEqual(1, info.Count());
+            IEnumerable<string> version = await absolute[0].GetLibraryVersions(token);
+            Assert.AreEqual(0, version.Count());
 
-            ILibrary library = await _catalog.GetLibraryAsync(info.First(), token);
+            ILibrary library = await _catalog.GetLibraryAsync(absolute[0].DisplayName, "", token);
             Assert.AreEqual(1, library.Files.Count);
             Assert.AreEqual(1, library.Files.Count(f => f.Value));
             Assert.AreEqual(file, library.Name);
@@ -76,10 +76,10 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync(folder, 3, token);
             Assert.AreEqual(1, absolute.Count);
 
-            IEnumerable<string> info = await absolute.First().GetLibraryIdsAsync(token);
-            Assert.AreEqual(1, info.Count());
+            IEnumerable<string> info = await absolute[0].GetLibraryVersions(token);
+            Assert.AreEqual(0, info.Count());
 
-            ILibrary library = await _catalog.GetLibraryAsync(info.First(), token);
+            ILibrary library = await _catalog.GetLibraryAsync(absolute[0].DisplayName, "", token);
             Assert.AreEqual(3, library.Files.Count);
 
             Directory.Delete(folder, true);
@@ -105,7 +105,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
         [TestMethod]
         public async Task GetLibraryAsync_File()
         {
-            ILibrary library = await _catalog.GetLibraryAsync(@"c:\some\path\to\file.js", CancellationToken.None);
+            ILibrary library = await _catalog.GetLibraryAsync(@"c:\some\path\to\file.js", "", CancellationToken.None);
             Assert.IsNotNull(library);
             Assert.AreEqual(1, library.Files.Count);
             Assert.AreEqual("file.js", library.Files.ElementAt(0).Key);
@@ -120,7 +120,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             File.WriteAllText(Path.Combine(folder, "file2.js"), "");
             File.WriteAllText(Path.Combine(folder, "file3.js"), "");
 
-            ILibrary library = await _catalog.GetLibraryAsync(folder, CancellationToken.None);
+            ILibrary library = await _catalog.GetLibraryAsync(folder, "", CancellationToken.None);
             Assert.IsNotNull(library);
             Assert.AreEqual(3, library.Files.Count);
             Assert.AreEqual("file1.js", library.Files.ElementAt(0).Key);
@@ -129,7 +129,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
         [TestMethod]
         public async Task GetLibraryAsync_Uri()
         {
-            ILibrary library = await _catalog.GetLibraryAsync("http://example.com/file.js", CancellationToken.None);
+            ILibrary library = await _catalog.GetLibraryAsync("http://example.com/file.js", "", CancellationToken.None);
             Assert.IsNotNull(library);
             Assert.AreEqual(1, library.Files.Count);
             Assert.AreEqual("file.js", library.Files.ElementAt(0).Key);

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = _file1,
+                Name = _file1,
                 DestinationPath = "lib",
                 Files = new[] { "file1.txt" }
             };
@@ -85,7 +85,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = "folder/file.txt",
+                Name = "folder/file.txt",
                 DestinationPath = "lib",
                 Files = new[] { "relative.txt" }
             };
@@ -121,7 +121,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = folder,
+                Name = folder,
                 DestinationPath = "lib",
                 Files = new[] { "file1.js", "file2.js" }
             };
@@ -157,7 +157,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = relativeFolder.OriginalString,
+                Name = relativeFolder.OriginalString,
                 DestinationPath = "lib",
                 Files = new[] { "file1.js", "file2.js" }
             };
@@ -183,7 +183,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = "https://raw.githubusercontent.com/jquery/jquery/master/src/event.js",
+                Name = "https://raw.githubusercontent.com/jquery/jquery/master/src/event.js",
                 DestinationPath = "lib",
                 Files = new[] { "event.js" }
             };
@@ -210,7 +210,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
+                Name = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
                 DestinationPath = "lib",
                 Files = new[] { "Flag.png" }
             };
@@ -230,7 +230,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = @"../file/does/not/exist.txt",
+                Name = @"../file/does/not/exist.txt",
                 DestinationPath = "lib",
                 Files = new[] { "file.js" }
             };
@@ -248,7 +248,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "filesystem",
-                LibraryId = @"../file/does/not/exist.txt",
+                Name = @"../file/does/not/exist.txt",
                 Files = new[] { "file.js" }
             };
 
@@ -281,7 +281,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             IProvider provider = _dependencies.GetProvider("filesystem");
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
+                Name = "http://glyphlist.azurewebsites.net/img/images/Flag.png",
                 DestinationPath = "lib",
                 Files = new[] { "Flag.png" }
             };

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
 
             IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync(searchTerm, 1, token);
             Assert.AreEqual(10, absolute.Count);
-            IEnumerable<string> libraryId = await absolute[0].GetLibraryIdsAsync(token);
-            Assert.IsTrue(libraryId.Any());
+            IEnumerable<string> libraryVersions = await absolute[0].GetLibraryVersions(token);
+            Assert.IsTrue(libraryVersions.Any());
 
-            ILibrary library = await _catalog.GetLibraryAsync(libraryId.First(), token);
+            ILibrary library = await _catalog.GetLibraryAsync(absolute[0].DisplayName, libraryVersions.First(), token);
             Assert.IsTrue(library.Files.Count > 0);
             Assert.AreEqual("jquery", library.Name);
             Assert.AreEqual(0, library.Files.Count(f => f.Value));
@@ -84,7 +84,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         public async Task GetLibraryAsync_Success()
         {
             CancellationToken token = CancellationToken.None;
-            ILibrary library = await _catalog.GetLibraryAsync("jquery@3.3.1", token);
+            ILibrary library = await _catalog.GetLibraryAsync("jquery", "3.3.1", token);
 
             Assert.IsNotNull(library);
             Assert.AreEqual("jquery", library.Name);
@@ -95,7 +95,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         public async Task GetLibraryAsync_InvalidLibraryId()
         {
             CancellationToken token = CancellationToken.None;
-            ILibrary library = await _catalog.GetLibraryAsync("invalid_id", token);
+            ILibrary library = await _catalog.GetLibraryAsync("invalid_id", "invalid_version", token);
         }
 
         [TestMethod]
@@ -130,13 +130,12 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         {
             CancellationToken token = CancellationToken.None;
             const string libraryId = "bootstrap@3.3.0";
-            string result = await _catalog.GetLatestVersion(libraryId, false, token);
+            string[] existing = libraryId.Split('@');
+            string result = await _catalog.GetLatestVersion(existing[0], false, token);
 
             // It can return null value.
             if (result != null)
             {
-                string[] existing = libraryId.Split('@');
-
                 Assert.AreNotEqual(existing[1], result);
             }
         }
@@ -146,13 +145,12 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         {
             CancellationToken token = CancellationToken.None;
             const string libraryId = "bootstrap@3.3.0";
-            string result = await _catalog.GetLatestVersion(libraryId, true, token);
+            string[] existing = libraryId.Split('@');
+            string result = await _catalog.GetLatestVersion(existing[0], true, token);
 
             // It can return null value.
             if (result != null)
             {
-                string[] existing = libraryId.Split('@');
-
                 Assert.AreNotEqual(existing[1], result);
             }
         }

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
@@ -55,16 +55,17 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
             Assert.AreEqual("jquery", group.DisplayName);
 
             // Get all libraries in group to display version list
-            IEnumerable<string> libraryIds = await group.GetLibraryIdsAsync(CancellationToken.None);
-            Assert.IsTrue(libraryIds.Count() >= 0);
+            IEnumerable<string> libraryVersions = await group.GetLibraryVersions(CancellationToken.None);
+            Assert.IsTrue(libraryVersions.Count() >= 0);
 
             // Get the library to install
-            ILibrary library = await catalog.GetLibraryAsync(libraryIds.First(), CancellationToken.None);
+            ILibrary library = await catalog.GetLibraryAsync(group.DisplayName, libraryVersions.First(), CancellationToken.None);
             Assert.AreEqual(group.DisplayName, library.Name);
 
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.3.1",
+                Name = "jquery",
+                Version="3.3.1",
                 ProviderId = "unpkg",
                 DestinationPath = "lib",
                 Files = new[] { "dist/jquery.js", "dist/jquery.min.js" }
@@ -90,7 +91,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         {
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "*&(}:@3.3.1",
+                Name = "*&(}:",
+                Version = "3.3.1",
                 ProviderId = "unpkg",
                 DestinationPath = "lib",
                 Files = new[] { "dist/jquery.min.js" }
@@ -107,7 +109,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "unpkg",
-                LibraryId = "jquery@3.3.1",
+                Name = "jquery",
+                Version = "3.3.1",
                 DestinationPath = "lib"
             };
 
@@ -128,7 +131,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
             var desiredState = new LibraryInstallationState
             {
                 ProviderId = "unpkg",
-                LibraryId = "jquery@3.3.1"
+                Name = "jquery",
+                Version = "3.3.1"
             };
 
             // Install library
@@ -144,7 +148,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         {
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.3.1",
+                Name = "jquery",
+                Version = "3.3.1",
                 DestinationPath = "lib"
             };
 
@@ -158,7 +163,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         {
             var desiredState = new LibraryInstallationState
             {
-                LibraryId = "jquery@3.3.1",
+                Name = "jquery",
+                Version = "3.3.1",
                 ProviderId = "unpkg",
                 DestinationPath = "lib",
                 Files = new[] { "file1.txt", "file2.txt" }

--- a/test/libman.Test/LibmanUpdateTest.cs
+++ b/test/libman.Test/LibmanUpdateTest.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             var logger = HostEnvironment.Logger as TestLogger;
 
-            Assert.AreEqual("The library \"jquery@3.3.1\" is already up to date", logger.Messages.Last().Value);
+            Assert.AreEqual("The library \"jquery\" is already up to date", logger.Messages.Last().Value);
         }
 
         [TestMethod]

--- a/test/libman.Test/LibraryResolverTest.cs
+++ b/test/libman.Test/LibraryResolverTest.cs
@@ -42,9 +42,12 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             Assert.AreEqual(3, result.Count);
 
-            Assert.AreEqual("jquery", result[0].LibraryId);
-            Assert.AreEqual("jquery@3.3.1", result[1].LibraryId);
-            Assert.AreEqual("jquery@2.2.0", result[2].LibraryId);
+            Assert.AreEqual("jquery", result[0].Name);
+            Assert.AreEqual("", result[0].Version);
+            Assert.AreEqual("jquery", result[1].Name);
+            Assert.AreEqual("3.3.1", result[1].Version);
+            Assert.AreEqual("jquery", result[2].Name);
+            Assert.AreEqual("2.2.0", result[2].Version);
 
             // Matches jquery for cdnjs provider
             result = LibraryResolver.Resolve(
@@ -54,8 +57,10 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             Assert.AreEqual(2, result.Count);
 
-            Assert.AreEqual("jquery@3.3.1", result[0].LibraryId);
-            Assert.AreEqual("jquery@2.2.0", result[1].LibraryId);
+            Assert.AreEqual("jquery", result[0].Name);
+            Assert.AreEqual("3.3.1", result[0].Version);
+            Assert.AreEqual("jquery", result[1].Name);
+            Assert.AreEqual("2.2.0", result[1].Version);
 
             // Matches only one result.
             result = LibraryResolver.Resolve(
@@ -64,7 +69,8 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
                 null);
 
             Assert.AreEqual(1, result.Count);
-            Assert.AreEqual("jquery@3.3.1", result[0].LibraryId);
+            Assert.AreEqual("jquery", result[0].Name);
+            Assert.AreEqual("3.3.1", result[0].Version);
 
             // Does not match library for a different provider.
             result = LibraryResolver.Resolve(
@@ -110,7 +116,8 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             ILibraryInstallationState result = LibraryResolver.ResolveLibraryByUserChoice(manifest.Libraries, HostEnvironment);
 
-            Assert.AreEqual("jquery@3.3.1", result.LibraryId);
+            Assert.AreEqual("jquery", result.Name);
+            Assert.AreEqual("3.3.1", result.Version);
         }
 
         private string _manifestContents = @"{


### PR DESCRIPTION
- Separates the data objects from Manifest and LibraryInstallationState
- Remove libraryId from from ILibraryInstallationState
- Adapt all clients and use cases to use Name and version instead of
libraryId