### PR TITLE
Disables interactive mode on consoles with redirected input

### DIFF
--- a/src/libman/Commands/InitCommand.cs
+++ b/src/libman/Commands/InitCommand.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
         protected async override Task<int> ExecuteInternalAsync()
         {
-            await CreateManifestAsync(DefaultProvider.Value(), DefaultDestination.Value(), Settings, CancellationToken.None);
+            await CreateManifestAsync(DefaultProvider.Value(), DefaultDestination.Value(), Settings, DefaultProvider.LongName, CancellationToken.None);
 
             return 0;
         }

--- a/src/libman/Commands/InstallCommand.cs
+++ b/src/libman/Commands/InstallCommand.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
         {
             if (!File.Exists(Settings.ManifestFileName))
             {
-                await CreateManifestAsync(Provider.Value(), null, Settings, CancellationToken.None);
+                await CreateManifestAsync(Provider.Value(), null, Settings, Provider.LongName, CancellationToken.None);
             }
 
             _manifest = await GetManifestAsync();
@@ -120,7 +120,10 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             if (string.IsNullOrWhiteSpace(InstallDestination))
             {
                 string destinationHint = Path.Combine(Settings.DefaultDestinationRoot, ProviderToUse.GetSuggestedDestination(library));
-                InstallDestination = HostEnvironment.InputReader.GetUserInputWithDefault(nameof(Destination), destinationHint);
+                InstallDestination = GetUserInputWithDefault(
+                    fieldName: nameof(Destination),
+                    defaultFieldValue: destinationHint,
+                    optionLongName: Destination.LongName);
             }
 
             string destinationToUse = Destination.Value();

--- a/src/libman/Contracts/ConsoleLogger.cs
+++ b/src/libman/Contracts/ConsoleLogger.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
         /// <returns></returns>
         public string GetUserInput(string fieldName)
         {
-            lock(_syncObject)
+            ThrowIfInputIsRedirected();
+
+            lock (_syncObject)
             {
                 Console.Out.Write($"{fieldName}: ");
                 return Console.ReadLine();
@@ -43,6 +45,8 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
         /// <returns></returns>
         public string GetUserInputWithDefault(string fieldName, string defaultValue)
         {
+            ThrowIfInputIsRedirected();
+
             lock (_syncObject)
             {
                 string message = $"{fieldName} [{defaultValue}]: ";
@@ -82,6 +86,14 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
                 {
                     Console.Out.WriteLine(message);
                 }
+            }
+        }
+
+        private void ThrowIfInputIsRedirected()
+        {
+            if (Console.IsInputRedirected)
+            {
+                throw new InvalidOperationException(Resources.Text.NonInteractiveConsoleMessage);
             }
         }
     }

--- a/src/libman/EnvironmentSettings.cs
+++ b/src/libman/EnvironmentSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Tools.Contracts;
@@ -41,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Tools
 
         public string DefaultProvider { get; set; }
 
-        public string DefaultDestinationRoot => 
+        public string DefaultDestinationRoot =>
             Directory.Exists(Path.Combine(CurrentWorkingDirectory, "wwwroot"))
                 ? Path.Combine("wwwroot", "lib")
                 : "lib";

--- a/src/libman/LibraryResolver.cs
+++ b/src/libman/LibraryResolver.cs
@@ -88,7 +88,16 @@ namespace Microsoft.Web.LibraryManager.Tools
 
             while (true)
             {
-                string choice = hostEnvironment.InputReader.GetUserInput(sb.ToString());
+                string choice = string.Empty;
+                try
+                {
+                    choice = hostEnvironment.InputReader.GetUserInput(sb.ToString());
+                }
+                catch (InvalidOperationException)
+                {
+                    hostEnvironment.Logger.Log(Resources.Text.SpecifyDisabmiguatedLibrary, LogLevel.Error);
+                    throw;
+                }
 
                 if (int.TryParse(choice, out int choiceIndex) && choiceIndex > 0 && choiceIndex < index)
                 {

--- a/src/libman/Resources/Text.Designer.cs
+++ b/src/libman/Resources/Text.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Text {
@@ -555,6 +555,15 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot prompt for user input in this console..
+        /// </summary>
+        internal static string NonInteractiveConsoleMessage {
+            get {
+                return ResourceManager.GetString("NonInteractiveConsoleMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Path to the project (Current directory is used as default).
         /// </summary>
         internal static string ProjectPathOptionDesc {
@@ -634,6 +643,24 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
         internal static string SpecifyDifferentDestination {
             get {
                 return ResourceManager.GetString("SpecifyDifferentDestination", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please specify the complete library id and the also the provider using &apos;--provider&apos; option..
+        /// </summary>
+        internal static string SpecifyDisabmiguatedLibrary {
+            get {
+                return ResourceManager.GetString("SpecifyDisabmiguatedLibrary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please specify &apos;{0}&apos; using the &apos;{1}&apos; option..
+        /// </summary>
+        internal static string SpecifyFieldUsingOption {
+            get {
+                return ResourceManager.GetString("SpecifyFieldUsingOption", resourceCulture);
             }
         }
         

--- a/src/libman/Resources/Text.resx
+++ b/src/libman/Resources/Text.resx
@@ -132,6 +132,9 @@
   <data name="DefaultProviderOptionDesc" xml:space="preserve">
     <value>The provider to use if no provider is defined for a given library. (eg. “cdnjs”, “filesystem”)</value>
   </data>
+  <data name="NonInteractiveConsoleMessage" xml:space="preserve">
+    <value>Cannot prompt for user input in this console.</value>
+  </data>
   <data name="DestinationOptionDesc" xml:space="preserve">
     <value>Location to install the library (if not specified, the default destination location will be used)</value>
   </data>
@@ -387,5 +390,11 @@ Please specify a different destination.</value>
   </data>
   <data name="InitFailedUnknownProvider" xml:space="preserve">
     <value>Failed to initialize libman.json. [{0}]: {1}</value>
+  </data>
+  <data name="SpecifyDisabmiguatedLibrary" xml:space="preserve">
+    <value>Please specify the complete library id and the also the provider using '--provider' option.</value>
+  </data>
+  <data name="SpecifyFieldUsingOption" xml:space="preserve">
+    <value>Please specify '{0}' using the '--{1}' option.</value>
   </data>
 </root>

--- a/test/libman.Test/SampleTestCommand.cs
+++ b/test/libman.Test/SampleTestCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
         {
             if (CreateNewManifest)
             {
-                Manifest = await CreateManifestAsync(DefaultProvider, DefaultDestination, Settings, CancellationToken.None);
+                Manifest = await CreateManifestAsync(DefaultProvider, DefaultDestination, Settings, "", CancellationToken.None);
             }
             else
             {


### PR DESCRIPTION
Fixes the issue where using the interactive commands (`libman init`/ `libman install`) appear to be hung if the console's input is redirected.
Visual studio's Package manager console is one such case.