### PR TITLE
Fix accessibility issue around PackageContentsTreeView control

### DIFF
--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -54,7 +54,11 @@
   <ItemGroup>
     <Compile Include="Commands\InstallLibraryCommand.cs" />
     <Compile Include="Shared\DefaultSolutionEvents.cs" />
+<<<<<<< HEAD
     <Compile Include="UI\Extensions\RemoveSubstringExtension.cs" />
+=======
+    <Compile Include="UI\Converters\CheckBoxAutomationNameConverter.cs" />
+>>>>>>> Fixed issue with treeview item automation name
     <Compile Include="UI\InstallDialogProvider.cs" />
     <Compile Include="UI\Controls\BindingProxy.cs" />
     <Compile Include="UI\Controls\BindLibraryNameToTargetLocation.cs" />

--- a/src/LibraryManager.Vsix/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Vsix/Resources/Text.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Checked.
+        ///   Looks up a localized string similar to Checked {0}.
         /// </summary>
         public static string Checked {
             get {
@@ -380,7 +380,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UnChecked.
+        ///   Looks up a localized string similar to UnChecked {0}.
         /// </summary>
         public static string UnChecked {
             get {

--- a/src/LibraryManager.Vsix/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Vsix/Resources/Text.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checked.
+        /// </summary>
+        public static string Checked {
+            get {
+                return ResourceManager.GetString("Checked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Check for updates.
         /// </summary>
         public static string CheckForUpdates {
@@ -367,6 +376,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         public static string TypeToSearch {
             get {
                 return ResourceManager.GetString("TypeToSearch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UnChecked.
+        /// </summary>
+        public static string UnChecked {
+            get {
+                return ResourceManager.GetString("UnChecked", resourceCulture);
             }
         }
         

--- a/src/LibraryManager.Vsix/Resources/Text.resx
+++ b/src/LibraryManager.Vsix/Resources/Text.resx
@@ -236,9 +236,9 @@ Do you want to continue?</value>
     <value>_Install</value>
   </data>
   <data name="Checked" xml:space="preserve">
-    <value>Checked</value>
+    <value>Checked {0}</value>
   </data>
   <data name="UnChecked" xml:space="preserve">
-    <value>UnChecked</value>
+    <value>UnChecked {0}</value>
   </data>
 </root>

--- a/src/LibraryManager.Vsix/Resources/Text.resx
+++ b/src/LibraryManager.Vsix/Resources/Text.resx
@@ -235,4 +235,10 @@ Do you want to continue?</value>
   <data name="Install" xml:space="preserve">
     <value>_Install</value>
   </data>
+  <data name="Checked" xml:space="preserve">
+    <value>Checked</value>
+  </data>
+  <data name="UnChecked" xml:space="preserve">
+    <value>UnChecked</value>
+  </data>
 </root>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -10,11 +10,11 @@
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance IsDesignTimeCreatable=False, Type=models:InstallDialogViewModel}">
     <UserControl.Resources>
         <converters:BoldingConverter x:Key="BoldingConverter" />
+        <converters:CheckBoxAutomationNameConverter x:Key="CheckBoxAutomationNameConverter" />
         <converters:PackageItemIconConverter x:Key="IconConverter" />
         <converters:VisibleIfNonNullConverter x:Key="VisibleIfNonNullConverter" />
     </UserControl.Resources>
-    <TreeView AutomationProperties.Name="{x:Static resources:Text.Files}"
-              ItemsSource="{Binding Path=DisplayRoots, Mode=OneWay}"
+    <TreeView ItemsSource="{Binding Path=DisplayRoots, Mode=OneWay}"
               VirtualizingPanel.IsVirtualizing="True"
               KeyboardNavigation.TabNavigation="Continue"
               PreviewKeyUp="OnPreviewKeyUp">
@@ -22,7 +22,14 @@
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
                 <Setter Property="KeyboardNavigation.TabNavigation" Value="Once"/>
-                <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
+                <Setter Property="AutomationProperties.Name">
+                    <Setter.Value>
+                        <MultiBinding Converter="{StaticResource CheckBoxAutomationNameConverter}">
+                            <Binding Path="Name"/>
+                            <Binding Path="IsChecked"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
                 <Style.Triggers>
                     <MultiTrigger>
                         <MultiTrigger.Conditions>
@@ -50,7 +57,6 @@
             </Style>
             <HierarchicalDataTemplate ItemsSource="{Binding Path=Children}" DataType="{x:Type models:PackageItem}">
                 <CheckBox IsChecked="{Binding Path=IsChecked}"
-                          AutomationProperties.Name="{x:Static resources:Text.Files}"
                           Focusable="False"
                           VerticalAlignment="Center">
                     <Grid>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -20,8 +20,7 @@
         <TreeView.ItemContainerStyle>
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
-                <Setter Property="Focusable" Value="False" />
-                <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue"/>
+                <Setter Property="KeyboardNavigation.TabNavigation" Value="Once"/>
                 <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
             </Style>
         </TreeView.ItemContainerStyle>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -23,6 +23,11 @@
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
                 <Setter Property="KeyboardNavigation.TabNavigation" Value="Once"/>
                 <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
+                <Style.Triggers>
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter Property="Foreground" Value="White"/>
+                    </Trigger>
+                </Style.Triggers>
             </Style>
         </TreeView.ItemContainerStyle>
         <TreeView.Resources>
@@ -58,7 +63,16 @@
                                 </MultiBinding>
                             </Image.Source>
                         </Image>
-                        <Label Grid.Column="1" Margin="2 0 0 0" Padding="0" VerticalAlignment="Center" Content="{Binding Name}" FontWeight="{Binding Path=IsMain, Converter={StaticResource BoldingConverter}}" />
+                        <Label
+                            Grid.Column="1"
+                            Margin="2 0 0 0"
+                            Padding="0"
+                            VerticalAlignment="Center"
+                            Content="{Binding Name}"
+                            FontWeight="{Binding Path=IsMain, Converter={StaticResource BoldingConverter}}"
+                            Foreground="{Binding Foreground,
+                            RelativeSource={RelativeSource Mode=FindAncestor,
+                                            AncestorType=TreeViewItem}}"/>
                     </Grid>
                 </CheckBox>
             </HierarchicalDataTemplate>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -24,9 +24,16 @@
                 <Setter Property="KeyboardNavigation.TabNavigation" Value="Once"/>
                 <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
                 <Style.Triggers>
-                    <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Foreground" Value="White"/>
-                    </Trigger>
+                    <MultiTrigger>
+                        <MultiTrigger.Conditions>
+                            <Condition Property="IsSelected" Value="True"/>
+                            <Condition Property="IsFocused" Value="True"/>
+                        </MultiTrigger.Conditions>
+                        <MultiTrigger.Setters>
+                            <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+                        </MultiTrigger.Setters>
+                    </MultiTrigger>
                 </Style.Triggers>
             </Style>
         </TreeView.ItemContainerStyle>
@@ -71,8 +78,8 @@
                             Content="{Binding Name}"
                             FontWeight="{Binding Path=IsMain, Converter={StaticResource BoldingConverter}}"
                             Foreground="{Binding Foreground,
-                            RelativeSource={RelativeSource Mode=FindAncestor,
-                                            AncestorType=TreeViewItem}}"/>
+                                                 RelativeSource={RelativeSource Mode=FindAncestor,
+                                                 AncestorType=TreeViewItem}}" />
                     </Grid>
                 </CheckBox>
             </HierarchicalDataTemplate>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -16,7 +16,8 @@
     <TreeView AutomationProperties.Name="{x:Static resources:Text.Files}"
               ItemsSource="{Binding Path=DisplayRoots, Mode=OneWay}"
               VirtualizingPanel.IsVirtualizing="True"
-              KeyboardNavigation.TabNavigation="Continue">
+              KeyboardNavigation.TabNavigation="Continue"
+              PreviewKeyUp="OnPreviewKeyUp">
         <TreeView.ItemContainerStyle>
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
@@ -38,6 +39,7 @@
             <HierarchicalDataTemplate ItemsSource="{Binding Path=Children}" DataType="{x:Type models:PackageItem}">
                 <CheckBox IsChecked="{Binding Path=IsChecked}"
                           AutomationProperties.Name="{x:Static resources:Text.Files}"
+                          Focusable="False"
                           VerticalAlignment="Center">
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
@@ -1,4 +1,7 @@
 ﻿using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Web.LibraryManager.Vsix.UI.Models;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 {
@@ -15,6 +18,21 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new PackageContentsTreeViewAutomationPeer(this);
+        }
+
+        private void OnPreviewKeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Space)
+            {
+                TreeView treeView = (TreeView)sender;
+                PackageItem packageItem = treeView.SelectedItem as PackageItem;
+
+                if (packageItem != null)
+                {
+                    packageItem.IsChecked = !packageItem.IsChecked;
+                    e.Handled = true;
+                }
+            }
         }
     }
 }

--- a/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Windows.Data;
+using Microsoft.Web.LibraryManager.Vsix.Resources;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
 {
@@ -17,11 +18,11 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
 
             if (isChecked)
             {
-                return "Checked" + (string)values[0];
+                return Text.Checked + ' ' + (string)values[0];
             }
             else
             {
-                return "UnChecked" + (string)values[0];
+                return Text.UnChecked + ' ' + (string)values[0];
             }
         }
 

--- a/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
 
             if (isChecked)
             {
-                return Text.Checked + ' ' + (string)values[0];
+                return string.Format(Text.Checked, (string)values[0]);
             }
             else
             {
-                return Text.UnChecked + ' ' + (string)values[0];
+                return string.Format(Text.UnChecked, (string)values[0]);
             }
         }
 

--- a/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
+{
+    internal class CheckBoxAutomationNameConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length != 2 || !(values[0] is string) || !(values[1] is bool))
+            {
+                return null;
+            }
+
+            bool isChecked = (bool)values[1];
+
+            if (isChecked)
+            {
+                return "Checked" + (string)values[0];
+            }
+            else
+            {
+                return "UnChecked" + (string)values[0];
+            }
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -133,7 +133,9 @@
                 BorderBrush="Black"
                 BorderThickness="1"
                 KeyboardNavigation.TabNavigation="Once">
-            <controls:PackageContentsTreeView x:Name="LibraryFilesToInstallTreeView" />
+            <controls:PackageContentsTreeView
+                x:Name="LibraryFilesToInstallTreeView"
+                AutomationProperties.Name="{x:Static resources:Text.Files}" />
         </Border>
 
         <Label Grid.Row="2" 

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -131,7 +131,8 @@
                 Grid.ColumnSpan="4" 
                 Margin="0 0 0 9"
                 BorderBrush="Black"
-                BorderThickness="1">
+                BorderThickness="1"
+                KeyboardNavigation.TabNavigation="Once">
             <controls:PackageContentsTreeView x:Name="LibraryFilesToInstallTreeView" />
         </Border>
 

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -133,9 +133,8 @@
                 BorderBrush="Black"
                 BorderThickness="1"
                 KeyboardNavigation.TabNavigation="Once">
-            <controls:PackageContentsTreeView
-                x:Name="LibraryFilesToInstallTreeView"
-                AutomationProperties.Name="{x:Static resources:Text.Files}" />
+            <controls:PackageContentsTreeView x:Name="LibraryFilesToInstallTreeView"
+                                              AutomationProperties.Name="{x:Static resources:Text.Files}" />
         </Border>
 
         <Label Grid.Row="2" 


### PR DESCRIPTION
Fixed following issues with this pr:
1. Made sure tree view items are non tabbable. User can tab into tree view and use up/down arrow keys to navigate
2. Home and end key press events work as expected
3. When treeview items are selected(via keyboard commands), screen reader should narrate checkbox status, folder status(expanded/collapsed), file name
4. When in choose specific mode , hitting right arrow key should expand node and left arrow should collapse node
5. When selected, treeview item text foreground color should be white
6. Hitting space should toggle treeview item selection