### PR TITLE
Changes to remove _ from library, target location and provider names when narrator is on

### DIFF
--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="Commands\InstallLibraryCommand.cs" />
     <Compile Include="Shared\DefaultSolutionEvents.cs" />
+    <Compile Include="UI\Extensions\RemoveSubstringExtension.cs" />
     <Compile Include="UI\InstallDialogProvider.cs" />
     <Compile Include="UI\Controls\BindingProxy.cs" />
     <Compile Include="UI\Controls\BindLibraryNameToTargetLocation.cs" />

--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml
@@ -8,6 +8,7 @@
              xmlns:resources="clr-namespace:Microsoft.Web.LibraryManager.Vsix.Resources"
              xmlns:search="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Controls.Search"
              xmlns:controls="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Controls"
+             xmlns:extensions="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Extensions"
              x:Name="ThisControl"
              Focusable="True"
              LostFocus="Library_LostFocus">
@@ -18,7 +19,7 @@
     <Grid>
         <!-- Text Entry -->
         <TextBox x:Name="LibrarySearchBox"
-                 AutomationProperties.Name="{x:Static resources:Text.Library}"
+                 AutomationProperties.Name="{extensions:RemoveSubstring {x:Static resources:Text.Library}}"
                  Text="{Binding ElementName=ThisControl,
                                 Path=Text,
                                 Mode=TwoWay,

--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml
@@ -69,6 +69,7 @@
                 </ListBox.ItemTemplate>
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding DisplayText}"/>
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <EventSetter Event="MouseLeftButtonUp" Handler="OnItemCommitGesture" />
                         <EventSetter Event="PreviewKeyDown" Handler="HandleListBoxKeyPress" />

--- a/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
@@ -61,6 +61,7 @@
                 </ListBox.ItemTemplate>
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding DisplayText}"/>
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <EventSetter Event="MouseLeftButtonUp" Handler="OnItemCommitGesture" />
                         <EventSetter Event="PreviewKeyDown" Handler="HandleListBoxKeyPress" />

--- a/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
@@ -7,6 +7,7 @@
              xmlns:resources="clr-namespace:Microsoft.Web.LibraryManager.Vsix.Resources"
              xmlns:search="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Controls.Search"
              xmlns:controls="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Controls"
+             xmlns:extensions="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Extensions"
              x:Name="ThisControl"
              Focusable="True"
              LostFocus="TargetLocation_LostFocus">
@@ -16,7 +17,7 @@
     <Grid>
         <!-- Text Entry -->
         <TextBox x:Name="TargetLocationSearchTextBox"
-                 AutomationProperties.Name="{x:Static resources:Text.TargetLocation}"
+                 AutomationProperties.Name="{extensions:RemoveSubstring {x:Static resources:Text.TargetLocation}}"
                  Text="{Binding ElementName=ThisControl,
                                 Path=Text,
                                 Mode=TwoWay,

--- a/src/LibraryManager.Vsix/UI/Extensions/RemoveSubstringExtension.cs
+++ b/src/LibraryManager.Vsix/UI/Extensions/RemoveSubstringExtension.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Extensions
         public RemoveSubstringExtension(object text, string remove)
         {
             _text = text;
-            _remove = remove;
+            _remove = remove ?? "_";
         }
 
         public override object ProvideValue(IServiceProvider serviceProvider)
@@ -27,7 +27,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Extensions
                 return null;
             }
 
-            string remove = _remove ?? "_";
             string s = null;
 
             MarkupExtension m = _text as MarkupExtension;
@@ -43,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Extensions
 
             if (s != null)
             {
-                return s.Replace(remove, string.Empty);
+                return s.Replace(_remove, string.Empty);
             }
 
             return null;

--- a/src/LibraryManager.Vsix/UI/Extensions/RemoveSubstringExtension.cs
+++ b/src/LibraryManager.Vsix/UI/Extensions/RemoveSubstringExtension.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Windows.Markup;
+
+namespace Microsoft.Web.LibraryManager.Vsix.UI.Extensions
+{
+    [MarkupExtensionReturnType(typeof(string))]
+    internal class RemoveSubstringExtension : MarkupExtension
+    {
+        private object _text;
+        private string _remove;
+
+        public RemoveSubstringExtension(object text)
+            : this(text, null)
+        {
+        }
+
+        public RemoveSubstringExtension(object text, string remove)
+        {
+            _text = text;
+            _remove = remove;
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            if (_text == null)
+            {
+                return null;
+            }
+
+            string remove = _remove ?? "_";
+            string s = null;
+
+            MarkupExtension m = _text as MarkupExtension;
+            if (m != null)
+            {
+                s = m.ProvideValue(serviceProvider) as string;
+            }
+
+            if (s == null)
+            {
+                s = _text as string;
+            }
+
+            if (s != null)
+            {
+                return s.Replace(remove, string.Empty);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -69,7 +69,13 @@
                       ItemsSource="{Binding Providers}" 
                       HorizontalAlignment="Left" 
                       VerticalAlignment="Center"
-                      Width="auto" />
+                      Width="auto">
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Id}"/>
+                    </Style>
+                </ComboBox.ItemContainerStyle>
+            </ComboBox>
             <DockPanel Grid.Row="1" 
                        Grid.Column="1" 
                        LastChildFill="True" 

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -7,6 +7,7 @@
                  xmlns:resources="clr-namespace:Microsoft.Web.LibraryManager.Vsix.Resources"
                  xmlns:controls="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Controls"
                  xmlns:converters="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Converters"
+                 xmlns:extensions="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Extensions"
                  xmlns:models="clr-namespace:Microsoft.Web.LibraryManager.Vsix.UI.Models"
                  xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
                  mc:Ignorable="d" d:DataContext="{d:DesignInstance IsDesignTimeCreatable=False, Type=models:InstallDialogViewModel}"
@@ -58,7 +59,7 @@
                 <AccessText Text="{x:Static resources:Text.Library}" />
             </Label>
             <ComboBox x:Name="ProviderComboBox"
-                      AutomationProperties.Name="{x:Static resources:Text.Provider}"
+                      AutomationProperties.Name="{extensions:RemoveSubstring {x:Static resources:Text.Provider}}"
                       Grid.Row="0"
                       Grid.Column="1"
                       Margin="0 0 0 9"


### PR DESCRIPTION
_ was added when access keys were implemented. This seems to interfere with narrator. Made changes to strip _ for automation names.

How was this tested:
- Manual testing
- Unit and integration tests