### PR TITLE
Fix serialization when using UI

### DIFF
--- a/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
+++ b/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Web.LibraryManager.Json
 {
     internal class LibraryInstallationStateOnDisk
     {
-        [JsonProperty(ManifestConstants.Library)]
-        public string LibraryId { get; set; }
-
         [JsonProperty(ManifestConstants.Provider)]
         public string ProviderId { get; set; }
+
+        [JsonProperty(ManifestConstants.Library)]
+        public string LibraryId { get; set; }
 
         [JsonProperty(ManifestConstants.Destination)]
         public string DestinationPath { get; set; }

--- a/src/LibraryManager/LibraryNaming/LibraryIdToNameAndVersionConverter.cs
+++ b/src/LibraryManager/LibraryNaming/LibraryIdToNameAndVersionConverter.cs
@@ -68,6 +68,26 @@ namespace Microsoft.Web.LibraryManager.LibraryNaming
         }
 
         /// <summary>
+        /// TEST ONLY: re-initialize in order to accommodate changes to the IDependencies per test
+        /// </summary>
+        /// <param name="dependencies"></param>
+        internal void Reinitialize(IDependencies dependencies)
+        {
+            lock (_syncObject)
+            {
+                _isInitialized = true;
+                _dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
+
+                _perProviderNamingScheme.Clear();
+
+                foreach (IProvider p in _dependencies.Providers)
+                {
+                    _perProviderNamingScheme[p.Id] = p.SupportsLibraryVersions ? _versionedNamingScheme : _simpleNamingScheme;
+                }
+            }
+        }
+
+        /// <summary>
         /// Splits the libraryId into name and version based on the provider.
         /// </summary>
         /// <param name="libraryId"></param>

--- a/src/LibraryManager/Properties/AssemblyInfo.cs
+++ b/src/LibraryManager/Properties/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.Test")]
 [assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.IntegrationTest")]
 [assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.Vsix")]
+[assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.Vsix.Test")]

--- a/test/LibraryManager.Mocks/HostInteraction.cs
+++ b/test/LibraryManager.Mocks/HostInteraction.cs
@@ -16,6 +16,15 @@ namespace Microsoft.Web.LibraryManager.Mocks
     public class HostInteraction : IHostInteraction
     {
         /// <summary>
+        /// Initializes a basic mock HostInteraction for tests.
+        /// </summary>
+        public HostInteraction()
+        {
+            WorkingDirectory = Path.Combine(Path.GetTempPath(), "LibraryManager");
+            CacheDirectory = Environment.ExpandEnvironmentVariables(@"%localappdata%\Microsoft\Library\");
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="HostInteraction"/> class.
         /// </summary>
         /// <param name="workingDirectory">The working directory.</param>

--- a/test/LibraryManager.Test/LibrariesValidatorTest.cs
+++ b/test/LibraryManager.Test/LibrariesValidatorTest.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.Cdnjs;
 using Microsoft.Web.LibraryManager.Providers.FileSystem;
@@ -31,6 +32,7 @@ namespace Microsoft.Web.LibraryManager.Test
             _projectFolder = Path.Combine(Path.GetTempPath(), "LibraryManager");
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory(), new UnpkgProviderFactory());
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(_dependencies);
         }
 
         [TestMethod]

--- a/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
+++ b/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Test
 
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory(), new UnpkgProviderFactory());
-            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(_dependencies);
         }
 
         [DataTestMethod]

--- a/test/LibraryManager.Test/LibraryInstallationStateTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationStateTest.cs
@@ -8,11 +8,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Json;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.Cdnjs;
 using Microsoft.Web.LibraryManager.Providers.FileSystem;
 using Microsoft.Web.LibraryManager.Providers.Unpkg;
+using Newtonsoft.Json;
 
 namespace Microsoft.Web.LibraryManager.Test
 {
@@ -34,7 +36,7 @@ namespace Microsoft.Web.LibraryManager.Test
 
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory(), new UnpkgProviderFactory());
-            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(_dependencies);
         }
 
         [TestMethod]

--- a/test/LibraryManager.Test/ManifestTest.cs
+++ b/test/LibraryManager.Test/ManifestTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Web.LibraryManager.Test
             _hostInteraction = new HostInteraction(_projectFolder, _cacheFolder);
             _dependencies = new Dependencies(_hostInteraction, new CdnjsProviderFactory(), new FileSystemProviderFactory());
 
-            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(_dependencies);
             Directory.CreateDirectory(_projectFolder);
             File.WriteAllText(_filePath, _doc);
         }

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             var hostInteraction = new HostInteraction(projectFolder, cacheFolder);
             var dependencies = new Dependencies(hostInteraction, new CdnjsProviderFactory());
 
-            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(dependencies);
 
             _provider = dependencies.GetProvider("cdnjs");
             _catalog = _provider.GetCatalog();

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.FileSystem;
-using System;
-using System.Linq;
 
 namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
 {
@@ -30,6 +31,8 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
 
             var hostInteraction = new HostInteraction(_projectFolder, "");
             _dependencies = new Dependencies(hostInteraction, new FileSystemProviderFactory());
+
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(_dependencies);
 
             // Create the files to install
             Directory.CreateDirectory(_projectFolder);

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
             var dependencies = new Dependencies(hostInteraction, new UnpkgProviderFactory());
             _provider = dependencies.GetProvider("unpkg");
 
-            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(dependencies);
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(dependencies);
             Directory.CreateDirectory(_projectFolder);
         }
 

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Microsoft.Web.LibraryManager.Vsix.Test.csproj
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Microsoft.Web.LibraryManager.Vsix.Test.csproj
@@ -10,6 +10,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LibraryManager.Vsix\Microsoft.Web.LibraryManager.Vsix.csproj" />
+    <ProjectReference Include="..\..\src\LibraryManager\Microsoft.Web.LibraryManager.csproj" />
+    <ProjectReference Include="..\LibraryManager.Mocks\Microsoft.Web.LibraryManager.Mocks.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSS.Core">

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/InstallDialogViewModelTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/InstallDialogViewModelTest.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Vsix.UI.Models;
+using Microsoft.Web.LibraryManager.Providers.Cdnjs;
+using Newtonsoft.Json;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
+{
+    [TestClass]
+    public class InstallDialogViewModelTest
+    {
+        // these settings should be kept in sync with those used in GetLibraryTextToBeInserted to ensure that the expectedObj is
+        // serialized the same as resultString.
+        private readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented,
+            NullValueHandling = NullValueHandling.Ignore,
+        };
+        private Manifest _manifest;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var dependencies = new Mocks.Dependencies(new Mocks.HostInteraction(), new CdnjsProviderFactory());
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(dependencies);
+            _manifest = new Manifest(dependencies);
+        }
+
+        [TestMethod]
+        public void GetLibraryTextToBeInserted_BasicProperties()
+        {
+            var installState = new LibraryInstallationState
+            {
+                ProviderId = "cdnjs",
+                Name = "jquery",
+                Version = "3.3.1",
+            };
+
+            string resultString = InstallDialogViewModel.GetLibraryTextToBeInserted(installState, _manifest);
+
+            var expectedObj = new
+            {
+                provider = "cdnjs",
+                library = "jquery@3.3.1",
+            };
+            string expected = JsonConvert.SerializeObject(expectedObj, _jsonSettings);
+
+            Assert.AreEqual(expected, resultString);
+        }
+    }
+}


### PR DESCRIPTION
This addresses a regression from #326.  When we add a library through the
UI *and* the libman.json file is open in a text buffer, we serialize the
LibraryInstallationState directly.  LibraryInstallationState is no longer annotated for JSON serialization, so this causes us to insert invalid JSON into the manifest file.