### PR TITLE
Fix for #395 (internally tracked as Bug 936856)

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
                 {
                     CompletionSet completionSet = await ViewModel.GetCompletionSetAsync(SearchTextBox.CaretIndex);
 
-                    if (completionSet.Equals(null) || !completionSet.Completions.Any())
+                    if (completionSet.Completions == null || !completionSet.Completions.Any())
                     {
                         Flyout.IsOpen = false;
                         return;


### PR DESCRIPTION
Apprently throwing unhandled exception from event handlers (at least from this one) leave WPF in a bad state. Not sure what's a good generic way of handling it, but this fix addresses the forward slash issue (in that case we were getting CompletionSet struct with Completion list set to null). Also removing a check for null of the struct itself. It's a struct. That method will always return false. 