### PR TITLE
Fixes file permission issues on Linux and MacOS

### DIFF
--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,6 +43,18 @@ namespace Microsoft.Web.LibraryManager.Contracts
             }
             else
             {
+                string originalTempFileName = tempFileName;
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    // Temp files created on Linux and MacOS by Path.GetTempFileName() will have 600 permissions.
+                    // We want 664 permissions (read permission for all). So rather than using the orignial temp file,
+                    // we will append suffix to its name, which in practical terms still guarantees a unique temp file but
+                    // will have the default 644 permissions when we write to that file.
+                    // See issue https://github.com/aspnet/LibraryManager/issues/475
+                    tempFileName += ".txt";
+                }
+
                 result = await WriteToFileAsync(tempFileName, sourceStream, cancellationToken).ConfigureAwait(false);
 
                 if (result)
@@ -52,19 +65,29 @@ namespace Microsoft.Web.LibraryManager.Contracts
                 // Clean up temp file if we didn't move it to the desination file successfully
                 if (!result)
                 {
-                    try
-                    {
-                        DeleteFiles(new string[] { tempFileName });
-                    }
-                    catch
-                    {
-                        Debug.Fail($"Could not clean up temporary file {tempFileName}");
-                        // Don't fail the operation if we couldn't clean up temporary file
-                    }
+                    SafeDeleteTempFile(tempFileName);
+                }
+
+                if (tempFileName != originalTempFileName)
+                {
+                    SafeDeleteTempFile(originalTempFileName);
                 }
             }
 
             return result;
+        }
+
+        private static void SafeDeleteTempFile(string tempFileName)
+        {
+            try
+            {
+                DeleteFiles(new string[] { tempFileName });
+            }
+            catch
+            {
+                Debug.Fail($"Could not clean up temporary file {tempFileName}");
+                // Don't fail the operation if we couldn't clean up temporary file
+            }
         }
 
         /// <summary>

--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
                     // we will append suffix to its name, which in practical terms still guarantees a unique temp file but
                     // will have the default 644 permissions when we write to that file.
                     // See issue https://github.com/aspnet/LibraryManager/issues/475
-                    tempFileName += ".txt";
+                    tempFileName += ".temp";
                 }
 
                 result = await WriteToFileAsync(tempFileName, sourceStream, cancellationToken).ConfigureAwait(false);
@@ -65,29 +65,16 @@ namespace Microsoft.Web.LibraryManager.Contracts
                 // Clean up temp file if we didn't move it to the desination file successfully
                 if (!result)
                 {
-                    SafeDeleteTempFile(tempFileName);
+                    DeleteFileFromDisk(tempFileName);
                 }
 
                 if (tempFileName != originalTempFileName)
                 {
-                    SafeDeleteTempFile(originalTempFileName);
+                    DeleteFileFromDisk(originalTempFileName);
                 }
             }
 
             return result;
-        }
-
-        private static void SafeDeleteTempFile(string tempFileName)
-        {
-            try
-            {
-                DeleteFiles(new string[] { tempFileName });
-            }
-            catch
-            {
-                Debug.Fail($"Could not clean up temporary file {tempFileName}");
-                // Don't fail the operation if we couldn't clean up temporary file
-            }
         }
 
         /// <summary>

--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
                     // Temp files created on Linux and MacOS by Path.GetTempFileName() will have 600 permissions.
                     // We want 664 permissions (read permission for all). So rather than using the orignial temp file,
                     // we will append suffix to its name, which in practical terms still guarantees a unique temp file but
-                    // will have the default 644 permissions when we write to that file.
+                    // will have the default 664 permissions when we write to that file.
                     // See issue https://github.com/aspnet/LibraryManager/issues/475
                     tempFileName += ".temp";
                 }


### PR DESCRIPTION
Fixes issue #475. The problem here was that we first write downloaded library to a temp file, and then copy it to the final destination. That by itself is fine, but on Linux and MacOS Path.GetTempFileName() create a temp file with permission 600, which causes issues on publishing (since read permission is missing for everyone other than the owner). Working around it by creating and writing to a slightly modified temp file name that will still be unique, but wasn't originally created as a temp file by mkstemps, so it won't have 600 permissions and instead will have the desired 664 permissions. 