### PR TITLE
Set AutomationProperties.Name for TreeViewItem

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -22,6 +22,7 @@
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
                 <Setter Property="Focusable" Value="False" />
                 <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue"/>
+                <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
             </Style>
         </TreeView.ItemContainerStyle>
         <TreeView.Resources>


### PR DESCRIPTION
Set AutomationProperties.Name for TreeViewItem to fix issue reported by keros accessibility tool.