### PR TITLE
Fix issues in en vsct

### DIFF
--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.en.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.en.vsct
@@ -16,7 +16,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>&amp;Knihovna na straně klienta...</ButtonText>
+          <ButtonText>Client-Side &amp;Library...</ButtonText>
         </Strings>
       </Button>
       <!-- Config file -->
@@ -27,7 +27,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Obnovit kni&amp;hovny na straně klienta</ButtonText>
+          <ButtonText>Restore Client-Side &amp;Libraries</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="Clean" priority="0x0200" type="Button">
@@ -35,7 +35,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>&amp;Vyčistit knihovny na straně klienta</ButtonText>
+          <ButtonText>&amp;Clean Client-Side Libraries</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidLibraryManagerPackageCmdSet" id="RestoreOnBuild" priority="0x0300" type="Button">
@@ -44,7 +44,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Při sestavování povolit obnovení knihoven na straně klienta...</ButtonText>
+          <ButtonText>Enable Restore Client-Side Libraries on Build...</ButtonText>
           <LocCanonicalName>ToggleLibraryRestoreOnBuild</LocCanonicalName>
         </Strings>
       </Button>
@@ -56,7 +56,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>&amp;Spravovat knihovny na straně klienta...</ButtonText>
+          <ButtonText>&amp;Manage Client-Side Libraries...</ButtonText>
           <CanonicalName>ManageClientSideLibraries</CanonicalName>
         </Strings>
       </Button>
@@ -68,7 +68,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>&amp;Obnovit knihovny na straně klienta</ButtonText>
+          <ButtonText>&amp;Restore Client-Side Libraries</ButtonText>
           <CanonicalName>RestoreClientSideLibraries</CanonicalName>
         </Strings>
       </Button>


### PR DESCRIPTION
VSCommandTable.en.vsct got messed up and all entries for "en" got replaced by "cs" during loc handback:
https://github.com/aspnet/LibraryManager/pull/464/files

Fixing it up.