### PR TITLE
Refactor UnkpgCatalog and JsDelivrCatalog for testability

### DIFF
--- a/src/LibraryManager/Helpers/Extensions.cs
+++ b/src/LibraryManager/Helpers/Extensions.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Web.LibraryManager
         {
             JObject result = null;
 
-            using (Stream stream = await WebRequestHandler.Instance.GetStreamAsync(url, cancellationToken))
+            using (Stream stream = await webRequestHandler.GetStreamAsync(url, cancellationToken))
             {
                 using (StreamReader reader = new StreamReader(stream))
                 {

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
         public const string IdText = "unpkg";
         public const string DownloadUrlFormat = "https://unpkg.com/{0}@{1}/{2}";
 
+        private CacheService _cacheService;
+        private ILibraryCatalog _catalog;
+
         public UnpkgProvider(IHostInteraction hostInteraction)
         {
             HostInteraction = hostInteraction;
@@ -30,12 +33,11 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 
         public IHostInteraction HostInteraction { get; }
 
-        private CacheService _cacheService;
-        private ILibraryCatalog _catalog;
+        private ILibraryNamingScheme LibraryNamingScheme { get; } = new VersionedLibraryNamingScheme();
 
         public ILibraryCatalog GetCatalog()
         {
-            return _catalog ?? (_catalog = new UnpkgCatalog(this));
+            return _catalog ?? (_catalog = new UnpkgCatalog(Id, LibraryNamingScheme, HostInteraction.Logger, WebRequestHandler.Instance));
         }
 
         // TODO: {alexgav} Could got to a command provider base class

--- a/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
+++ b/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
         public const string DownloadUrlFormat = "https://cdn.jsdelivr.net/npm/{0}@{1}/{2}";
         public const string DownloadUrlFormatGH = "https://cdn.jsdelivr.net/gh/{0}@{1}/{2}";
 
+        private readonly CacheService _cacheService;
+        private ILibraryCatalog _catalog;
+
         public JsDelivrProvider(IHostInteraction hostInteraction)
         {
             HostInteraction = hostInteraction;
@@ -30,12 +33,11 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
 
         public IHostInteraction HostInteraction { get; }
 
-        private CacheService _cacheService;
-        private ILibraryCatalog _catalog;
+        private ILibraryNamingScheme LibraryNamingScheme { get; } = new VersionedLibraryNamingScheme();
 
         public ILibraryCatalog GetCatalog()
         {
-            return _catalog ?? (_catalog = new JsDelivrCatalog(this));
+            return _catalog ?? (_catalog = new JsDelivrCatalog(Id, LibraryNamingScheme, HostInteraction.Logger, WebRequestHandler.Instance));
         }
         
         internal string CacheFolder

--- a/test/LibraryManager.Mocks/WebRequestHandler.cs
+++ b/test/LibraryManager.Mocks/WebRequestHandler.cs
@@ -1,4 +1,9 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +16,8 @@ namespace Microsoft.Web.LibraryManager.Mocks
     /// </summary>
     public class WebRequestHandler : IWebRequestHandler
     {
+        private Dictionary<string, string> _arrangedResponses = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
         /// Returns a Stream for testing purposes
         /// </summary>
@@ -20,9 +27,28 @@ namespace Microsoft.Web.LibraryManager.Mocks
         public Task<Stream> GetStreamAsync(string url, CancellationToken cancellationToken)
         {
             UnicodeEncoding uniEncoding = new UnicodeEncoding();
-            byte[] content = uniEncoding.GetBytes("Stream content for test");
+            string responseText = "Stream content for test";
+            if (_arrangedResponses.ContainsKey(url))
+            {
+                responseText = _arrangedResponses[url];
+            }
+
+            byte[] content = Encoding.Default.GetBytes(responseText);
 
             return Task.FromResult<Stream>( new MemoryStream(content));
+        }
+
+        /// <summary>
+        /// Register a prerecorded response for a specified URL
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="responseContent"></param>
+        /// <returns></returns>
+        public WebRequestHandler ArrangeResponse(string url, string responseContent)
+        {
+            _arrangedResponses.Add(url, responseContent);
+
+            return this;
         }
     }
 }

--- a/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrCatalogTest.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
-using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.jsDelivr;
 
 namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
@@ -18,94 +15,93 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
     [TestClass]
     public class JsDelivrCatalogTest
     {
-        private JsDelivrCatalog _catalog;
-
-        [TestInitialize]
-        public void Setup()
+        private static JsDelivrCatalog SetupCatalog(IWebRequestHandler webRequestHandler = null)
         {
-            _catalog = new JsDelivrCatalog(JsDelivrProvider.IdText,
-                                           new VersionedLibraryNamingScheme(),
-                                           new Mocks.Logger(),
-                                           new Mocks.WebRequestHandler());
+            return new JsDelivrCatalog(JsDelivrProvider.IdText,
+                                       new VersionedLibraryNamingScheme(),
+                                       new Mocks.Logger(),
+                                       webRequestHandler ?? new Mocks.WebRequestHandler());
         }
 
         [TestMethod]
         public async Task SearchAsync_Success()
         {
             string searchTerm = "jquery";
-            CancellationToken token = CancellationToken.None;
+            JsDelivrCatalog sut = SetupCatalog();
 
-            IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync(searchTerm, 1, token);
+            IReadOnlyList<ILibraryGroup> absolute = await sut.SearchAsync(searchTerm, 1, CancellationToken.None);
             Assert.AreEqual(100, absolute.Count);
-            IEnumerable<string> libraryVersions = await absolute[0].GetLibraryVersions(token);
-            Assert.IsTrue(libraryVersions.Any());
-
-            ILibrary library = await _catalog.GetLibraryAsync("jquery", libraryVersions.First(), token);
-            Assert.IsTrue(library.Files.Count > 0);
-            Assert.AreEqual("jquery", library.Name);
-            Assert.AreEqual(0, library.Files.Count(f => f.Value));
-            Assert.IsNotNull(library.Name);
-            Assert.IsNotNull(library.Version);
-            Assert.AreEqual(JsDelivrProvider.IdText, library.ProviderId);
+            IEnumerable<string> libraryVersions = await absolute[0].GetLibraryVersions(CancellationToken.None);
+            CollectionAssert.Contains(libraryVersions.ToList(), "3.4.1");
         }
 
         [TestMethod]
         public async Task SearchAsync_NoHits()
         {
-            CancellationToken token = CancellationToken.None;
             // The search service is surprisingly flexible for finding full-text matches, so this
             // gibberish string was determined manually.
             string searchTerm = "*9(_-zv_";
+            JsDelivrCatalog sut = SetupCatalog();
 
-            IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync(searchTerm, 1, token);
+            IReadOnlyList<ILibraryGroup> absolute = await sut.SearchAsync(searchTerm, 1, CancellationToken.None);
+
             Assert.AreEqual(0, absolute.Count);
         }
 
         [TestMethod]
         public async Task SearchAsync_EmptyString()
         {
-            CancellationToken token = CancellationToken.None;
-            IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync("", 1, token);
+            JsDelivrCatalog sut = SetupCatalog();
+
+            IReadOnlyList<ILibraryGroup> absolute = await sut.SearchAsync("", 1, CancellationToken.None);
+
             Assert.AreEqual(0, absolute.Count);
         }
 
         [TestMethod]
         public async Task SearchAsync_NullString()
         {
-            CancellationToken token = CancellationToken.None;
-            IReadOnlyList<ILibraryGroup> absolute = await _catalog.SearchAsync(null, 1, token);
+            JsDelivrCatalog sut = SetupCatalog();
+
+            IReadOnlyList<ILibraryGroup> absolute = await sut.SearchAsync(null, 1, CancellationToken.None);
+
             Assert.AreEqual(0, absolute.Count);
         }
 
         [TestMethod]
         public async Task GetLibraryAsync_Success()
         {
+            Mocks.WebRequestHandler fakeRequestHandler = new Mocks.WebRequestHandler().SetupFiles("jquery@3.3.1", "jquery/jquery@3.3.1");
+            JsDelivrCatalog sut = SetupCatalog(fakeRequestHandler);
+
             CancellationToken token = CancellationToken.None;
-            ILibrary library = await _catalog.GetLibraryAsync("jquery", "3.3.1", token);
+            ILibrary library = await sut.GetLibraryAsync("jquery", "3.3.1", token);
 
             Assert.IsNotNull(library);
             Assert.AreEqual("jquery", library.Name);
             Assert.AreEqual("3.3.1", library.Version);
 
-            ILibrary libraryGH = await _catalog.GetLibraryAsync("jquery/jquery", "3.3.1", token);
+            ILibrary libraryGH = await sut.GetLibraryAsync("jquery/jquery", "3.3.1", token);
 
             Assert.IsNotNull(libraryGH);
             Assert.AreEqual("jquery/jquery", libraryGH.Name);
             Assert.AreEqual("3.3.1", libraryGH.Version);
         }
 
-        [TestMethod, ExpectedException(typeof(InvalidLibraryException))]
+        [TestMethod]
         public async Task GetLibraryAsync_InvalidLibraryId()
         {
-            CancellationToken token = CancellationToken.None;
-            ILibrary library = await _catalog.GetLibraryAsync("invalid_id", "", token);
+            JsDelivrCatalog sut = SetupCatalog();
+
+            await Assert.ThrowsExceptionAsync<InvalidLibraryException>(() => sut.GetLibraryAsync("invalid_id", "", CancellationToken.None));
         }
 
         [TestMethod]
         public async Task GetLibraryCompletionSetAsync_Names()
         {
-            CancellationToken token = CancellationToken.None;
-            CompletionSet result = await _catalog.GetLibraryCompletionSetAsync("jquery", 0);
+            JsDelivrCatalog sut = SetupCatalog();
+
+            CompletionSet result = await sut.GetLibraryCompletionSetAsync("jquery", 0);
 
             Assert.AreEqual(0, result.Start);
             Assert.AreEqual(6, result.Length);
@@ -116,10 +112,12 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
 
         [TestMethod]
         [Ignore] // Enable it after version completion sorting is committed.
+                 // TODO: Also add a test for GitHub version completion
         public async Task GetLibraryCompletionSetAsync_Versions()
         {
-            CancellationToken token = CancellationToken.None;
-            CompletionSet result = await _catalog.GetLibraryCompletionSetAsync("jquery@", 7);
+            JsDelivrCatalog sut = SetupCatalog();
+
+            CompletionSet result = await sut.GetLibraryCompletionSetAsync("jquery@", 7);
 
             Assert.AreEqual(7, result.Start);
             Assert.AreEqual(0, result.Length);
@@ -131,42 +129,58 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
         [TestMethod]
         public async Task GetLatestVersion_LatestExist()
         {
-            CancellationToken token = CancellationToken.None;
-            const string libraryId = "bootstrap@3.3.0";
-            string result = await _catalog.GetLatestVersion(libraryId, false, token);
+            const string libraryId = "fakeLib@3.3.0";
+            Mocks.WebRequestHandler fakeHandler = new Mocks.WebRequestHandler().SetupVersions("fakeLib", "fake/fakeLib");
+            JsDelivrCatalog sut = SetupCatalog(fakeHandler);
 
-            // It can return null value.
-            if (result != null)
-            {
-                string[] existing = libraryId.Split('@');
-                Assert.AreNotEqual(existing[1], result);
-            }
+            string result = await sut.GetLatestVersion(libraryId, false, CancellationToken.None);
 
-            const string libraryIdGH = "twbs/bootstrap@3.3.0";
-            string resultGH = await _catalog.GetLatestVersion(libraryIdGH, false, token);
+            Assert.AreEqual("1.0.0", result);
 
-            // It can return null value.
-            if (resultGH != null)
-            {
-                string[] existing = libraryIdGH.Split('@');
-                Assert.AreNotEqual(existing[1], resultGH);
-            }
+            // TODO: A new test should be added for when the tags are missing.  This is passing because the fake
+            //       data is as expected.  However, real data does not include the tags and would return null.
+            //       The original test implementation checked for null and didn't assert anything in that case.
+            const string libraryIdGH = "fake/fakeLib@3.3.0";
+            string resultGH = await sut.GetLatestVersion(libraryIdGH, false, CancellationToken.None);
+
+            Assert.AreEqual("1.0.0", resultGH);
         }
 
         [TestMethod]
+        [Ignore] // TODO: GetLatestVersion currently only looks for the stable tag.
         public async Task GetLatestVersion_PreRelease()
         {
-            CancellationToken token = CancellationToken.None;
-            const string libraryId = "bootstrap@3.3.0";
-            string result = await _catalog.GetLatestVersion(libraryId, true, token);
+            const string libraryId = "fakeLib@3.3.0";
+            Mocks.WebRequestHandler fakeHandler = new Mocks.WebRequestHandler().SetupVersions("fakeLib", "fake/fakeLib");
+            JsDelivrCatalog sut = SetupCatalog(fakeHandler);
 
-            // It can return null value.
-            if (result != null)
-            {
-                string[] existing = libraryId.Split('@');
+            string result = await sut.GetLatestVersion(libraryId, true, CancellationToken.None);
 
-                Assert.AreNotEqual(existing[1], result);
-            }
+            Assert.AreEqual("2.0.0-beta", result);
+        }
+    }
+
+    internal static class JsDelivrCatalogSetups
+    {
+        public static Mocks.WebRequestHandler SetupFiles(this Mocks.WebRequestHandler h, string libraryId, string githubLibraryId)
+        {
+            string files = @"{ ""files"": [ { ""name"": ""testFile.js"" } ] }";
+
+            return h.ArrangeResponse(string.Format(JsDelivrCatalog.LibraryFileListUrlFormat, libraryId), files)
+                    .ArrangeResponse(string.Format(JsDelivrCatalog.LibraryFileListUrlFormatGH, githubLibraryId), files);
+        }
+
+        public static Mocks.WebRequestHandler SetupVersions(this Mocks.WebRequestHandler h, string libraryId, string githubLibraryId)
+        {
+            string versions = @"{
+  ""tags"": {
+    ""beta"": ""2.0.0-beta"",
+    ""latest"": ""1.0.0""
+  }
+}";
+
+            return h.ArrangeResponse(string.Format(JsDelivrCatalog.LatestLibraryVersionUrl, libraryId), versions)
+                    .ArrangeResponse(string.Format(JsDelivrCatalog.LatestLibraryVersionUrlGH, githubLibraryId), versions);
         }
     }
 }

--- a/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrCatalogTest.cs
@@ -18,21 +18,15 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
     [TestClass]
     public class JsDelivrCatalogTest
     {
-        private ILibraryCatalog _catalog;
-        private IProvider _provider;
+        private JsDelivrCatalog _catalog;
 
         [TestInitialize]
         public void Setup()
         {
-            string projectFolder = Path.Combine(Path.GetTempPath(), "LibraryManager");
-            string cacheFolder = Environment.ExpandEnvironmentVariables(@"%localappdata%\Microsoft\Library\");
-            var hostInteraction = new HostInteraction(projectFolder, cacheFolder);
-            var dependencies = new Dependencies(hostInteraction, new JsDelivrProviderFactory());
-
-            LibraryIdToNameAndVersionConverter.Instance.Reinitialize(dependencies);
-
-            _provider = dependencies.GetProvider("jsdelivr");
-            _catalog = _provider.GetCatalog();
+            _catalog = new JsDelivrCatalog(JsDelivrProvider.IdText,
+                                           new VersionedLibraryNamingScheme(),
+                                           new Mocks.Logger(),
+                                           new Mocks.WebRequestHandler());
         }
 
         [TestMethod]
@@ -52,7 +46,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
             Assert.AreEqual(0, library.Files.Count(f => f.Value));
             Assert.IsNotNull(library.Name);
             Assert.IsNotNull(library.Version);
-            Assert.AreEqual(_provider.Id, library.ProviderId);
+            Assert.AreEqual(JsDelivrProvider.IdText, library.ProviderId);
         }
 
         [TestMethod]


### PR DESCRIPTION
This change is a beginning to make the unit tests reliable and consistent, without relying upon web requests to external resources beyond our control.  It's just a first pass, as the full set of changes needed are very broad.