### PR TITLE
Having LibMan use MEF instead of reflection for .NET Standard 2.0 to pull in IProviderFactory

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="System.Runtime.Loader" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <PackageReference Include="System.Runtime.Loader" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+    <PackageReference Include="System.Runtime.Loader" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
+++ b/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageReference Include="System.ValueTuple" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <ProjectReference Include="..\LibraryManager.Contracts\Microsoft.Web.LibraryManager.Contracts.csproj" />
-    <Reference Include="System.ComponentModel.Composition" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <Reference Include="System.Web" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
   </ItemGroup>

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProviderFactory.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProviderFactory.cs
@@ -2,18 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Web.LibraryManager.Contracts;
-
-#if NET472
 using System.ComponentModel.Composition;
-#endif
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
 {
     /// <summary>Internal use only</summary>
-#if NET472
     [Export(typeof(IProviderFactory))]
-#endif
     internal class CdnjsProviderFactory : IProviderFactory
     {
         /// <summary>

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProviderFactory.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProviderFactory.cs
@@ -2,20 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
-using Microsoft.Web.LibraryManager.Contracts;
-
-#if NET472
 using System.ComponentModel.Composition;
-#endif
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Providers.FileSystem
 {
     /// <summary>Internal use only</summary>
-#if NET472
     [Export(typeof(IProviderFactory))]
-#endif
-
     internal class FileSystemProviderFactory : IProviderFactory
     {
         /// <summary>

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProviderFactory.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProviderFactory.cs
@@ -1,15 +1,10 @@
 ﻿using System;
 using Microsoft.Web.LibraryManager.Contracts;
-
-#if NET472
 using System.ComponentModel.Composition;
-#endif
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 {
-#if NET472
     [Export(typeof(IProviderFactory))]
-#endif
     internal class UnpkgProviderFactory : IProviderFactory
     {
         public IProvider CreateProvider(IHostInteraction hostInteraction)

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrProviderFactory.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrProviderFactory.cs
@@ -3,17 +3,12 @@
 
 using System;
 using Microsoft.Web.LibraryManager.Contracts;
-
-#if NET472
 using System.ComponentModel.Composition;
-#endif
 
 namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
 {
 
-#if NET472
     [Export(typeof(IProviderFactory))]
-#endif
     internal class JsDelivrProviderFactory : IProviderFactory
     {
         public IProvider CreateProvider(IHostInteraction hostInteraction)

--- a/src/libman/Contracts/Dependencies.cs
+++ b/src/libman/Contracts/Dependencies.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.Loader;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
 using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Tools.Contracts
@@ -18,9 +16,6 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
     {
         private readonly IHostInteraction _hostInteraction;
         private readonly List<IProvider> _providers = new List<IProvider>();
-
-        [ImportMany]
-        private IEnumerable<IProviderFactory> _providerFactories;
 
         private readonly IEnumerable<string> _assemblyPaths;
 
@@ -58,18 +53,33 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
             if (_providers.Count > 0)
                 return;
 
-            AggregateCatalog aggregateCatalog = new AggregateCatalog();
+            // Prepare part discovery to support both flavors of MEF attributes.
+            PartDiscovery discovery = PartDiscovery.Combine(
+                new AttributedPartDiscovery(Resolver.DefaultInstance), // "NuGet MEF" attributes (Microsoft.Composition)
+                new AttributedPartDiscoveryV1(Resolver.DefaultInstance)); // ".NET MEF" attributes (System.ComponentModel.Composition)
 
-            foreach (string assemblyPath in _assemblyPaths)
-            {
-                Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-                aggregateCatalog.Catalogs.Add(new AssemblyCatalog(assembly));
-            }
+            Task<DiscoveredParts> t = discovery.CreatePartsAsync(_assemblyPaths);
+            t.Wait();
 
-            CompositionContainer container = new CompositionContainer(aggregateCatalog);
-            container.SatisfyImportsOnce(this);
+            // Build up a catalog of MEF parts
+            ComposableCatalog catalog = ComposableCatalog.Create(Resolver.DefaultInstance).AddParts(t.Result);
 
-            foreach (IProviderFactory factory in _providerFactories)
+            // Assemble the parts into a valid graph.
+            CompositionConfiguration config = CompositionConfiguration.Create(catalog);
+
+            // Prepare an ExportProvider factory based on this graph.
+            IExportProviderFactory epf = config.CreateExportProviderFactory();
+
+            // Create an export provider, which represents a unique container of values.
+            // You can create as many of these as you want, but typically an app needs just one.
+            ExportProvider vsExportProvider = epf.CreateExportProvider();
+
+            // Obtain .NET shim for the export provider to keep the rest of the editors code the same
+            System.ComponentModel.Composition.Hosting.ExportProvider exportProvider = vsExportProvider.AsExportProvider();
+
+            IEnumerable<IProviderFactory> providerFactories = exportProvider.GetExportedValues<IProviderFactory>();
+
+            foreach (IProviderFactory factory in providerFactories)
             {
                 if (factory != null)
                 {

--- a/src/libman/libman.csproj
+++ b/src/libman/libman.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.1.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibraryManager\Microsoft.Web.LibraryManager.csproj" />


### PR DESCRIPTION
Currently LibMan has 2 methods to import IProviderFactory: .NET Standard 2.0 uses reflection while .NET 472 uses MEF. This change have both frameworks use MEF to do so.