### PR TITLE
[UI] Fix issue with cancel button for unpkg provider

### DIFF
--- a/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
@@ -200,16 +200,22 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
                     completionSet.Length = version.Length;
 
                     NpmPackageInfo npmPackageInfo = await NpmPackageInfoCache.GetPackageInfoAsync(name, CancellationToken.None);
-                    foreach (SemanticVersion semVersion in npmPackageInfo.Versions)
-                    {
-                        string versionText = semVersion.ToString();
-                        CompletionItem completionItem = new CompletionItem
-                        {
-                            DisplayText = versionText,
-                            InsertionText = name + "@" + versionText
-                        };
 
-                        completions.Add(completionItem);
+                    IList<SemanticVersion> versions = npmPackageInfo.Versions;
+
+                    if ( versions!= null)
+                    {
+                        foreach (SemanticVersion semVersion in versions)
+                        {
+                            string versionText = semVersion.ToString();
+                            CompletionItem completionItem = new CompletionItem
+                            {
+                                DisplayText = versionText,
+                                InsertionText = name + "@" + versionText
+                            };
+
+                            completions.Add(completionItem);
+                        }
                     }
 
                     completionSet.CompletionType = CompletionSortOrder.Version;

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         }
 
         [TestMethod]
-        public async Task GetLibraryCompletionSetAsync_WithNullNpmPackageInfoVersions()
+        public async Task GetLibraryCompletionSetAsync_WithNullNpmPackageInfoVersions_ReturnsNoCompletions()
         {
             CompletionSet result = await _catalog.GetLibraryCompletionSetAsync("@", 1);
 

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         [TestMethod]
         public async Task GetLibraryCompletionSetAsync_Names()
         {
-            CancellationToken token = CancellationToken.None;
             CompletionSet result = await _catalog.GetLibraryCompletionSetAsync("jquery", 0);
 
             Assert.AreEqual(0, result.Start);
@@ -115,7 +114,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         [Ignore] // Enable it after version completion sorting is committed.
         public async Task GetLibraryCompletionSetAsync_Versions()
         {
-            CancellationToken token = CancellationToken.None;
             CompletionSet result = await _catalog.GetLibraryCompletionSetAsync("jquery@", 7);
 
             Assert.AreEqual(7, result.Start);
@@ -153,6 +151,17 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
             {
                 Assert.AreNotEqual(existing[1], result);
             }
+        }
+
+        [TestMethod]
+        public async Task GetLibraryCompletionSetAsync_WithNullNpmPackageInfoVersions()
+        {
+            CompletionSet result = await _catalog.GetLibraryCompletionSetAsync("@", 1);
+
+            Assert.AreEqual(1, result.Start);
+            Assert.AreEqual(0, result.Length);
+            Assert.AreEqual(0, result.Completions.Count());
+            Assert.AreEqual(CompletionSortOrder.Version, result.CompletionType);
         }
     }
 }


### PR DESCRIPTION
Issue description:
- Invoke libman UI
- Select ‘unpkg’ in the provider combo
- Type ‘@’ character in the ‘Library’ text box.
- Hit cancel button

You will notice that dialog doesn't close. Made a change as a part of this pr to not throw null ref exception and close the dialog when cancel button is hit.

How was this tested?
- Manual testing
- Ran existing unit and integration tests
- Added unit test for this scenario