### PR TITLE
Set http client to use default proxy settings

### DIFF
--- a/src/LibraryManager/CacheService/WebRequestHandler.cs
+++ b/src/LibraryManager/CacheService/WebRequestHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +20,7 @@ namespace Microsoft.Web.LibraryManager
         private WebRequestHandler()
         {
             HttpClientHandler httpMessageHandler = new HttpClientHandler();
+            httpMessageHandler.Proxy = WebRequest.DefaultWebProxy;
             _httpClient = new HttpClient(httpMessageHandler);
         }
 


### PR DESCRIPTION
By default, HttpMessageHandler seems to not inherit the default proxy settings from the OS.  Setting them to the default from WebRequest seems to fix #399 for me.

I tested this using Fiddler as a proxy with basic auth, but I don't have a configuration to test with NTLM proxy authentication.  Hopefully this will "Just Work" like others have claimed it did for them.