### PR TITLE
Updating localized VSCT files

### DIFF
--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.cs.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.cs.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="cs" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="cs" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">&amp;Knihovna na straně klienta...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.de.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.de.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="de" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="de" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">Clientseitige &amp;Bibliothek...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.en.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.en.xlf
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
         </trans-unit>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.es.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.es.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="es" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="es" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">&amp;Biblioteca del lado cliente...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.fr.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.fr.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="fr" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="fr" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">&amp;Bibliothèque côté client...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.it.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.it.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="it" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="it" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">&amp;Libreria lato client...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.ja.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.ja.xlf
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="ja" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="ja" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">クライアント側ライブラリ(&amp;L)...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.ko.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.ko.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="ko" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="ko" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">클라이언트 쪽 라이브러리(&amp;L)...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.pl.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.pl.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="pl" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="pl" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">Bib&amp;lioteka po stronie klienta...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.pt-BR.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.pt-BR.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="pt-BR" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="pt-BR" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">&amp;Biblioteca do Lado do Cliente...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.ru.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.ru.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="ru" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="ru" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">Клиентская &amp;библиотека...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.tr.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.tr.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="tr" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="tr" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">İstemci Tarafı &amp;Kitaplık...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.zh-Hans.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.zh-Hans.xlf
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="zh-Hans" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="zh-Hans" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">客户端库(&amp;L)...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.zh-Hant.xlf
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/LocalizationFiles/VSCommandTable.zh-Hant.xlf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd" version="1.2">
-  <file original="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="zh-Hant" datatype="xml">
+  <file original="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct" source-language="en" target-language="zh-Hant" datatype="xml">
     <body>
