### PR TITLE
Fix deserialization of backslashes from VS editor

### DIFF
--- a/src/LibraryManager.Vsix/Json/JsonHelpers.cs
+++ b/src/LibraryManager.Vsix/Json/JsonHelpers.cs
@@ -94,21 +94,32 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             SortedNodeList<Node> children = GetChildren(parent);
 
+            string GetCanonicalizedValue(BlockChildNode m)
+            {
+                if (m.Value is TokenNode value)
+                {
+                    return value.GetCanonicalizedText();
+                }
+                return m.UnquotedValueText;
+            }
+
             foreach (MemberNode child in children.OfType<MemberNode>())
             {
+                // note: the Json parser escapes backslashes in the node's Value text,
+                // so we need to unescape those so that they match the value from the manifest.
                 switch (child.UnquotedNameText)
                 {
                     case ManifestConstants.Provider:
-                        state.ProviderId = child.UnquotedValueText;
+                        state.ProviderId = GetCanonicalizedValue(child);
                         break;
                     case ManifestConstants.Library:
-                        state.LibraryId = child.UnquotedValueText;
+                        state.LibraryId = GetCanonicalizedValue(child);
                         break;
                     case ManifestConstants.Destination:
-                        state.DestinationPath = child.UnquotedValueText;
+                        state.DestinationPath = GetCanonicalizedValue(child);
                         break;
                     case ManifestConstants.Files:
-                        state.Files = (child.Value as ArrayNode)?.Elements.Select(e => e.UnquotedValueText).ToList();
+                        state.Files = (child.Value as ArrayNode)?.Elements.Select(e => GetCanonicalizedValue(e)).ToList();
                         break;
                 }
             }

--- a/test/LibraryManager.IntegrationTest/SuggestedActionTests.cs
+++ b/test/LibraryManager.IntegrationTest/SuggestedActionTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Test.Apex.Services;
 using Microsoft.Test.Apex.VisualStudio.Editor;
 using Microsoft.Test.Apex.VisualStudio.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -44,8 +45,47 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             // TODO: Use resource string so that this test can run in non-English VS.
             Editor.LightBulb.GetActiveLightBulb().InvokeByText("Uninstall jquery@3.3.1");
 
-            Verify.Strings.AreEqual(afterUninstall, Editor.Contents.Trim());
+            // It can take a little while for the editor buffer to get updated, so check for it in a loop
+            WaitFor.IsTrue(() => Editor.Contents.Trim() == afterUninstall, TimeSpan.FromSeconds(1));
             Helpers.FileIO.WaitForDeletedFile(restoreFolder, Path.Combine(restoreFolder, "jquery.min.js"), true);
+        }
+
+        [TestMethod]
+        public void UninstallLibrary_RemoveFilesystemLibrary()
+        {
+            string libraryPath = Path.Combine(SolutionRootPath, "LooseFiles");
+            string libraryPathJson = libraryPath.Replace("\\", "\\\\");
+            string withLibrary = @"{
+  ""version"": ""1.0"",
+  ""libraries"": [
+    {
+      ""library"": """ + libraryPathJson + @""",
+      ""provider"": ""filesystem"",
+      ""destination"": ""wwwroot/UninstallSuggestedAction/files"",
+      ""files"": [ ""filesystem.js"" ]
+    }
+  ]
+}";
+            string afterUninstall = @"{
+  ""version"": ""1.0"",
+  ""libraries"": [
+  ]
+}";
+
+            SetManifestContents(withLibrary);
+
+            string restoreFolder = Path.Combine(SolutionRootPath, _projectName, "wwwroot", "UninstallSuggestedAction", "files");
+            Helpers.FileIO.WaitForRestoredFile(restoreFolder, Path.Combine(restoreFolder, "filesystem.js"), true);
+
+            Editor.Caret.MoveToExpression(@"""library""");
+            Editor.LightBulb.Verify.IsLightBulbPresent(TimeSpan.FromSeconds(5));
+            // TODO: Use resource string so that this test can run in non-English VS.
+            // Note: VS truncates the file path, so find the Uninstall action based on prefix.
+            Editor.LightBulb.GetActiveLightBulb().Actions.Single(a => a.Text.StartsWith("Uninstall")).Invoke();
+
+            // It can take a little while for the editor buffer to get updated, so check for it in a loop
+            WaitFor.IsTrue(() => Editor.Contents.Trim() == afterUninstall, TimeSpan.FromSeconds(1));
+            Helpers.FileIO.WaitForDeletedFile(restoreFolder, Path.Combine(restoreFolder, "filesystem.js"), true);
         }
     }
 }

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/JSONHelpersTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/JSONHelpersTest.cs
@@ -116,5 +116,25 @@ namespace Microsoft.Web.LibraryManager.Test
 
             Assert.AreEqual(0, JsonHelpers.GetChildren(firstToken).Count);
         }
+
+        [TestMethod]
+        public void TryGetInstallationState_PathsContainingBackslashes_ShouldNotOverescape()
+        {
+            string libraryJson = @"{
+  ""library"": ""C:\\libraryPath"",
+  ""provider"": ""test\\provider"",
+  ""destination"": ""lib\\path"",
+  ""files"": [ ""subfolder\\file.js"" ]
+}";
+            var value = JsonNodeParser.Parse(libraryJson).TopLevelValue as ObjectNode;
+
+            JsonHelpers.TryGetInstallationState(value, out Contracts.ILibraryInstallationState state);
+
+            Assert.IsNotNull(state);
+            Assert.AreEqual(@"C:\libraryPath", state.Name);
+            Assert.AreEqual(@"subfolder\file.js", state.Files[0]);
+            Assert.AreEqual(@"test\provider", state.ProviderId);
+            Assert.AreEqual(@"lib\path", state.DestinationPath);
+        }
     }
 }

--- a/test/libman.Test/LibmanInstallTest.cs
+++ b/test/libman.Test/LibmanInstallTest.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
             command.Execute("jquery", "--files", "abc.js");
-            string expectedMessage = @"[LIB018]: ""jquery@3.4.0"" does not contain the following: abc.js
+            string expectedMessage = @"[LIB018]: ""jquery@3.4.1"" does not contain the following: abc.js
 Valid files are core.js, jquery.js, jquery.min.js, jquery.min.map, jquery.slim.js, jquery.slim.min.js, jquery.slim.min.map";
 
             var logger = HostEnvironment.Logger as TestLogger;

--- a/test/libman.Test/LibmanUpdateTest.cs
+++ b/test/libman.Test/LibmanUpdateTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
   ""defaultDestination"": ""wwwroot"",
   ""libraries"": [
     {
-      ""library"": ""jquery@3.4.0"",
+      ""library"": ""jquery@3.4.1"",
       ""files"": [
         ""jquery.min.js"",
         ""jquery.js""
@@ -139,7 +139,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
   ""defaultDestination"": ""wwwroot"",
   ""libraries"": [
     {
-      ""library"": ""jquery@3.4.0"",
+      ""library"": ""jquery@3.4.1"",
       ""files"": [ ""jquery.min.js"", ""jquery.js"" ]
     }
   ]


### PR DESCRIPTION
When we deserialize these values using VS' JSON parser, it adds an extra
level of escaping to the backslashes.  We need to compensate for this when we
compare with values from the LibMan manifest.

This fixes #363 and #306.