### PR TITLE
Uninstall LightBulb fails to remove files

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -28,6 +28,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="15.7.942-master669188BE" />
     <PackageReference Update="Microsoft.VisualStudio.Threading" Version="15.8.168" />
     <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="15.0.26201" PrivateAssets="All" />
+    <PackageReference Update="Moq" Version="4.10.1" PrivateAssets="All" />
     <PackageReference Update="NerdBank.GitVersioning" Version="2.1.23" PrivateAssets="All" />
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Update="Nuget.VisualStudio" Version="4.7.0" />

--- a/src/LibraryManager.Vsix/Contracts/Dependencies.cs
+++ b/src/LibraryManager.Vsix/Contracts/Dependencies.cs
@@ -1,73 +1,31 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.LibraryNaming;
-using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {
     internal class Dependencies : IDependencies
     {
         private readonly IHostInteraction _hostInteraction;
-        private readonly List<IProvider> _providers = new List<IProvider>();
         private static readonly Dictionary<string, Dependencies> _cache = new Dictionary<string, Dependencies>();
 
-        [ImportMany(typeof(IProviderFactory), AllowRecomposition = true)]
-        private IEnumerable<IProviderFactory> _providerFactories = null;
-
-        private Dependencies(IHostInteraction hostInteraction)
+        internal Dependencies(IHostInteraction hostInteraction, IReadOnlyList<IProvider> providers)
         {
             _hostInteraction = hostInteraction;
-            Initialize();
+            Providers = providers;
         }
 
-        public IReadOnlyList<IProvider> Providers => _providers;
+        public IReadOnlyList<IProvider> Providers { get; }
 
         public IHostInteraction GetHostInteractions() => _hostInteraction;
-
-        public static Dependencies FromConfigFile(string configFilePath)
-        {
-            if (!_cache.ContainsKey(configFilePath))
-            {
-                PerProjectLogger perProjectLogger = new PerProjectLogger(configFilePath);
-                HostInteraction hostInteraction = new HostInteraction(configFilePath, perProjectLogger);
-                _cache[configFilePath] = new Dependencies(hostInteraction);
-            }
-
-            // We need to initialize naming schemes for the providers before we can proceed with any operation.
-            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_cache[configFilePath]);
-
-            return _cache[configFilePath];
-        }
 
         public IProvider GetProvider(string providerId)
         {
             return Providers?.FirstOrDefault(p => p.Id.Equals(providerId, StringComparison.OrdinalIgnoreCase));
-        }
-
-        private void Initialize()
-        {
-            if (_providers.Count > 0)
-            {
-                return;
-            }
-
-            this.SatisfyImportsOnce();
-
-            foreach (IProviderFactory factory in _providerFactories)
-            {
-                IProvider provider = factory.CreateProvider(_hostInteraction);
-
-                if (provider != null && !_providers.Contains(provider))
-                {
-                    _providers.Add(provider);
-                }
-            }
         }
     }
 }

--- a/src/LibraryManager.Vsix/Contracts/DependenciesFactory.cs
+++ b/src/LibraryManager.Vsix/Contracts/DependenciesFactory.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Contracts
+{
+    /// <summary>
+    /// Factory for creating Dependencies in this host
+    /// </summary>
+    [Export(typeof(IDependenciesFactory))]
+    internal class DependenciesFactory : IDependenciesFactory
+    {
+        [ImportMany(typeof(IProviderFactory), AllowRecomposition = true)]
+        private IEnumerable<IProviderFactory> _providerFactories = null;
+
+        private static readonly Dictionary<string, Dependencies> _cache = new Dictionary<string, Dependencies>();
+
+        /// <summary>
+        /// Creates or re-uses a cached Dependencies for the given path
+        /// </summary>
+        /// <param name="configFilePath">File path to the libman.json file</param>
+        public IDependencies FromConfigFile(string configFilePath)
+        {
+            if (!_cache.ContainsKey(configFilePath))
+            {
+                var perProjectLogger = new PerProjectLogger(configFilePath);
+                var hostInteraction = new HostInteraction(configFilePath, perProjectLogger);
+                IReadOnlyList<IProvider> providers = GetProviders(hostInteraction);
+                _cache[configFilePath] = new Dependencies(hostInteraction, providers);
+            }
+
+            // We need to initialize naming schemes for the providers before we can proceed with any operation.
+            LibraryIdToNameAndVersionConverter.Instance.EnsureInitialized(_cache[configFilePath]);
+
+            return _cache[configFilePath];
+        }
+
+        private IReadOnlyList<IProvider> GetProviders(IHostInteraction hostInteraction)
+        {
+            return _providerFactories.Select(pf => pf.CreateProvider(hostInteraction)).ToList();
+        }
+    }
+}

