### PR TITLE
Handle esc key press event when popup is open

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
@@ -295,5 +295,13 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
         {
             LibrarySearchBox.Focus();
         }
+
+        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && Flyout.IsOpen)
+            {
+                LibrarySearchBox.Focus();
+            }
+        }
     }
 }

--- a/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml.cs
@@ -324,5 +324,13 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
         {
             TargetLocationSearchTextBox.Focus();
         }
+
+        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && Flyout.IsOpen)
+            {
+                TargetLocationSearchTextBox.Focus();
+            }
+        }
     }
 }


### PR DESCRIPTION
When popup is open, and esc key is pressed, focus should remain in textbox. 

How was it tested?
- Manual testing
- Ran existing unit and integration tests