### PR TITLE
Fixing version completion for scoped packages

### DIFF
--- a/src/LibraryManager.Vsix/UI/Models/LibraryIdViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/LibraryIdViewModel.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
         protected override Task<CompletionSet> FilterCompletions(CompletionSet input)
         {
             CompletionSet result = input;
-            int atIndex = SearchText.IndexOf('@');
+            int atIndex = SearchText.IndexOf('@', 1);
 
             if (atIndex >= 0)
             {

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
@@ -15,93 +15,106 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
     [TestClass]
     public class LibraryIdViewModelTests
     {
-        private readonly ILibraryCatalog _testCatalog = new LibraryCatalog()
-            .AddLibrary(new Library { Name = "test", Version = "1.0" })
-            .AddLibrary(new Library { Name = "test", Version = "1.2" })
-            .AddLibrary(new Library { Name = "test", Version = "2.0" })
-            .AddLibrary(new Library { Name = "@types/node", Version = "1.0" })
-            .AddLibrary(new Library { Name = "@types/node", Version = "1.2" })
-            .AddLibrary(new Library { Name = "@types/node", Version = "2.0" })
-
-            //Add garbage data 
-            .AddLibrary(new Library { Name = "@Bad@Package@", Version = "abc/2.junk" })
-            .AddLibrary(new Library { Name = "", Version = "2.0" })
-            .AddLibrary(new Library { Name = "Blah", Version = "" })
-            .AddLibrary(new Library { Name = "", Version = "" });
-
-
-        private IProvider GetTestProvider()
+        private ISearchService GetTestSearchService(ILibraryCatalog libraryCatalog)
         {
-            IProvider testProvider = new Provider(new HostInteraction())
-            {
-                Catalog = _testCatalog
-            };
-
-            return testProvider;
+            IProvider testProvider = new Provider(new HostInteraction()) { Catalog = libraryCatalog };
+            return new ProviderCatalogSearchService(() => testProvider);
         }
 
-        private ISearchService GetTestSearchService()
+        private ILibraryCatalog CreateLibraryCatalogWithUnscopedLibrary()
         {
-            IProvider provider = GetTestProvider();
-            return new ProviderCatalogSearchService(() => provider);
+            return new LibraryCatalog()
+                .AddLibrary(new Library { Name = "test", Version = "1.0" })
+                .AddLibrary(new Library { Name = "test", Version = "1.2" })
+                .AddLibrary(new Library { Name = "test", Version = "2.0" });
         }
 
         [TestMethod]
         public async Task FilterCompletions_SearchTextDoesNotContainAtSign_ReturnAllMatchingCompletions()
         {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "test");
+            ILibraryCatalog testCatalog = new LibraryCatalog()
+                .AddLibrary(new Library { Name = "test", Version = "1.0" })
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.2" });
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test");
 
             CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 3);
-
-            Assert.AreEqual(3, result.Completions.Count());
-        }
-
-        [TestMethod]
-        public async Task FilterCompletions_SearchTextEndsWithAt_ReturnAllMatchingCompletions()
-        {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "test@");
-
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 5);
-
-            // the version segment is "", which matches all versions
-            Assert.AreEqual(3, result.Completions.Count());
-        }
-
-        [TestMethod]
-        public async Task FilterCompletions_ScopedPackageWithoutTrailingAt_ReturnAllMatchingCompletions()
-        {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "@types/node");
-
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 11);
-
-            Assert.AreEqual(3, result.Completions.Count());
-        }
-
-        [TestMethod]
-        public async Task FilterCompletions_ScopedPackageEndsWithAt_ReturnAllMatchingCompletions()
-        {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "@types/node@");
-
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 12);
-
-            // the version segment is "", which matches all versions
-            Assert.AreEqual(3, result.Completions.Count());
-        }
-
-        [TestMethod]
-        public async Task FilterCompletions_ScopedPackageEndsWithAfterAt_ReturnAllMatchingCompletions()
-        {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "@types/node@2");
-
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 13);
 
             Assert.AreEqual(1, result.Completions.Count());
         }
 
         [TestMethod]
+        public async Task FilterCompletions_SearchTextEndsWithAt_ReturnAllMatchingCompletions()
+        {
+            ILibraryCatalog testCatalog = new LibraryCatalog()
+                .AddLibrary(new Library { Name = "test", Version = "1.0" })
+                .AddLibrary(new Library { Name = "test", Version = "1.2" })
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.2" });
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test@");
+
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 5);
+
+            // the version segment is "", which matches all versions
+            Assert.AreEqual(2, result.Completions.Count());
+        }
+
+        [TestMethod]
+        public async Task FilterCompletions_ScopedPackageWithoutTrailingAt_ReturnAllMatchingCompletions()
+        {
+            ILibraryCatalog testCatalog = new LibraryCatalog()
+                .AddLibrary(new Library { Name = "test", Version = "1.0" })
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.2" });
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "@types/test");
+
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 11);
+
+            Assert.AreEqual(1, result.Completions.Count());
+        }
+
+        [TestMethod]
+        public async Task FilterCompletions_ScopedPackageEndsWithAt_ReturnAllMatchingCompletions()
+        {
+            ILibraryCatalog testCatalog = new LibraryCatalog()
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.0" })
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.2" })
+                .AddLibrary(new Library { Name = "test", Version = "1.2" });
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "@types/test@");
+
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 12);
+
+            // the version segment is "", which matches all versions
+            Assert.AreEqual(2, result.Completions.Count());
+        }
+
+        [TestMethod]
+        public async Task FilterCompletions_ScopedPackageEndsWithAfterAt_ReturnAllMatchingCompletions()
+        {
+            ILibraryCatalog testCatalog = new LibraryCatalog()
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.0" })
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.2" })
+                .AddLibrary(new Library { Name = "@types/test", Version = "2.0" })
+                .AddLibrary(new Library { Name = "test", Version = "1.2" });
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "@types/test@2");
+
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 13);
+
+            Assert.AreEqual(2, result.Completions.Count());
+        }
+
+        [TestMethod]
         public async Task FilterCompletions_SearchTextEndsWithAfterAt_ReturnFilteredCompletions()
         {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "test@2");
