### PR TITLE
Fix icon to show in the Manage Extensions dialog

### DIFF
--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -266,7 +266,10 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <EmbeddedResource Include="Resources\Icon.png" />
+    <Content Include="Resources\Icon.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Microsoft.Web.LibraryManager.Vsix.pkgdef">
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
The icon was not included in the VSIX because it was being embedded in the DLL.  This meant that the vsixmanifest was pointing at a non-existent file, and so VS would fall back to a default icon for LibMan's extension details.

This .png file isn't used elsewhere as an embedded resource; for the context menu items, we use an KnownImageMoniker instead.