--- a/src/LibraryManager.Vsix/Contracts/IDependenciesFactory.cs
+++ b/src/LibraryManager.Vsix/Contracts/IDependenciesFactory.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Web.LibraryManager.Contracts;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Contracts
+{
+    internal interface IDependenciesFactory
+    {
+        IDependencies FromConfigFile(string configFilePath);
+    }
+}

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;
@@ -23,6 +24,14 @@ namespace Microsoft.Web.LibraryManager.Vsix
     [Name(nameof(FilesCompletionProvider))]
     internal class FilesCompletionProvider : BaseCompletionProvider
     {
+        private readonly IDependenciesFactory _dependenciesFactory;
+
+        [ImportingConstructor]
+        internal FilesCompletionProvider(IDependenciesFactory dependenciesFactory)
+        {
+            _dependenciesFactory = dependenciesFactory;
+        }
+
         public override JsonCompletionContextType ContextType
         {
             get { return JsonCompletionContextType.ArrayElement; }
@@ -43,7 +52,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             if (string.IsNullOrEmpty(state.Name))
                 yield break;
 
-            var dependencies = Dependencies.FromConfigFile(ConfigFilePath);
+            var dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
             IProvider provider = dependencies.GetProvider(state.ProviderId);
             ILibraryCatalog catalog = provider?.GetCatalog();
 

--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 
@@ -21,6 +22,14 @@ namespace Microsoft.Web.LibraryManager.Vsix
     {
         private static readonly ImageMoniker _libraryIcon = KnownMonikers.Method;
         private static readonly ImageMoniker _folderIcon = KnownMonikers.FolderClosed;
+
+        private IDependenciesFactory _dependenciesFactory { get; set;}
+
+        [ImportingConstructor]
+        internal LibraryIdCompletionProvider(IDependenciesFactory dependenciesFactory)
+        {
+            _dependenciesFactory = dependenciesFactory;
+        }
 
         public override JsonCompletionContextType ContextType
         {
@@ -43,7 +52,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 yield break;
             }
 
-            var dependencies = Dependencies.FromConfigFile(ConfigFilePath);
+            var dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
             IProvider provider = dependencies.GetProvider(state.ProviderId);
             ILibraryCatalog catalog = provider?.GetCatalog();
 

--- a/src/LibraryManager.Vsix/Json/Completion/PathCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/PathCompletionProvider.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 
@@ -17,6 +18,14 @@ namespace Microsoft.Web.LibraryManager.Vsix
     [Name(nameof(PathCompletionProvider))]
     internal class PathCompletionProvider : BaseCompletionProvider
     {
+        private readonly IDependenciesFactory _dependenciesFactory;
+
+        [ImportingConstructor]
+        internal PathCompletionProvider(IDependenciesFactory dependenciesFactory)
+        {
+            _dependenciesFactory = dependenciesFactory;
+        }
+
         public override JsonCompletionContextType ContextType
         {
             get { return JsonCompletionContextType.PropertyValue; }
@@ -48,7 +57,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 yield break;
             }
 
-            var dependencies = Dependencies.FromConfigFile(ConfigFilePath);
+            var dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
             string cwd = dependencies?.GetHostInteractions().WorkingDirectory;
 
             if (string.IsNullOrEmpty(cwd))

--- a/src/LibraryManager.Vsix/Json/Completion/ProviderCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/ProviderCompletionProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 
@@ -17,6 +18,14 @@ namespace Microsoft.Web.LibraryManager.Vsix
     internal class ProviderCompletionProvider : BaseCompletionProvider
     {
         private static readonly ImageMoniker _libraryIcon = KnownMonikers.Method;
+
+        private readonly IDependenciesFactory _dependenciesFactory;
+
+        [ImportingConstructor]
+        internal ProviderCompletionProvider(IDependenciesFactory dependenciesFactory)
+        {
+            _dependenciesFactory = dependenciesFactory;
+        }
 
         public override JsonCompletionContextType ContextType
         {
@@ -30,7 +39,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             if (member == null || (member.UnquotedNameText != ManifestConstants.Provider && member.UnquotedNameText != ManifestConstants.DefaultProvider))
                 yield break;
 
-            var dependencies = Dependencies.FromConfigFile(ConfigFilePath);
+            var dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
             IEnumerable<string> providerIds = dependencies.Providers?.Select(p => p.Id);
 
             if (providerIds == null || !providerIds.Any())

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Json.VS.SuggestedActions;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;
@@ -29,6 +30,9 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         [Import]
         public ILibraryCommandService LibraryCommandService { get; set; }
+
+        [Import]
+        public IDependenciesFactory DependenciesFactory { get; private set;}
 
         public IEnumerable<ISuggestedAction> GetSuggestedActions(ITextView textView, ITextBuffer textBuffer, int caretPosition, Node node)
         {

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             try
             {
-                var dependencies = Dependencies.FromConfigFile(_provider.ConfigFilePath);
+                var dependencies = _provider.DependenciesFactory.FromConfigFile(_provider.ConfigFilePath);
                 IProvider provider = dependencies.GetProvider(_provider.InstallationState.ProviderId);
                 ILibraryCatalog catalog = provider?.GetCatalog();
 

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
         {
             get
             {
-                var dependencies = Dependencies.FromConfigFile(_provider.ConfigFilePath);
+                var dependencies = _provider.DependenciesFactory.FromConfigFile(_provider.ConfigFilePath);
                 IProvider provider = dependencies.GetProvider(_provider.InstallationState.ProviderId);
                 ILibraryCatalog catalog = provider?.GetCatalog();
 

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Json
 {
@@ -26,7 +27,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
     internal class TextviewCreationListener : IVsTextViewCreationListener
     {
         private Manifest _manifest;
-        private Dependencies _dependencies;
+        private IDependencies _dependencies;
         private Project _project;
         private ErrorList _errorList;
         private string _manifestPath;
@@ -42,6 +43,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
 
         [Import]
         ILibraryCommandService libraryCommandService { get; set; }
+
+        [Import]
+        private IDependenciesFactory DependenciesFactory { get; set; }
 
         public void VsTextViewCreated(IVsTextView textViewAdapter)
         {
@@ -61,7 +65,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
 
             new CompletionController(textViewAdapter, textView, CompletionBroker);
 
-            _dependencies = Dependencies.FromConfigFile(doc.FilePath);
+            _dependencies = DependenciesFactory.FromConfigFile(doc.FilePath);
             _manifest = Manifest.FromFileAsync(doc.FilePath, _dependencies, CancellationToken.None).Result;
             _manifestPath = doc.FilePath;
             _project = VsHelpers.GetDTEProjectFromConfig(_manifestPath);

--- a/src/LibraryManager.Vsix/LibraryManagerPackage.cs
+++ b/src/LibraryManager.Vsix/LibraryManagerPackage.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Tasks = System.Threading.Tasks;
 
 namespace Microsoft.Web.LibraryManager.Vsix
@@ -46,7 +47,10 @@ namespace Microsoft.Web.LibraryManager.Vsix
     internal sealed class LibraryManagerPackage : AsyncPackage
     {
         [Import]
-        ILibraryCommandService LibraryCommandService { get; set; }
+        internal ILibraryCommandService LibraryCommandService { get; set; }
+
+        [Import]
+        internal IDependenciesFactory DependenciesFactory { get; private set; }
 
         protected override async Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
@@ -59,12 +63,12 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             if (commandService != null && LibraryCommandService != null)
             {
-                InstallLibraryCommand.Initialize(this, commandService, LibraryCommandService);
+                InstallLibraryCommand.Initialize(commandService, LibraryCommandService, DependenciesFactory);
                 CleanCommand.Initialize(this, commandService, LibraryCommandService);
                 RestoreCommand.Initialize(this, commandService, LibraryCommandService);
                 RestoreSolutionCommand.Initialize(this, commandService, LibraryCommandService);
-                RestoreOnBuildCommand.Initialize(this, commandService);
-                ManageLibrariesCommand.Initialize(this, commandService, LibraryCommandService);
+                RestoreOnBuildCommand.Initialize(this, commandService, DependenciesFactory);
+                ManageLibrariesCommand.Initialize(this, commandService, LibraryCommandService, DependenciesFactory);
             }
         }
     }

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -53,6 +53,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Commands\InstallLibraryCommand.cs" />
+    <Compile Include="Contracts\DependenciesFactory.cs" />
+    <Compile Include="Contracts\IDependenciesFactory.cs" />
     <Compile Include="Shared\DefaultSolutionEvents.cs" />
     <Compile Include="UI\Converters\CheckBoxAutomationNameConverter.cs" />
     <Compile Include="UI\Extensions\RemoveSubstringExtension.cs" />

--- a/src/LibraryManager.Vsix/Properties/AssemblyInfo.cs
+++ b/src/LibraryManager.Vsix/Properties/AssemblyInfo.cs
@@ -17,6 +17,8 @@ using Microsoft.Web.LibraryManager.Vsix;
 [assembly: AssemblyCulture("")]
 
 [assembly: ComVisible(false)]
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.IntegrationTest")]
 [assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.Vsix.Test")]
 

--- a/src/LibraryManager.Vsix/Shared/DefaultSolutionEvents.cs
+++ b/src/LibraryManager.Vsix/Shared/DefaultSolutionEvents.cs
@@ -29,8 +29,13 @@ namespace Microsoft.Web.LibraryManager.Vsix
         private uint _solutionEventsCookie;
 
         public DefaultSolutionEvents()
+            : this(Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution)
         {
-            _solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
+        }
+
+        public DefaultSolutionEvents(IVsSolution solution)
+        {
+            _solution = solution;
             _solution.AdviseSolutionEvents(this, out _solutionEventsCookie);
         }
 
@@ -73,7 +78,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             BeforeUnloadProject?.Invoke(this, new ParamEventArgs(pRealHierarchy, pStubHierarchy));
 
             return VSConstants.S_OK;
-    }
+        }
 
         int IVsSolutionEvents.OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
         {

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -30,12 +30,15 @@ namespace Microsoft.Web.LibraryManager.Vsix
         private object _lockObject = new object();
 
         [ImportingConstructor]
-        public LibraryCommandService(IDependenciesFactory dependenciesFactory, ITaskStatusCenterService taskStatusCenterService)
+        public LibraryCommandService(IDependenciesFactory dependenciesFactory,
+                                     ITaskStatusCenterService taskStatusCenterService,
+                                     // HACK: lets tests inject one but still satisfy MEF construction since there is no Export
+                                     [Import(AllowDefault = true)] DefaultSolutionEvents solutionEvents)
         {
             _dependenciesFactory = dependenciesFactory;
             _taskStatusCenterService = taskStatusCenterService;
             
-            _solutionEvents = new DefaultSolutionEvents();
+            _solutionEvents = solutionEvents ?? new DefaultSolutionEvents();
             _solutionEvents.BeforeCloseSolution += OnBeforeCloseSolution;
             _solutionEvents.BeforeCloseProject += OnBeforeCloseProject;
             _solutionEvents.BeforeUnloadProject += OnBeforeUnloadProject;

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             return await manifest.RestoreAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task UninstallLibraryAsync(string configFilePath, string libraryName, string providerId, string version,CancellationToken cancellationToken)
+        private async Task UninstallLibraryAsync(string configFilePath, string libraryName, string version, string providerId, CancellationToken cancellationToken)
         {
             string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(libraryName, version, providerId);
             Logger.LogEventsHeader(OperationType.Uninstall, libraryId);

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -95,8 +95,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI
                 InstallButton.IsEnabled = true;
             }
 
-            Dependencies dependencies = Dependencies.FromConfigFile(_configFileName);
-            string cwd = dependencies?.GetHostInteractions().WorkingDirectory;
+            string cwd = _deps?.GetHostInteractions().WorkingDirectory;
 
             IEnumerable<Tuple<string, string>> completions = GetCompletions(cwd, searchText, caretPosition, out Span textSpan);
 

--- a/test/LibraryManager.IntegrationTest/FileSaveRestoreTests.cs
+++ b/test/LibraryManager.IntegrationTest/FileSaveRestoreTests.cs
@@ -43,20 +43,11 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
   ""libraries"": []
 }";
 
-            ReplaceFileContent(addingLibraryContent);
+            SetManifestContents(addingLibraryContent);
             Helpers.FileIO.WaitForRestoredFiles(pathToLibrary, expectedFiles, caseInsensitive: true);
 
-            ReplaceFileContent(deletingLibraryContent);
+            SetManifestContents(deletingLibraryContent);
             Helpers.FileIO.WaitForDeletedFiles(pathToLibrary, expectedFiles, caseInsensitive: true);
-        }
-
-        private void ReplaceFileContent(string content)
-        {
-            Editor.Selection.SelectAll();
-            Editor.KeyboardCommands.Delete();
-            Editor.Edit.InsertTextInBuffer(content);
-
-            _libmanConfig.Save();
         }
     }
 }

--- a/test/LibraryManager.IntegrationTest/Helpers/FileIOHelper.cs
+++ b/test/LibraryManager.IntegrationTest/Helpers/FileIOHelper.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
 
         private static HashSet<string> GetSubDirectoriesAndFiles(string currentWorkingDirectory, bool caseInsensitive)
         {
+            if(!Directory.Exists(currentWorkingDirectory))
+            {
+                return new HashSet<string>();
+            }
+
             StringComparer comparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
             IEnumerable<string> subItems = Directory.EnumerateFileSystemEntries(currentWorkingDirectory, "*", SearchOption.AllDirectories);
@@ -49,6 +54,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             WaitForRestoredFiles(currentWorkingDirectory, new[] { expectedFile }, caseInsensitive, timeout);
         }
 
+        // TODO: This method expects that expectedFiles will be full paths, not relative to currentWorkingDirectory.  Instead it should use relative paths.
+        //       With the current design, each caller basically uses the form WaitFor*File(dir, Path.Combine(dir, expectedFile)), which is a silly API to use.
         private static string WaitForRestoredFilesHelper(string currentWorkingDirectory, IEnumerable<string> expectedFiles, bool caseInsensitive, int timeout)
         {
             string errorMessage = null;

--- a/test/LibraryManager.IntegrationTest/SuggestedActionTests.cs
+++ b/test/LibraryManager.IntegrationTest/SuggestedActionTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Test.Apex.VisualStudio.Editor;
+using Microsoft.Test.Apex.VisualStudio.Shell;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Web.LibraryManager.IntegrationTest
+{
+    [TestClass]
+    public class SuggestedActionTests : VisualStudioLibmanHostTest
+    {
+        [TestMethod]
+        public void UninstallLibrary_RemovesFilesFromProject()
+        {
+            string withLibrary = @"{
+  ""version"": ""1.0"",
+  ""defaultProvider"": ""cdnjs"",
+  ""libraries"": [
+    {
+      ""library"": ""jquery@3.3.1"",
+      ""destination"": ""wwwroot/UninstallSuggestedAction/files"",
+      ""files"": [ ""jquery.min.js"" ]
+    }
+  ]
+}";
+            string afterUninstall = @"{
+  ""version"": ""1.0"",
+  ""defaultProvider"": ""cdnjs"",
+  ""libraries"": [
+  ]
+}";
+
+            SetManifestContents(withLibrary);
+
+            string restoreFolder = Path.Combine(SolutionRootPath, _projectName, "wwwroot", "UninstallSuggestedAction", "files");
+            Helpers.FileIO.WaitForRestoredFile(restoreFolder, Path.Combine(restoreFolder, "jquery.min.js"), true);
+
+            Editor.Caret.MoveToExpression("jquery");
+            Editor.LightBulb.Verify.IsLightBulbPresent(TimeSpan.FromSeconds(5));
+            // TODO: Use resource string so that this test can run in non-English VS.
+            Editor.LightBulb.GetActiveLightBulb().InvokeByText("Uninstall jquery@3.3.1");
+
+            Verify.Strings.AreEqual(afterUninstall, Editor.Contents.Trim());
+            Helpers.FileIO.WaitForDeletedFile(restoreFolder, Path.Combine(restoreFolder, "jquery.min.js"), true);
+        }
+    }
+}

--- a/test/LibraryManager.IntegrationTest/VisualStudioLibmanHostTests.cs
+++ b/test/LibraryManager.IntegrationTest/VisualStudioLibmanHostTests.cs
@@ -92,6 +92,18 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             }
         }
 
+        /// <summary>
+        /// Sets the contents of the manifest file by editing it in VS
+        /// </summary>
+        protected void SetManifestContents(string contents)
+        {
+            var doc = _libmanConfig.Open();
+            Editor.Selection.SelectAll();
+            Editor.KeyboardCommands.Delete();
+            Editor.Edit.InsertTextInBuffer(contents);
+            doc.Save();
+        }
+
         protected override VisualStudioHostConfiguration GetVisualStudioHostConfiguration()
         {
             VisualStudioHostConfiguration configuration = base.GetVisualStudioHostConfiguration();

--- a/test/LibraryManager.Mocks/HostInteraction.cs
+++ b/test/LibraryManager.Mocks/HostInteraction.cs
@@ -65,9 +65,6 @@ namespace Microsoft.Web.LibraryManager.Mocks
         {
             var absolutePath = new FileInfo(Path.Combine(WorkingDirectory, path));
 
-            if (absolutePath.Exists)
-                return true;
-
             if (!absolutePath.FullName.StartsWith(WorkingDirectory))
                 throw new UnauthorizedAccessException();
 

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Microsoft.Web.LibraryManager.Vsix.Test.csproj
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Microsoft.Web.LibraryManager.Vsix.Test.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Shared/LibraryCommandServiceTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Shared/LibraryCommandServiceTest.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TaskStatusCenter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Moq;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Test.Shared
+{
+    [TestClass]
+    public class LibraryCommandServiceTest
+    {
+        [TestMethod]
+        public async Task UninstallAsync_DeletesFilesFromDisk()
+        {
+            IHostInteraction mockInteraction = new Mocks.HostInteraction();
+            var mockTaskStatusCenterService = new Mock<ITaskStatusCenterService>();
+            mockTaskStatusCenterService.Setup(m => m.CreateTaskHandlerAsync(It.IsAny<string>()))
+                                       .Returns(Task.FromResult(new Mock<ITaskHandler>().Object));
+            var mockDependencies = new Dependencies(mockInteraction, new IProvider[]
+            {
+                new Mocks.Provider(mockInteraction)
+                {
+                    Id = "testProvider",
+                    Catalog = new Mocks.LibraryCatalog(),
+                    Result = new LibraryOperationResult
+                    {
+                        InstallationState = new LibraryInstallationState
+                        {
+                            ProviderId = "testProvider",
+                            Files = new [] { "test.js" },
+                            DestinationPath = "testDestination",
+                        }
+                    },
+                    SupportsLibraryVersions = true,
+                }
+            });
+            var mockDependenciesFactory = new Mock<IDependenciesFactory>();
+            mockDependenciesFactory.Setup(m => m.FromConfigFile(It.IsAny<string>()))
+                                   .Returns(mockDependencies);
+            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(mockDependencies);
+
+            string manifestContents = @"{
+    ""version"": ""1.0"",
+    ""libraries"": [
+        {
+            ""library"": ""test@1.0"",
+            ""provider"": ""testProvider"",
+            ""destination"": ""testDestination""
+        }
+    ]
+}";
+            byte[] manifestBytes = Encoding.Default.GetBytes(manifestContents);
+
+            string configFilePath = Path.Combine(mockInteraction.WorkingDirectory, "libman.json");
+            await mockInteraction.WriteFileAsync("libman.json", () => new MemoryStream(manifestBytes), default(LibraryInstallationState), CancellationToken.None);
+            await mockInteraction.WriteFileAsync(@"testDestination\test.js", () => new MemoryStream(manifestBytes), default(LibraryInstallationState), CancellationToken.None);
+            var solutionEvents = new DefaultSolutionEvents(new Mock<IVsSolution>().Object);
+
+            var ut = new LibraryCommandService(mockDependenciesFactory.Object, mockTaskStatusCenterService.Object, solutionEvents);
+            await ut.UninstallAsync(configFilePath, "test", "1.0", "testProvider", CancellationToken.None);
+
+            Assert.IsFalse(File.Exists(Path.Combine(mockInteraction.WorkingDirectory, "testDestination", "test.js")));
+        }
+    }
+}


### PR DESCRIPTION
This fixes a simple issue (one line, swapping order of parameters) which fixes #441.  Adding a unit test to cover this led to many other changes.

This is also a pre-req to fixing #306, which was filed before the regression was introduced.