### PR TITLE
Update libman CLI help text

### DIFF
--- a/src/libman/MultilingualResources/libman.cs.xlf
+++ b/src/libman/MultilingualResources/libman.cs.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Vytvoří nový soubor libman.json.</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Přidá definici knihovny do souboru LibMan.json a stáhne knihovnu do zadaného umístění.</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -107,7 +107,7 @@ Pokud knihovna určuje poskytovatele, přepíše položku defaultProvider.
 Pokud knihovna určuje cíl, přepíše položku defaultDestination.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Odstraní všechny soubory pro zadanou knihovnu z jejich zadaného cíle a pak odebere zadanou definici knihovny z libman.json.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.de.xlf
+++ b/src/libman/MultilingualResources/libman.de.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Neue Datei "libman.json" erstellen</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Fügen Sie der Datei "libman.json" eine Bibliotheksdefinition hinzu, und laden Sie die Bibliothek an den angegebenen Speicherort herunter.</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -99,7 +99,7 @@
           <target state="translated">Fehler, wenn keine Datei "libman.json" im aktuellen Ordner vorliegt. Wenn eine Bibliothek einen Anbieter angibt, überschreibt dieser den defaultProvider-Wert. Wenn eine Bibliothek ein Ziel angibt, überschreibt dieses den defaultDestination-Wert.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Hiermit werden alle Dateien für die angegebene Bibliothek aus dem angegebenen Ziel gelöscht, anschließend wird die angegebene Bibliotheksdefinition aus der Datei "libman.json" entfernt.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.es.xlf
+++ b/src/libman/MultilingualResources/libman.es.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Crea un archivo libman.json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Agregue una definición de biblioteca al archivo LibMan.json y descargue la biblioteca a la ubicación especificada.</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -99,7 +99,7 @@
           <target state="translated">Error si no hay ningún archivo libman.json en la carpeta actual. Si se especifica un proveedor en una biblioteca, este reemplazará al valor defaultProvider. Si se especifica un destino en una biblioteca, este reemplazará al valor defaultDestination.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Elimina todos los archivos de la biblioteca especificada del destino establecido y, a continuación, elimina la definición de biblioteca dada del archivo libman.json</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.fr.xlf
+++ b/src/libman/MultilingualResources/libman.fr.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Créer un fichier libman.json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Ajoutez une définition de bibliothèque au fichier LibMan.json, puis téléchargez la bibliothèque à l'emplacement spécifié</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -101,7 +101,7 @@
           <target state="translated">Une erreur se produit si le dossier actif ne contient aucun fichier libman.json. Si une bibliothèque spécifie un fournisseur, celui-ci remplace le fournisseur par défaut. Si une bibliothèque spécifie une destination, celle-ci remplace la destination par défaut.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Supprime tous les fichiers de la bibliothèque spécifiée de la destination indiquée, puis supprime la définition de bibliothèque spécifiée de libman.json</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.it.xlf
+++ b/src/libman/MultilingualResources/libman.it.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Crea un nuovo file libman.json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Aggiunge una definizione di libreria nel file LibMan.json e scarica la libreria nel percorso specificato</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -107,7 +107,7 @@
     Se una libreria specifica una destinazione, eseguirà l'override di defaultDestination</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Elimina tutti i file per la libreria specificata dalla rispettiva destinazione, quindi rimuove la definizione di libreria specificata da libman.json</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.ja.xlf
+++ b/src/libman/MultilingualResources/libman.ja.xlf
@@ -43,7 +43,7 @@
           <target state="translated">新しい libman.json を作成します</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">ライブラリ定義を LibMan.json ファイルに追加し、指定した場所にライブラリをダウンロードします</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -104,7 +104,7 @@
           <target state="translated">現在のフォルダーに libman.json がない場合は、エラーになります。ライブラリでプロバイダーを指定している場合は、defaultProvider がオーバーライドされます。ライブラリで宛先を指定している場合は、defaultDestination がオーバーライドされます。</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">指定したライブラリのすべてのファイルを、指定した宛先から削除した後、指定したライブラリ定義を libman.json から削除します</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.ko.xlf
+++ b/src/libman/MultilingualResources/libman.ko.xlf
@@ -43,7 +43,7 @@
           <target state="translated">새 libman.json을 만듭니다.</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">LibMan.json 파일에 라이브러리 정의를 추가하고 라이브러리를 지정한 위치로 다운로드하세요.</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -104,7 +104,7 @@
     라이브러리에서 대상을 지정하면 이 대상으로 defaultDestination이 재정의됩니다.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">지정한 라이브러리의 모든 파일을 지정된 대상에서 삭제한 다음 지정된 라이브러리 정의를 libman.json에서 제거합니다.</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.pl.xlf
+++ b/src/libman/MultilingualResources/libman.pl.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Utwórz nowy plik libman.json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Dodaj definicję biblioteki do pliku LibMan.json i pobierz bibliotekę do określonej lokalizacji</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -107,7 +107,7 @@
     Jeśli biblioteka określa lokalizację docelową, przesłoni ona domyślną lokalizację docelową</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Usuwa wszystkie pliki dla określonej biblioteki z jej wskazanej lokalizacji docelowej, a następnie usuwa definicję określonej biblioteki z pliku libman.json</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.pt-BR.xlf
