### PR TITLE
Add retry loop when downloading content from providers.

### DIFF
--- a/src/LibraryManager.Contracts/ResourceDownloadException.cs
+++ b/src/LibraryManager.Contracts/ResourceDownloadException.cs
@@ -18,7 +18,17 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// </summary>
         /// <param name="url">The url for the resource.</param>
         public ResourceDownloadException(string url)
-            : base(string.Format(Text.ErrorUnableToDownloadResource, url))
+            : this(string.Format(Text.ErrorUnableToDownloadResource, url), null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ResourceDownloadException"/>.
+        /// </summary>
+        /// <param name="url">The url for the resource.</param>
+        /// <param name="innerException">Inner exception</param>
+        public ResourceDownloadException(string url, Exception innerException)
+            : base(string.Format(Text.ErrorUnableToDownloadResource, url), innerException)
         {
             Url = url;
         }

--- a/src/LibraryManager/CacheService/WebRequestHandler.cs
+++ b/src/LibraryManager/CacheService/WebRequestHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Web.LibraryManager
             {
                 return await _httpClient.GetStreamAsync(url).WithCancellation(cancellationToken).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
-                throw new ResourceDownloadException(url);
+                throw new ResourceDownloadException(url, ex);
             }
         }
     }


### PR DESCRIPTION
This attempts to address severe flakiness we've seen from all providers,
as well as in executing our unit tests.  Many of the failures we see are
intermittent 404s, so the loop gives us better resiliency when CDNs are
being flaky.