### PR TITLE
Cli rename

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corp.</Company>
     <Description>Create custom providers for the Visual Studio Library Manager</Description>
-    <Copyright>Copyright © Microsoft</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 
     <Product>Microsoft.Web.LibraryManager</Product>
     <PackageIconUrl>https://aka.ms/vsextensibilityicon</PackageIconUrl>

--- a/LibraryManager.msbuild
+++ b/LibraryManager.msbuild
@@ -87,7 +87,6 @@ Package the global tool along with the Shims.
                          Copyright=$(Copyright);
                          Description=$(Description);
                          RepositoryUrl=$(RepositoryUrl);
-                         RepositoryCommit='abc';
                          Serviceable=true;
                          PackageOutputPath=$(LibmanArtifactsDir)$(Configuration)\" />
     <!--

--- a/src/libman/libman.csproj
+++ b/src/libman/libman.csproj
@@ -7,6 +7,7 @@
     <NuspecFile>libman.nuspec</NuspecFile>
     <PackageType>DotNetTool</PackageType>
     <Description>Command line tool for Library Manager</Description>
+    <CLIToolDescription>Command line tool for Library Manager</CLIToolDescription>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
@@ -38,7 +39,8 @@
     `dotnet pack`
   **********************************************************
    -->
-  <Target Name="SetGlobalToolProperties" BeforeTargets="GenerateNuspec">
+
+  <Target Name="SetGlobalToolProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
     <PropertyGroup>
       <NuspecProperties>
         publishDir=$(PublishDir);
@@ -47,10 +49,10 @@
         projectUrl=$(PackageProjectUrl);
         serviceable=$(Serviceable);
         copyright=$(Copyright);
-        description=$(Description);
+        description=$(CLIToolDescription);
         repositoryUrl=$(RepositoryUrl);
         targetframework=$(TargetFramework);
-        repositoryCommit=$(RepositoryCommit);
+        repositoryCommit=$(GitCommitId);
       </NuspecProperties>
       <!--
         packageIconUrl=$(PackageIconUrl);

--- a/src/libman/libman.nuspec
+++ b/src/libman/libman.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
-    <id>libman</id>
-    <tags>libman</tags>
+    <id>Microsoft.Web.LibraryManager.Cli</id>
+    <tags>libman;LibraryManager;DotNetCoreGlobalTool</tags>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/tools/ShimGenerator/ShimGenerator.targets
+++ b/tools/ShimGenerator/ShimGenerator.targets
@@ -5,7 +5,7 @@
       <IntermediateDirectoryForShimsBase Condition="'$(IntermediateDirectoryForShimsBase)' == '' ">$(IntermediateOutputPath)</IntermediateDirectoryForShimsBase>
       <ShimTargetName Condition="'$(ShimTargetName)' == '' ">libman</ShimTargetName>
       <ShimTargetFileName Condition="'$(ShimTargetFileName)' == '' ">libman.dll</ShimTargetFileName>
-      <ShimPackageId Condition="'$(ShimPackageId)' == ''">libman</ShimPackageId>
+      <ShimPackageId Condition="'$(ShimPackageId)' == ''">microsoft.web.librarymanager.cli</ShimPackageId>
   </PropertyGroup>
 
   <Target Name="CleanPreviousOutput">


### PR DESCRIPTION
Renames the CLI nuget package to `Microsoft.Web.LibraryManager.Cli`
Also fixes up NuGet properties for `Copyright` for all packages and `GitCommitId` for the CLI package.