### PR TITLE
Added AutomationProperties.Name to completion items

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/Library.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/Library.xaml
@@ -69,6 +69,7 @@
                 </ListBox.ItemTemplate>
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding DisplayText}"/>
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <EventSetter Event="MouseLeftButtonUp" Handler="OnItemCommitGesture" />
                         <EventSetter Event="PreviewKeyDown" Handler="HandleListBoxKeyPress" />

--- a/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/TargetLocation.xaml
@@ -61,6 +61,7 @@
                 </ListBox.ItemTemplate>
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding DisplayText}"/>
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <EventSetter Event="MouseLeftButtonUp" Handler="OnItemCommitGesture" />
                         <EventSetter Event="PreviewKeyDown" Handler="HandleListBoxKeyPress" />

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -69,7 +69,13 @@
                       ItemsSource="{Binding Providers}" 
                       HorizontalAlignment="Left" 
                       VerticalAlignment="Center"
-                      Width="auto" />
+                      Width="auto">
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Id}"/>
+                    </Style>
+                </ComboBox.ItemContainerStyle>
+            </ComboBox>
             <DockPanel Grid.Row="1" 
                        Grid.Column="1" 
                        LastChildFill="True" 


### PR DESCRIPTION
Added AutomationProperties.Name to completion items so that narrator reads the selected item instead of the class name.

Testing:
- Manual testing
- Ran all unit and integration tests


