### PR TITLE
Enable roll-forward on major versions for CLI tool

### DIFF
--- a/src/libman/runtimeconfig.template.json
+++ b/src/libman/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
This enables the CLI tool to continue to work on images which only have versions newer than netcoreapp2.1.

In the future if a breaking change is made that breaks us on roll-forward, we'll have to multi-target the project to that framework.  It's not worthwhile to multi-target for every new version and have to ship just to keep in lockstep though.

This fixes #520 