-      <group id="E:\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
+      <group id="C:\Users\bhsubra\Desktop\LibraryManager\src\LibraryManager.Vsix\Commands\CommandTable\VSCommandTable.en.vsct">
         <trans-unit id="InstallPackage|ButtonText">
           <source xml:lang="en">Client-Side &amp;Library...</source>
           <target state="translated">用戶端程式庫(&amp;L)...</target>

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.cs.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.cs.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Přidat klientské knihovny...</ButtonText>
+          <ButtonText>&amp;Knihovna na straně klienta...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Obnovit klientské knihovny</ButtonText>
+          <ButtonText>O&amp;bnovit knihovny na straně klienta</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Vyčistit</ButtonText>
+          <ButtonText>Vyč&amp;istit knihovny na straně klienta</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Povolit obnovení při sestavení...</ButtonText>
+          <ButtonText>Povolit obnovení knihoven na straně klienta při sestavení...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Spravovat klientské knihovny...</ButtonText>
+          <ButtonText>&amp;Spravovat knihovny na straně klienta...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Obnovit klientské knihovny</ButtonText>
+          <ButtonText>&amp;Obnovit knihovny na straně klienta</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.de.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.de.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Clientseitige Bibliothek hinzufügen</ButtonText>
+          <ButtonText>Clientseitige &amp;Bibliothek...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Clientseitige wiederherstellen</ButtonText>
+          <ButtonText>Clientseitige &amp;Bibliotheken wiederherstellen</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Bereinigen</ButtonText>
+          <ButtonText>Clientseitige Bibliotheken &amp;bereinigen</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Aktivieren Sie auf Build...</ButtonText>
+          <ButtonText>Wiederherstellung clientseitiger Bibliotheken bei Builderstellung aktivieren...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Verwalten Sie clientseitige Bibliotheken...</ButtonText>
+          <ButtonText>Clientseitige Bibliotheken &amp;verwalten...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Clientseitige wiederherstellen</ButtonText>
+          <ButtonText>Clientseitige Bibliotheken &amp;wiederherstellen</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.es.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.es.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Agregar biblioteca del lado cliente...</ButtonText>
+          <ButtonText>&amp;Biblioteca del lado cliente...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Restaurar bibliotecas del lado cliente</ButtonText>
+          <ButtonText>Restaurar &amp;bibliotecas del lado cliente</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Borrar</ButtonText>
+          <ButtonText>&amp;Limpiar bibliotecas del lado cliente</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Habilitar la restauración en la compilación...</ButtonText>
+          <ButtonText>Habilitar la restauración de bibliotecas del lado cliente al compilar...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Administrar bibliotecas del lado cliente...</ButtonText>
+          <ButtonText>&amp;Administrar bibliotecas del lado cliente...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Restaurar bibliotecas del lado cliente</ButtonText>
+          <ButtonText>&amp;Restaurar bibliotecas del lado cliente</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.fr.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.fr.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Add Client-Side Library...</ButtonText>
+          <ButtonText>&amp;Bibliothèque côté client...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Restore Client-Side Libraries</ButtonText>
+          <ButtonText>Restaurer les &amp;bibliothèques côté client</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Clean</ButtonText>
+          <ButtonText>&amp;Nettoyer les bibliothèques côté client</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Enable Restore on Build...</ButtonText>
+          <ButtonText>Activer la restauration des bibliothèques côté client sur la build...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Manage Client-Side Libraries...</ButtonText>
+          <ButtonText>&amp;Gérer les bibliothèques côté client...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Restaurer les bibliothèques côté client</ButtonText>
+          <ButtonText>&amp;Restaurer les bibliothèques côté client</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.it.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.it.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Aggiungi libreria lato client...</ButtonText>
+          <ButtonText>&amp;Libreria lato client...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Ripristina librerie lato client</ButtonText>
+          <ButtonText>Ripristina &amp;librerie lato client</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Pulisci</ButtonText>
+          <ButtonText>&amp;Pulisci librerie lato client</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Consenti ripristino durante la compilazione...</ButtonText>
+          <ButtonText>Abilita ripristino delle librerie lato client durante la compilazione...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Gestisci librerie lato client...</ButtonText>
+          <ButtonText>&amp;Gestisci librerie lato client...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Ripristina librerie lato client</ButtonText>
+          <ButtonText>&amp;Ripristina librerie lato client</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ja.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ja.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>クライアント側のライブラリを追加するには.</ButtonText>
+          <ButtonText>クライアント側ライブラリ(&amp;L)...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>クライアント側のライブラリを復元します。</ButtonText>
+          <ButtonText>クライアント側ライブラリの復元(&amp;L)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>クリーニング</ButtonText>
+          <ButtonText>クライアント側ライブラリのクリーンアップ(&amp;C)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>ビルドでの復元を有効にする.</ButtonText>
+          <ButtonText>ビルド時のクライアント側ライブラリの復元を有効にする...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>クライアント側のライブラリを管理してください.</ButtonText>
+          <ButtonText>クライアント側ライブラリの管理(&amp;M)...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>クライアント側のライブラリを復元します。</ButtonText>
+          <ButtonText>クライアント側ライブラリの復元(&amp;R)</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ko.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ko.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>클라이언트 라이브러리 추가...</ButtonText>
+          <ButtonText>클라이언트 쪽 라이브러리(&amp;L)...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>클라이언트 라이브러리를 복원</ButtonText>
+          <ButtonText>클라이언트 쪽 라이브러리 복원(&amp;L)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>청소</ButtonText>
+          <ButtonText>클라이언트 쪽 라이브러리 정리(&amp;C)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>빌드에 대 한 복원을 사용...</ButtonText>
+          <ButtonText>빌드에 클라이언트 쪽 라이브러리 복원 사용...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>클라이언트 라이브러리를 관리 하는...</ButtonText>
+          <ButtonText>클라이언트 쪽 라이브러리 관리(&amp;M)...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>클라이언트 라이브러리를 복원</ButtonText>
+          <ButtonText>클라이언트 쪽 라이브러리 복원(&amp;R)</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pl.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pl.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Dodaj bibliotekę po stronie klienta...</ButtonText>
+          <ButtonText>Bib&amp;lioteka po stronie klienta...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Przywróć biblioteki po stronie klienta</ButtonText>
+          <ButtonText>Przywróć bib&amp;lioteki po stronie klienta</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Czyste</ButtonText>
+          <ButtonText>Wy&amp;czyść biblioteki po stronie klienta</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Włącz przywracanie przy kompilacji...</ButtonText>
+          <ButtonText>Włącz przywracanie bibliotek po stronie klienta przy kompilacji...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Zarządzaj bibliotekami po stronie klienta...</ButtonText>
+          <ButtonText>Zarządzaj biblioteka&amp;mi po stronie klienta...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Przywróć biblioteki po stronie klienta</ButtonText>
+          <ButtonText>P&amp;rzywróć biblioteki po stronie klienta</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pt-BR.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pt-BR.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Adicionar biblioteca do lado do cliente...</ButtonText>
+          <ButtonText>&amp;Biblioteca do Lado do Cliente...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Restauras bibliotecas do lado do cliente</ButtonText>
+          <ButtonText>Restaurar &amp;Bibliotecas do Lado do Cliente</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Limpar</ButtonText>
+          <ButtonText>&amp;Limpar Bibliotecas do Lado do Cliente</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Habilitar a restauração no build ...</ButtonText>
+          <ButtonText>Habilitar Restauração de Bibliotecas do Lado do Cliente no Build...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Gerenciar bibliotecas do lado do cliente ...</ButtonText>
+          <ButtonText>&amp;Gerenciar Bibliotecas do Lado do Cliente...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Restaurar bibliotecas do lado do cliente</ButtonText>
+          <ButtonText>&amp;Restaurar Bibliotecas do Lado do Cliente</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ru.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ru.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Добавить клиентскую библиотеку...</ButtonText>
+          <ButtonText>Клиентская &amp;библиотека...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Восстановить клиентские библиотеки</ButtonText>
+          <ButtonText>Восстановить клиент&amp;ские библиотеки</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Очистить</ButtonText>
+          <ButtonText>&amp;Очистить клиентские библиотеки</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Включить восстановление при сборке...</ButtonText>
+          <ButtonText>Включить восстановление клиентских библиотек при сборке...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Управление клиентскими библиотеками...</ButtonText>
+          <ButtonText>&amp;Управление клиентскими библиотеками...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Восстановить клиентские библиотеки</ButtonText>
+          <ButtonText>&amp;Восстановить клиентские библиотеки</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.tr.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.tr.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>İstemci tarafı kitaplığı Ekle...</ButtonText>
+          <ButtonText>İstemci Tarafı &amp;Kitaplık...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>İstemci tarafı kitaplıkları geri yükle</ButtonText>
+          <ButtonText>İstemci Tarafı &amp;Kitaplıkları Geri Yükle</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Temiz</ButtonText>
+          <ButtonText>İstemci Tarafı Kitaplıkları &amp;Temizle</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Geri Yükleme'yi yapı izin ver...</ButtonText>
+          <ButtonText>Derleme Sırasında İstemci Tarafı Kitaplıkların Geri Yüklenmesini Etkinleştir...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>İstemci tarafı kitaplıkları Yönet...</ButtonText>
+          <ButtonText>İstemci Tarafı Kitaplıkları &amp;Yönet...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>İstemci tarafı kitaplıkları geri yükle</ButtonText>
+          <ButtonText>İstemci Tarafı Kitaplıkları &amp;Geri Yükle</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hans.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hans.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>添加客户端库...</ButtonText>
+          <ButtonText>客户端库(&amp;L)...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>恢复客户端库</ButtonText>
+          <ButtonText>还原客户端库(&amp;L)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>清除</ButtonText>
+          <ButtonText>清理客户端库(&amp;C)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>启用还原生成...</ButtonText>
+          <ButtonText>在生成时启用“还原客户端库”...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>管理客户端库...</ButtonText>
+          <ButtonText>管理客户端库(&amp;M)...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>恢复客户端库</ButtonText>
+          <ButtonText>还原客户端库(&amp;R)</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hant.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hant.vsct
@@ -9,14 +9,14 @@
     </Groups>
     <Buttons>
       <!-- Folder -->