+            ILibraryCatalog testCatalog = new LibraryCatalog()
+                .AddLibrary(new Library { Name = "test", Version = "1.0" })
+                .AddLibrary(new Library { Name = "test", Version = "1.2" })
+                .AddLibrary(new Library { Name = "test", Version = "2.0" })
+                .AddLibrary(new Library { Name = "@types/test", Version = "1.2" });
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test@2");
 
             CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 5);
 
@@ -112,7 +125,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         [TestMethod]
         public async Task GetRecommendedSelectedCompletionAsync_DoesNotContainAt_ReturnsFirstItem()
         {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "test");
+            ILibraryCatalog testCatalog = CreateLibraryCatalogWithUnscopedLibrary();
+            
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test");
             var completionSet = new CompletionSet
             {
                 Start = 0,
@@ -131,7 +146,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         [TestMethod]
         public async Task GetRecommendedSelectedCompletionAsync_SearchTextDoesContainAt_ReturnsItemThatStartsWithPrefix()
         {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "test@2");
+            ILibraryCatalog testCatalog = CreateLibraryCatalogWithUnscopedLibrary();
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test@2");
             var completionSet = new CompletionSet
             {
                 Start = 0,
@@ -150,7 +167,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         [TestMethod]
         public async Task GetRecommendedSelectedCompletionAsync_SearchTextDoesContainAt_NonMatching_ReturnsFirstItem()
         {
-            var testObj = new LibraryIdViewModel(GetTestSearchService(), "test@3");
+            ILibraryCatalog testCatalog = CreateLibraryCatalogWithUnscopedLibrary();
+
+            var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test@3");
             var completionSet = new CompletionSet
             {
                 Start = 0,

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
@@ -18,7 +18,17 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         private readonly ILibraryCatalog _testCatalog = new LibraryCatalog()
             .AddLibrary(new Library { Name = "test", Version = "1.0" })
             .AddLibrary(new Library { Name = "test", Version = "1.2" })
-            .AddLibrary(new Library { Name = "test", Version = "2.0" });
+            .AddLibrary(new Library { Name = "test", Version = "2.0" })
+            .AddLibrary(new Library { Name = "@types/node", Version = "1.0" })
+            .AddLibrary(new Library { Name = "@types/node", Version = "1.2" })
+            .AddLibrary(new Library { Name = "@types/node", Version = "2.0" })
+
+            //Add garbage data 
+            .AddLibrary(new Library { Name = "@Bad@Package@", Version = "abc/2.junk" })
+            .AddLibrary(new Library { Name = "", Version = "2.0" })
+            .AddLibrary(new Library { Name = "Blah", Version = "" })
+            .AddLibrary(new Library { Name = "", Version = "" });
+
 
         private IProvider GetTestProvider()
         {
@@ -41,7 +51,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         {
             var testObj = new LibraryIdViewModel(GetTestSearchService(), "test");
 
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 0);
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 3);
 
             Assert.AreEqual(3, result.Completions.Count());
         }
@@ -51,10 +61,41 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         {
             var testObj = new LibraryIdViewModel(GetTestSearchService(), "test@");
 
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 0);
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 5);
 
             // the version segment is "", which matches all versions
             Assert.AreEqual(3, result.Completions.Count());
+        }
+
+        [TestMethod]
+        public async Task FilterCompletions_ScopedPackageWithoutTrailingAt_ReturnAllMatchingCompletions()
+        {
+            var testObj = new LibraryIdViewModel(GetTestSearchService(), "@types/node");
+
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 11);
+
+            Assert.AreEqual(3, result.Completions.Count());
+        }
+
+        [TestMethod]
+        public async Task FilterCompletions_ScopedPackageEndsWithAt_ReturnAllMatchingCompletions()
+        {
+            var testObj = new LibraryIdViewModel(GetTestSearchService(), "@types/node@");
+
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 12);
+
+            // the version segment is "", which matches all versions
+            Assert.AreEqual(3, result.Completions.Count());
+        }
+
+        [TestMethod]
+        public async Task FilterCompletions_ScopedPackageEndsWithAfterAt_ReturnAllMatchingCompletions()
+        {
+            var testObj = new LibraryIdViewModel(GetTestSearchService(), "@types/node@2");
+
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 13);
+
+            Assert.AreEqual(1, result.Completions.Count());
         }
 
         [TestMethod]
@@ -62,7 +103,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         {
             var testObj = new LibraryIdViewModel(GetTestSearchService(), "test@2");
 
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 0);
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 5);
 
             // This will match both 1.2 and 2.0
             Assert.AreEqual(2, result.Completions.Count());


### PR DESCRIPTION
This fixes LibraryIdViewModel.FilterCompletions not returning any completions for scoped packages. 