### PR TITLE
Fix to make TreeViewItems non tabbable

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -20,8 +20,7 @@
         <TreeView.ItemContainerStyle>
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
-                <Setter Property="Focusable" Value="False" />
-                <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue"/>
+                <Setter Property="KeyboardNavigation.TabNavigation" Value="Once"/>
                 <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
             </Style>
         </TreeView.ItemContainerStyle>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -16,7 +16,8 @@
     <TreeView AutomationProperties.Name="{x:Static resources:Text.Files}"
               ItemsSource="{Binding Path=DisplayRoots, Mode=OneWay}"
               VirtualizingPanel.IsVirtualizing="True"
-              KeyboardNavigation.TabNavigation="Continue">
+              KeyboardNavigation.TabNavigation="Continue"
+              PreviewKeyUp="OnPreviewKeyUp">
         <TreeView.ItemContainerStyle>
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
@@ -38,6 +39,7 @@
             <HierarchicalDataTemplate ItemsSource="{Binding Path=Children}" DataType="{x:Type models:PackageItem}">
                 <CheckBox IsChecked="{Binding Path=IsChecked}"
                           AutomationProperties.Name="{x:Static resources:Text.Files}"
+                          Focusable="False"
                           VerticalAlignment="Center">
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
@@ -1,4 +1,7 @@
 ﻿using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Web.LibraryManager.Vsix.UI.Models;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 {
@@ -15,6 +18,21 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new PackageContentsTreeViewAutomationPeer(this);
+        }
+
+        private void OnPreviewKeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Space)
+            {
+                TreeView treeView = (TreeView)sender;
+                PackageItem packageItem = treeView.SelectedItem as PackageItem;
+
+                if (packageItem != null)
+                {
+                    packageItem.IsChecked = !packageItem.IsChecked;
+                    e.Handled = true;
+                }
+            }
         }
     }
 }

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -124,7 +124,8 @@
                 Grid.ColumnSpan="4" 
                 Margin="0 0 0 9"
                 BorderBrush="Black"
-                BorderThickness="1">
+                BorderThickness="1"
+                KeyboardNavigation.TabNavigation="Once">
             <controls:PackageContentsTreeView x:Name="LibraryFilesToInstallTreeView" />
         </Border>
 


### PR DESCRIPTION
As a part of this change verified below:
- Made sure tree view items are non tabbable. User can tab into tree view and use up/down arrow keys to navigate
- Home and end key press events work as expected

