### PR TITLE
Fixing Hang for Add Client-Side Library Window for CHS machines

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             TextChange textChange = e.Changes.Last();
 
             // We will invoke completion on text insertion and not deletion.
-            if (textChange.AddedLength > 0)
+            if (textChange.AddedLength > 0 && !string.IsNullOrEmpty(Text))
             {
                 VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {


### PR DESCRIPTION
Fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/774500. 

For Chinese, the TextChanged event gets fired (claiming that the AddedLength is positive) even when the Text property hasn't changed yet. This is causing a null ref because of Text. 