-      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100" type="Button">
+      <Button guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0101" type="Button">
         <Parent guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" />
         <Icon guid="ImageCatalogGuid" id="JSWebScript" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>新增用戶端程式庫...</ButtonText>
+          <ButtonText>用戶端程式庫(&amp;L)...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>還原用戶端程式庫</ButtonText>
+          <ButtonText>還原用戶端程式庫(&amp;L)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>清除</ButtonText>
+          <ButtonText>清除用戶端程式庫(&amp;C)</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>啟用組建上的還原...</ButtonText>
+          <ButtonText>在建置時啟用還原用戶端程式庫...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>管理用戶端程式庫...</ButtonText>
+          <ButtonText>管理用戶端程式庫(&amp;M)...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>還原用戶端程式庫</ButtonText>
+          <ButtonText>還原用戶端程式庫(&amp;R)</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -77,7 +77,7 @@
   <CommandPlacements>
     <!-- Folder menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
-      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD"/>
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
       <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />


### PR DESCRIPTION
It looks like the last time English VSCT file was updated, we updated XLF files and had that translated, but we haven't converted translated XLF files back into localized VSCT files. Localized VSCT files were either not translated at all or had stale translations in them. I updated all VSCT files, not just French. 

The path change in the XLF files is ignorable. Only VSCT changes really matter here. We should consider using github file URL rather than local repo path in the XLF files to avoid meaningless diffs like that.