### PR TITLE
Package all dependencies for Microsoft.Web.LibraryManager.Build

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -41,7 +41,7 @@
         but before NuGet generates a nuspec. See https://github.com/NuGet/Home/issues/4704.
         -->
         <ItemGroup>
-            <_PackageFiles Include="bin\$(Configuration)\*\*.LibraryManager.dll;bin\$(Configuration)\*\*.LibraryManager.Contracts.dll;bin\$(Configuration)\*\Newtonsoft.Json.dll">
+            <_PackageFiles Include="bin\$(Configuration)\**\*.dll" Exclude="bin\$(Configuration)\**\Microsoft.Build.*.dll">
                 <PackagePath>tools\%(RecursiveDir)</PackagePath>
                 <Visible>false</Visible>
                 <BuildAction>Content</BuildAction>


### PR DESCRIPTION
This change is to include all dependencies of the msbuild task assembly in the package directory. 

Package contents after the change: <br/>
![image](https://user-images.githubusercontent.com/1521254/43370425-b0cbce2c-9333-11e8-873a-10102d0da8f7.png)
