### PR TITLE
Fixing a bad test in LibraryIdViewModelTests

### DIFF
--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
 
             var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "@types/test@2");
 
-            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 13);
+            CompletionSet result = await testObj.GetCompletionSetAsync(caretIndex: 12);
 
             Assert.AreEqual(2, result.Completions.Count());
         }


### PR DESCRIPTION
Here if the `caretIndex`  is at 13 (the end of the string), making `GetCompletionSetAsync `filter all completions that start with `@types/test@2`, so there should only be 1 result.

Fixing the scenario so it's correctly filtering on completions starting with `@types/test@` and contain "2" in the version.

Silly me, don't know why I didn't run all unit tests again before merging my previous PR...