### PR TITLE
Fixing 790461 - Libman Install Dialog Install button crashes VS

### DIFF
--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -143,17 +143,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
                     }
                 }
 
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
                 UI.InstallDialog dialog = new UI.InstallDialog(dependencies, _libraryCommandService, configFilePath, target, rootFolder, project);
 
-                var dte = (DTE)Package.GetGlobalService(typeof(SDTE));
-                int hwnd = dte.MainWindow.HWnd;
-                WindowInteropHelper windowInteropHelper = new WindowInteropHelper(dialog);
-
-                // Set visual studio window's handle as the owner of the dialog.
-                // This will remove the dialog from alt-tab list and will not allow the user to switch the dialog box to the background 
-                windowInteropHelper.Owner = new IntPtr(hwnd);
-
-                dialog.ShowDialog();
+                dialog.ShowModal();
 
                 Telemetry.TrackUserTask("Open-InstallDialog");
             }

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -143,8 +143,6 @@ namespace Microsoft.Web.LibraryManager.Vsix
                     }
                 }
 
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
                 UI.InstallDialog dialog = new UI.InstallDialog(dependencies, _libraryCommandService, configFilePath, target, rootFolder, project);
 
                 dialog.ShowModal();

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -216,10 +216,10 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI
         async Task ClickInstallButtonAsync()
         {
             bool isLibraryInstallationStateValid = await IsLibraryInstallationStateValidAsync().ConfigureAwait(false);
+            await Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             if (isLibraryInstallationStateValid)
             {
-                await Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 CloseDialog(true);
                 ViewModel.InstallPackageCommand.Execute(null);
             }


### PR DESCRIPTION
Based on [Bug 790461](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/790461) it seems like `            bool isLibraryInstallationStateValid = await IsLibraryInstallationStateValidAsync().ConfigureAwait(false);
` on line 218 is switching to a background thread after it returns. In the `else` clause below we are accessing `ViewModel` which is a dependency property that requires us to be on the UI thread to access, which crashes VS.