### PR TITLE
[UI] Fix accessibility issues in treeView

### DIFF
--- a/src/LibraryManager.Vsix/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Vsix/Resources/Text.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Checked {0}.
+        ///   Looks up a localized string similar to Checked {0} {1}.
         /// </summary>
         public static string Checked {
             get {
@@ -160,11 +160,29 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File.
+        /// </summary>
+        public static string File {
+            get {
+                return ResourceManager.GetString("File", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Files:.
         /// </summary>
         public static string Files {
             get {
                 return ResourceManager.GetString("Files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folder.
+        /// </summary>
+        public static string Folder {
+            get {
+                return ResourceManager.GetString("Folder", resourceCulture);
             }
         }
         
@@ -178,7 +196,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Indeterminate {0}.
+        ///   Looks up a localized string similar to Indeterminate {0} {1}.
         /// </summary>
         public static string Indeterminate {
             get {
@@ -416,7 +434,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UnChecked {0}.
+        ///   Looks up a localized string similar to UnChecked {0} {1}.
         /// </summary>
         public static string UnChecked {
             get {

--- a/src/LibraryManager.Vsix/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Vsix/Resources/Text.Designer.cs
@@ -178,6 +178,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Indeterminate {0}.
+        /// </summary>
+        public static string Indeterminate {
+            get {
+                return ResourceManager.GetString("Indeterminate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Install.
         /// </summary>
         public static string Install {

--- a/src/LibraryManager.Vsix/Resources/Text.resx
+++ b/src/LibraryManager.Vsix/Resources/Text.resx
@@ -237,9 +237,11 @@ Do you want to continue?</value>
   </data>
   <data name="Checked" xml:space="preserve">
     <value>Checked {0} {1}</value>
+    <comment>{0} indicates PackageItemType, which could be a file or a folder. {1} is the name of the file or folder</comment>
   </data>
   <data name="UnChecked" xml:space="preserve">
     <value>UnChecked {0} {1}</value>
+    <comment>{0} indicates PackageItemType, which could be a file or a folder. {1} is the name of the file or folder</comment>
   </data>
   <data name="SuggestedAction_Update_Prerelease" xml:space="preserve">
     <value>Pre-release: {0}</value>
@@ -253,6 +255,7 @@ Do you want to continue?</value>
   </data>
   <data name="Indeterminate" xml:space="preserve">
     <value>Indeterminate {0} {1}</value>
+    <comment>{0} indicates PackageItemType, which could be a file or a folder. {1} is the name of the file or folder</comment>
   </data>
   <data name="File" xml:space="preserve">
     <value>File</value>

--- a/src/LibraryManager.Vsix/Resources/Text.resx
+++ b/src/LibraryManager.Vsix/Resources/Text.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -250,5 +250,8 @@ Do you want to continue?</value>
   <data name="SuggestedAction_Update_Title" xml:space="preserve">
     <value>Update Library</value>
     <comment>Title for SuggestedAction set</comment>
+  </data>
+  <data name="Indeterminate" xml:space="preserve">
+    <value>Indeterminate {0}</value>
   </data>
 </root>

--- a/src/LibraryManager.Vsix/Resources/Text.resx
+++ b/src/LibraryManager.Vsix/Resources/Text.resx
@@ -236,10 +236,10 @@ Do you want to continue?</value>
     <value>_Install</value>
   </data>
   <data name="Checked" xml:space="preserve">
-    <value>Checked {0}</value>
+    <value>Checked {0} {1}</value>
   </data>
   <data name="UnChecked" xml:space="preserve">
-    <value>UnChecked {0}</value>
+    <value>UnChecked {0} {1}</value>
   </data>
   <data name="SuggestedAction_Update_Prerelease" xml:space="preserve">
     <value>Pre-release: {0}</value>
@@ -252,6 +252,12 @@ Do you want to continue?</value>
     <comment>Title for SuggestedAction set</comment>
   </data>
   <data name="Indeterminate" xml:space="preserve">
-    <value>Indeterminate {0}</value>
+    <value>Indeterminate {0} {1}</value>
+  </data>
+  <data name="File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Folder" xml:space="preserve">
+    <value>Folder</value>
   </data>
 </root>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -24,6 +24,7 @@
                 <Setter Property="AutomationProperties.Name">
                     <Setter.Value>
                         <MultiBinding Converter="{StaticResource CheckBoxAutomationNameConverter}">
+                            <Binding Path="ItemTypeInFileDirectoryView"/>
                             <Binding Path="Name"/>
                             <Binding Path="IsChecked"/>
                         </MultiBinding>

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -16,7 +16,7 @@
     </UserControl.Resources>
     <TreeView ItemsSource="{Binding Path=DisplayRoots, Mode=OneWay}"
               VirtualizingPanel.IsVirtualizing="True"
-               BorderThickness="0"
+              BorderThickness="0"
               PreviewKeyUp="OnPreviewKeyUp">
         <TreeView.ItemContainerStyle>
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -16,13 +16,11 @@
     </UserControl.Resources>
     <TreeView ItemsSource="{Binding Path=DisplayRoots, Mode=OneWay}"
               VirtualizingPanel.IsVirtualizing="True"
-              KeyboardNavigation.TabNavigation="Continue"
-              BorderThickness="0"
+               BorderThickness="0"
               PreviewKeyUp="OnPreviewKeyUp">
         <TreeView.ItemContainerStyle>
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">
                 <Setter Property="IsExpanded" Value="{Binding Path=IsExpanded, Mode=TwoWay}" />
-                <Setter Property="KeyboardNavigation.TabNavigation" Value="Once"/>
                 <Setter Property="AutomationProperties.Name">
                     <Setter.Value>
                         <MultiBinding Converter="{StaticResource CheckBoxAutomationNameConverter}">

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml
@@ -17,6 +17,7 @@
     <TreeView ItemsSource="{Binding Path=DisplayRoots, Mode=OneWay}"
               VirtualizingPanel.IsVirtualizing="True"
               KeyboardNavigation.TabNavigation="Continue"
+              BorderThickness="0"
               PreviewKeyUp="OnPreviewKeyUp">
         <TreeView.ItemContainerStyle>
             <Style TargetType="{x:Type TreeViewItem}" d:DataContext="{d:DesignInstance Type=TreeViewItem, IsDesignTimeCreatable=False}">

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
@@ -33,6 +33,17 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
                     e.Handled = true;
                 }
             }
+            else if (e.Key == Key.Tab)
+            {
+                TreeView treeView = (TreeView)sender;
+                TreeViewItem topTreeViewItem = treeView.ItemContainerGenerator.ContainerFromIndex(0) as TreeViewItem;
+
+                if (topTreeViewItem != null)
+                {
+                    topTreeViewItem.IsSelected = true;
+                    e.Handled = true;
+                }
+            }
         }
     }
 }

--- a/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
@@ -9,10 +9,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values == null || values.Length != 3 || !(values[0] is string))
-            {
-                return null;
-            }
+            ValidateInputs(values);
 
             if (values[2] == null)
             {
@@ -28,6 +25,24 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
             else
             {
                 return string.Format(Text.UnChecked, (string)values[0], (string)values[1]);
+            }
+        }
+
+        private void ValidateInputs(object[] values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            if (values.Length != 3)
+            {
+                throw new ArgumentOutOfRangeException(nameof(values), $"{nameof(values)} length must be 3");
+            }
+
+            if (!(values[0] is string))
+            {
+                throw new ArgumentException(string.Format("{0} is not a string", values[0]));
             }
         }
 

--- a/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
@@ -9,9 +9,14 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values == null || values.Length != 2 || !(values[0] is string) || !(values[1] is bool))
+            if (values == null || values.Length != 2 || !(values[0] is string))
             {
                 return null;
+            }
+
+            if (values[1] == null)
+            {
+                return string.Format(Text.Indeterminate, (string)values[0]);
             }
 
             bool isChecked = (bool)values[1];

--- a/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
@@ -9,25 +9,25 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values == null || values.Length != 2 || !(values[0] is string))
+            if (values == null || values.Length != 3 || !(values[0] is string))
             {
                 return null;
             }
 
-            if (values[1] == null)
+            if (values[2] == null)
             {
-                return string.Format(Text.Indeterminate, (string)values[0]);
+                return string.Format(Text.Indeterminate, (string)values[0], (string)values[1]);
             }
 
-            bool isChecked = (bool)values[1];
+            bool isChecked = (bool)values[2];
 
             if (isChecked)
             {
-                return string.Format(Text.Checked, (string)values[0]);
+                return string.Format(Text.Checked, (string)values[0], (string)values[1]);
             }
             else
             {
-                return string.Format(Text.UnChecked, (string)values[0]);
+                return string.Format(Text.UnChecked, (string)values[0], (string)values[1]);
             }
         }
 

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml
@@ -119,14 +119,12 @@
                          Margin="0 0 0 9"
                          GroupName="FilesToInstall"
                          Content="{x:Static resources:Text.IncludeAllLibraryFiles}"
-                         Checked="IncludeAllLibraryFilesRb_Checked"
                          IsChecked="{Binding LibraryFilesToInstall,
                                              Mode=TwoWay,
                                              Converter={StaticResource EnumToBoolConverter},
                                              ConverterParameter=InstallAllLibraryFiles}" />
             <RadioButton Content="{x:Static resources:Text.ChooseSpecificFiles}"
                          GroupName="FilesToInstall"
-                         Checked="ChooseSpecificFilesRb_Checked"
                          IsChecked="{Binding LibraryFilesToInstall,
                                              Mode=TwoWay,
                                              Converter={StaticResource EnumToBoolConverter},

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -62,16 +62,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI
             FocusManager.SetFocusedElement(LibrarySearchBox, LibrarySearchBox);
         }
 
-        private void IncludeAllLibraryFilesRb_Checked(object sender, RoutedEventArgs e)
-        {
-            LibraryFilesToInstallTreeView.Visibility = Visibility.Visible;
-        }
-
-        private void ChooseSpecificFilesRb_Checked(object sender, RoutedEventArgs e)
-        {
-            LibraryFilesToInstallTreeView.IsEnabled = true;
-        }
-
         private void ProviderComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             // User chose to reset provider. So we need to reset all controls to initial state.

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI
 
         private void IncludeAllLibraryFilesRb_Checked(object sender, RoutedEventArgs e)
         {
-            LibraryFilesToInstallTreeView.IsEnabled = false;
+            LibraryFilesToInstallTreeView.Visibility = Visibility.Visible;
         }
 
         private void ChooseSpecificFilesRb_Checked(object sender, RoutedEventArgs e)

--- a/src/LibraryManager.Vsix/UI/Models/PackageItem.cs
+++ b/src/LibraryManager.Vsix/UI/Models/PackageItem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Web.LibraryManager.Vsix.Resources;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 {
@@ -104,6 +105,21 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
         {
             get { return _itemType; }
             set { Set(ref _itemType, value); }
+        }
+
+        public string ItemTypeInFileDirectoryView
+        {
+            get
+            {
+                if (ItemType == PackageItemType.Folder)
+                {
+                    return Text.Folder;
+                }
+                else
+                {
+                    return Text.File;
+                }
+            }
         }
 
         public string Name

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
@@ -21,6 +21,30 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Converters
         }
 
         [TestMethod]
+        public void Convert_WithInputsLessThanThree_ReturnsNull()
+        {
+            CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
+
+            object[] values = new object[] { Text.File };
+
+            object result = checkBoxAutomationNameConverter.Convert(values, null, null, null);
+
+            Assert.AreEqual(null, result);
+        }
+
+        [TestMethod]
+        public void Convert_WithNonStringFirstValue_ReturnsNull()
+        {
+            CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
+
+            object[] values = new object[] { 2 , "jquery.min.js" , null};
+
+            object result = checkBoxAutomationNameConverter.Convert(values, null, null, null);
+
+            Assert.AreEqual(null, result);
+        }
+
+        [TestMethod]
         public void Convert_WithNulIsCheckedValue_ReturnsStringWithIndeterminateText()
         {
             CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Vsix.Resources;
 using Microsoft.Web.LibraryManager.Vsix.UI.Converters;
@@ -11,37 +12,32 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Converters
     public class CheckBoxAutomationNameConverterTests
     {
         [TestMethod]
-        public void Convert_WithNullValues_ReturnsNull()
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Convert_WithNullValues_ThrowsArgumentNullException()
         {
             CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
 
-            object result = checkBoxAutomationNameConverter.Convert(null, null, null, null);
-
-            Assert.AreEqual(null, result);
+            _ = checkBoxAutomationNameConverter.Convert(null, null, null, null);
         }
 
         [TestMethod]
-        public void Convert_WithInputsLessThanThree_ReturnsNull()
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Convert_WithInputsLessThanThree_ThrowsArgumentOutOfRangeException()
         {
             CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
-
             object[] values = new object[] { Text.File };
 
-            object result = checkBoxAutomationNameConverter.Convert(values, null, null, null);
-
-            Assert.AreEqual(null, result);
+            _ = checkBoxAutomationNameConverter.Convert(values, null, null, null);
         }
 
         [TestMethod]
-        public void Convert_WithNonStringFirstValue_ReturnsNull()
+        [ExpectedException(typeof(ArgumentException))]
+        public void Convert_WithNonStringFirstValue_ThrowsArgumentException()
         {
             CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
-
             object[] values = new object[] { 2 , "jquery.min.js" , null};
 
-            object result = checkBoxAutomationNameConverter.Convert(values, null, null, null);
-
-            Assert.AreEqual(null, result);
+            _ = checkBoxAutomationNameConverter.Convert(values, null, null, null);
         }
 
         [TestMethod]

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Vsix.Resources;
+using Microsoft.Web.LibraryManager.Vsix.UI.Converters;
+
+namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Converters
+{
+    [TestClass]
+    public class CheckBoxAutomationNameConverterTests
+    {
+        [TestMethod]
+        public void Convert_WithNullValues_ReturnsNull()
+        {
+            CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
+
+            object result = checkBoxAutomationNameConverter.Convert(null, null, null, null);
+
+            Assert.AreEqual(null, result);
+        }
+
+        [TestMethod]
+        public void Convert_WithNulIsCheckedValue_ReturnsStringWithIndeterminateText()
+        {
+            CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
+
+            string fileName = "jquery.min.js";
+            object[] values = new object[] { Text.File, fileName, null};
+            object result = checkBoxAutomationNameConverter.Convert(values, null, null, null);
+
+            string expected = string.Format(Text.Indeterminate, Text.File, fileName);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Convert_WithCheckedState_ReturnsStringWithCheckedText()
+        {
+            CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
+
+            string fileName = "jquery.min.js";
+            object[] values = new object[] { Text.File, fileName, true };
+            object result = checkBoxAutomationNameConverter.Convert(values, null, null, null);
+
+            string expected = string.Format(Text.Checked, Text.File, fileName);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Convert_WithUnCheckedState_ReturnsStringWithUnCheckedText()
+        {
+            CheckBoxAutomationNameConverter checkBoxAutomationNameConverter = new CheckBoxAutomationNameConverter();
+
+            string fileName = "jquery.min.js";
+            object[] values = new object[] { Text.File, fileName, false };
+            object result = checkBoxAutomationNameConverter.Convert(values, null, null, null);
+
+            string expected = string.Format(Text.UnChecked, Text.File, fileName);
+            Assert.AreEqual(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Changes in this pr include:
- Tabbing into treeView will not set focus and select the first item 
- Updated CheckBoxNameAutomationConverter to include Intermediate state of checkBox. Also made changes so that narrator specifies whether folder/file is selected
- Reduce border thickness
- TreeView should is not accessible when IncludeAllLibraryFiles option is selected
- Added new resource strings
- Added unit tests for CheckBoxNameAutomationConverter 

