### PR TITLE
Fixed VSTS Bug 666417 by setting the popup's StaysOpen property to false

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml
@@ -49,6 +49,7 @@
         <!-- Fly out -->
         <Popup x:Name="Flyout"
                Placement="Bottom"
+               StaysOpen="False"
                PlacementTarget="{Binding ElementName=LibrarySearchBox}">
             <ListBox x:Name="Options"
                 SelectionMode="Single"


### PR DESCRIPTION
Bug is being tracked by:


[BUG 666417 - Fix accessibility bugs reported by Keros tool in LibraryManager project](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/666417)