### PR TITLE
Improve accessibility for committing completions in Install Dialog

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml
@@ -17,6 +17,7 @@
     <Grid>
         <!-- Text Entry -->
         <TextBox x:Name="SearchTextBox"
+                 AutomationProperties.LiveSetting="Assertive"
                  AutomationProperties.Name="{Binding AutomationName}"
                  Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                  TextChanged="SearchTextBox_TextChanged"

--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
                 case Key.Escape:
                     Flyout.IsOpen = false;
                     SearchTextBox.ScrollToEnd();
+                    SelectedItem = null;
                     e.Handled = true;
                     break;
                 case Key.Down:
@@ -146,6 +147,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
                 case Key.Escape:
                     Flyout.IsOpen = false;
                     SearchTextBox.ScrollToEnd();
+                    SelectedItem = null;
                     e.Handled = true;
                     break;
                 case Key.Down:

--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -28,6 +28,20 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             InitializeComponent();
 
             Loaded += HandleLoaded;
+            DataContextChanged += HandleDataContextChanged;
+        }
+
+        private void HandleDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is SearchTextBoxViewModel old)
+            {
+                old.ExternalTextChange -= NotifyScreenReaderOfTextChanged;
+            }
+
+            if (e.NewValue is SearchTextBoxViewModel vm)
+            {
+                vm.ExternalTextChange += NotifyScreenReaderOfTextChanged;
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -35,6 +49,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new TextControlTypeAutomationPeer(this);
+        }
+
+        private void NotifyScreenReaderOfTextChanged(object sender, EventArgs e)
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                UIElementAutomationPeer.FromElement(SearchTextBox).RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            });
         }
 
         private void HandleLoaded(object sender, RoutedEventArgs e)
@@ -85,6 +108,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             }
 
             ViewModel.SearchText = completion.CompletionItem.InsertionText;
+            ViewModel.OnExternalTextChange();
             SearchTextBox.CaretIndex = ViewModel.SearchText.IndexOf(completion.CompletionItem.DisplayText, StringComparison.OrdinalIgnoreCase) + completion.CompletionItem.DisplayText.Length;
             Flyout.IsOpen = false;
             SelectedItem = null;

--- a/src/LibraryManager.Vsix/UI/Models/SearchTextBoxViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/SearchTextBoxViewModel.cs
@@ -33,6 +33,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
             WatermarkText = watermarkText ?? string.Empty;
         }
 
+        /// <summary>
+        /// Event to trigger to notify screen readers when the text has been changed.
+        /// </summary>
+        /// <remarks>
+        /// This is for cases where the text value is changed by a user operation other than an edit.
+        /// For example, changes due to commiting a completion item, or when influenced by changes in another control.
+        /// </remarks>
+        public event EventHandler ExternalTextChange;
+
         public ISearchService SearchService { get; private set; }
         public string SearchText
         {
@@ -75,6 +84,17 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
             }
 
             return Task.FromResult(selectedItem);
+        }
+
+        /// <summary>
+        /// Fire an event to announce to screen readers that the text has been changed.
+        /// </summary>
+        /// <remarks>
+        /// This should be used for non-editing events that modify the value of the text
+        /// </remarks>
+        public void OnExternalTextChange()
+        {
+            ExternalTextChange?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/LibraryManager.Vsix/UI/Models/TargetLocationViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/TargetLocationViewModel.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
                     targetLibrary = targetLibrary.TrimEnd('/');
 
                     SearchText = _lastSuggestedTargetLocation = _baseFolder + targetLibrary + '/';
+                    OnExternalTextChange();
                 }
             }
         }


### PR DESCRIPTION
This addresses 2 accessibility issues:

1. When a user dismisses completion, or types a search text that doesn't match any completions, then hits tab, we will commit the last partially-matching completion item that we remembered from the session.  This can be a very bad experience, as we overwrite a value that the user typed in.

2. When we commit library names, 2 fields are changed but there is no indication given to a screen reader.  After these changes, we will notify when completions are committed (so the user knows the completed value), and also when changing the library name causes the Target Location to be updated.