### PR TITLE
Fixed wrong link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please start a discussion on the [Home repo issue tracker](https://github.com/as
 
 
 ## Bugs and feature requests?
-For non-security related bugs please log a new issue in the [issue tracker](/aspnet/LibraryManager/issues).
+For non-security related bugs please log a new issue in the [issue tracker](../../../issues).
 
 ## Reporting security issues and bugs
 Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC)  secure@microsoft.com. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://technet.microsoft.com/en-us/security/ff852094.aspx).


### PR DESCRIPTION
The link for bugs and features requests is broken -> fixed with a working relative path.