### PR TITLE
Corrected relative paths of tools dll in targets (fixes #500)

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.targets
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard2.0\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
-        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net472\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
+        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netstandard2.0\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
+        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
The targets file uses relative paths which is not working for projects using `packages.config`. This PR fixes #500 