### PR TITLE
Only use the library version for version completion, not the full ID.

### DIFF
--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
 
             foreach (string version in versionsArray)
             {
-                versions.Add(LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(name, version, _provider.Id));
+                versions.Add(version);
             }
 
             return versions;


### PR DESCRIPTION
For GitHub only, the JSDeliver verison completion would cause the library name to be duplicated as the version completion contained the full library ID.  E.g. jquery/jquery@jquery/jquery@3.3.1.