### PR TITLE
Handle Shift+Tab correctly for Library and TargetLocation controls

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
@@ -118,9 +118,13 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             switch (e.Key)
             {
                 case Key.Tab:
+                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Shift)
+                    {
+                        LibrarySearchBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+                    }
                     // SelectedItem could be null if the key press came from keyboard navigation and not commit operation.
                     // In this case we will just move the focus to next control.
-                    if (SelectedItem == null)
+                    else if (SelectedItem == null)
                     {
                         LibrarySearchBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
                     }

--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 
         private void HandleKeyPress(object sender, KeyEventArgs e)
         {
-        switch (e.Key)
+            switch (e.Key)
             {
                 case Key.Tab:
                     if (SelectedItem != null)

--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml.cs
@@ -115,25 +115,13 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 
         private void HandleKeyPress(object sender, KeyEventArgs e)
         {
-            switch (e.Key)
+        switch (e.Key)
             {
                 case Key.Tab:
-                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Shift)
-                    {
-                        LibrarySearchBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
-                    }
-                    // SelectedItem could be null if the key press came from keyboard navigation and not commit operation.
-                    // In this case we will just move the focus to next control.
-                    else if (SelectedItem == null)
-                    {
-                        LibrarySearchBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
-                    }
-                    else
+                    if (SelectedItem != null)
                     {
                         CommitSelectionAndMoveFocus();
                     }
-
-                    e.Handled = true;
                     break;
                 case Key.Enter:
                     CommitSelectionAndMoveFocus();

--- a/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml.cs
@@ -142,22 +142,10 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             switch (e.Key)
             {
                 case Key.Tab:
-                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Shift)
-                    {
-                        TargetLocationSearchTextBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
-                    }
-                    // SelectedItem could be null if the key press came from keyboard navigation and not commit operation.
-                    // In this case we will just move the focus to next control.
-                    else if (SelectedItem == null)
-                    {
-                        TargetLocationSearchTextBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
-                    }
-                    else
+                    if (SelectedItem != null)
                     {
                         CommitSelectionAndMoveFocus();
                     }
-
-                    e.Handled = true;
                     break;
                 case Key.Enter:
                     CommitSelectionAndMoveFocus();

--- a/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml.cs
@@ -142,9 +142,13 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             switch (e.Key)
             {
                 case Key.Tab:
+                    if (e.KeyboardDevice.Modifiers == ModifierKeys.Shift)
+                    {
+                        TargetLocationSearchTextBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+                    }
                     // SelectedItem could be null if the key press came from keyboard navigation and not commit operation.
                     // In this case we will just move the focus to next control.
-                    if (SelectedItem == null)
+                    else if (SelectedItem == null)
                     {
                         TargetLocationSearchTextBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
                     }


### PR DESCRIPTION
We want to be able to navigate to previous control when Shift+Tab is pressed when invoked from Library/TargetLocation controls