+++ b/src/libman/MultilingualResources/libman.pt-BR.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Criar um novo libman.json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Adiciona uma definição de biblioteca ao arquivo LibMan.json e baixa a biblioteca para o local especificado</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -105,7 +105,7 @@
     Se uma biblioteca especificar um destino, ele sobrescreverá o defaultDestination</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Exclui todos os arquivos da biblioteca especificada do destino especificado, em seguida, remove a definição da biblioteca do libman.json</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.ru.xlf
+++ b/src/libman/MultilingualResources/libman.ru.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Создать новый файл libman.json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">Добавьте определение библиотеки в файл LibMan.json и загрузите библиотеку в указанное расположение</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -107,7 +107,7 @@
     Если для библиотеки указано место назначения, оно переопределит defaultDestination</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Удаляет все файлы для указанной библиотеки из указанного места назначения, затем удаляет определение библиотеки из файла libman.json</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.tr.xlf
+++ b/src/libman/MultilingualResources/libman.tr.xlf
@@ -43,7 +43,7 @@
           <target state="translated">Yeni bir libman.json oluşturun</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">LibMan.json dosyasına bir kitaplık tanımı ekleyin ve kitaplığı belirtilen konuma indirin</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -101,7 +101,7 @@
           <target state="translated">Geçerli klasörde libman.json olmadığında gösterilen hata Kitaplık bir sağlayıcı belirtiyorsa, bu varsayılan defaultProvider değerini geçersiz kılar Kitaplık bir hedef belirtiyorsa, bu defaultDestination değerini geçersiz kılar</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">Belirtilen kitaplığın tüm belgelerini belirtilen konumdan siler ve ardından belirtilen kitaplık tanımını libman.json üzerinden kaldırır</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.zh-Hans.xlf
+++ b/src/libman/MultilingualResources/libman.zh-Hans.xlf
@@ -43,7 +43,7 @@
           <target state="translated">创建新的 libman. json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">向 LibMan.json 文件添加库定义, 并将库下载到指定位置</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -101,7 +101,7 @@
     如果库指定目标，它将覆盖 defaultDestination</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">从指定的目标删除指定库的所有文件, 然后从 libman.json 删除指定的库定义</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/MultilingualResources/libman.zh-Hant.xlf
+++ b/src/libman/MultilingualResources/libman.zh-Hant.xlf
@@ -43,7 +43,7 @@
           <target state="translated">建立新的 libman.json</target>
         </trans-unit>
         <trans-unit id="InstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Add a library definition to the LibMan.json file, and download the library to the specified location</source>
+          <source>Add a library definition to the libman.json file, and download the library to the specified location</source>
           <target state="translated">將程式庫定義新增到 LibMan.json 檔案，並將程式庫下載到指定的位置</target>
         </trans-unit>
         <trans-unit id="InstallCommandExamples" translate="yes" xml:space="preserve">
@@ -107,7 +107,7 @@ libman install myCalendar --provider filesystem --files calendar.js --files cale
 若程式庫指定了目的地，就會覆寫 defaultDestination</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandDesc" translate="yes" xml:space="preserve">
-          <source>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</source>
+          <source>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</source>
           <target state="translated">從指定的目的地刪除指定程式庫的所有檔案，然後從 libman.json 移除指定的程式庫定義</target>
         </trans-unit>
         <trans-unit id="UnInstallCommandExamples" translate="yes" xml:space="preserve">

--- a/src/libman/Resources/Text.Designer.cs
+++ b/src/libman/Resources/Text.Designer.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add a library definition to the LibMan.json file, and download the library to the specified location.
+        ///   Looks up a localized string similar to Add a library definition to the libman.json file, and download the library to the specified location.
         /// </summary>
         internal static string InstallCommandDesc {
             get {
@@ -656,7 +656,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json.
+        ///   Looks up a localized string similar to Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json.
         /// </summary>
         internal static string UnInstallCommandDesc {
             get {

--- a/src/libman/Resources/Text.resx
+++ b/src/libman/Resources/Text.resx
@@ -145,7 +145,7 @@
     <value>Create a new libman.json</value>
   </data>
   <data name="InstallCommandDesc" xml:space="preserve">
-    <value>Add a library definition to the LibMan.json file, and download the library to the specified location</value>
+    <value>Add a library definition to the libman.json file, and download the library to the specified location</value>
   </data>
   <data name="InstallCommandExamples" xml:space="preserve">
     <value>    libman install jquery@3.2.1
@@ -189,7 +189,7 @@
     If a library specifies a destination, it will override the defaultDestination</value>
   </data>
   <data name="UnInstallCommandDesc" xml:space="preserve">
-    <value>Deletes all files for the specified library from their specified destination, then removess the specified library definition from libman.json</value>
+    <value>Deletes all files for the specified library from their specified destination, then removes the specified library definition from libman.json</value>
   </data>
   <data name="UnInstallCommandExamples" xml:space="preserve">
     <value>    libman uninstall jquery


### PR DESCRIPTION
* Adjust the casing of *LibMan.json* in the `install` help text, so it's consistent with the casing used elsewhere.
* Correct a spelling mistake in the `uninstall` help text.