### PR TITLE
Fix code warnings from analyzers

### DIFF
--- a/LibraryManager.msbuild
+++ b/LibraryManager.msbuild
@@ -102,7 +102,7 @@ Build the test projects.
   <Target Name="BuildTestProjects">
     <ItemGroup>
       <TestProjects Include="$(RepoRoot)\test\**\*.csproj" />
-      <TestProjects Remove="$(RepoRoot)\test\LibraryManager.IntegrationTest\TestSolution\**\*.csproj" />
+      <TestProjects Remove="$(RepoRoot)\test\LibraryManager.IntegrationTest\**\TestSolution\**\*.csproj" />
     </ItemGroup>
     <MSBuild Targets="Build"
              Projects="@(TestProjects)"

--- a/build/analyzers/rulesets/Default.ruleset
+++ b/build/analyzers/rulesets/Default.ruleset
@@ -36,6 +36,7 @@
     <Rule Id="CA1023" Action="Warning" />                     <!-- Indexers should not be multidimensional. -->
     <Rule Id="CA1026" Action="Info" />                        <!-- Default parameters should not be used. An externally visible type contains an externally visible method that uses a default parameter. -->
     <Rule Id="CA1027" Action="Info" />                        <!-- Mark enums with FlagsAttribute. -->
+    <Rule Id="CA1031" Action="None" />                        <!-- Do not catch general exception types. -->
     <Rule Id="CA1034" Action="Info" />                        <!-- Nested types should not be visible. -->
     <Rule Id="CA1035" Action="Warning" />                     <!-- ICollection implementations have strongly typed members. A public or protected type implements System.Collections.ICollection but does not provide a strongly typed method for ICollection.CopyTo. -->
     <Rule Id="CA1038" Action="Warning" />                     <!-- Enumerators should be strongly typed. A public or protected type implements System.Collections.IEnumerator but does not provide a strongly typed version of the IEnumerator.Current property. -->

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -123,7 +123,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
         public static void ClearOutputWindow()
         {
             // Don't access _outputWindowPane through the property here so that we don't force creation
-            ThreadHelper.Generic.BeginInvoke(() => OutputWindowPaneValue?.Clear());
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                OutputWindowPaneValue?.Clear();
+            });
         }
 
         private static IVsOutputWindowPane OutputWindowPane
@@ -188,13 +192,18 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         private static void LogToActivityLog(string message, __ACTIVITYLOG_ENTRYTYPE type)
         {
-            ThreadHelper.Generic.BeginInvoke(() => ActivityLog.LogEntry((uint)type, Vsix.Name, message));
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                ActivityLog.LogEntry((uint)type, Vsix.Name, message);
+            });
         }
 
         private static void LogToStatusBar(string message)
         {
-            ThreadHelper.Generic.BeginInvoke(() =>
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 Statusbar.FreezeOutput(0);
                 Statusbar.SetText(message);
                 Statusbar.FreezeOutput(1);
@@ -203,7 +212,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         private static void LogToOutputWindow(object message)
         {
-            ThreadHelper.Generic.BeginInvoke(() => OutputWindowPane?.OutputString(message + Environment.NewLine));
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                OutputWindowPane?.OutputString(message + Environment.NewLine);
+            });
         }
 
         private static bool EnsurePane()

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             get { return JsonCompletionContextType.ArrayElement; }
         }
 
+        [SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "Checked for task completion before calling .Result")]
         protected override IEnumerable<JsonCompletionEntry> GetEntries(JsonCompletionContext context)
         {
             MemberNode member = context.ContextNode.FindType<MemberNode>();
@@ -52,7 +54,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             if (string.IsNullOrEmpty(state.Name))
                 yield break;
 
-            var dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
+            IDependencies dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
             IProvider provider = dependencies.GetProvider(state.ProviderId);
             ILibraryCatalog catalog = provider?.GetCatalog();
 

--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
@@ -36,6 +37,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
             get { return JsonCompletionContextType.PropertyValue; }
         }
 
+        [SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "Checked for task completion before calling .Result")]
         protected override IEnumerable<JsonCompletionEntry> GetEntries(JsonCompletionContext context)
         {
             var member = context.ContextNode as MemberNode;
@@ -52,7 +54,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 yield break;
             }
 
-            var dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
+            IDependencies dependencies = _dependenciesFactory.FromConfigFile(ConfigFilePath);
             IProvider provider = dependencies.GetProvider(state.ProviderId);
             ILibraryCatalog catalog = provider?.GetCatalog();
 

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
             try
             {
-                var dependencies = _provider.DependenciesFactory.FromConfigFile(_provider.ConfigFilePath);
+                IDependencies dependencies = _provider.DependenciesFactory.FromConfigFile(_provider.ConfigFilePath);
                 IProvider provider = dependencies.GetProvider(_provider.InstallationState.ProviderId);
                 ILibraryCatalog catalog = provider?.GetCatalog();
 

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Language.Intellisense;
@@ -24,11 +25,12 @@ namespace Microsoft.Web.LibraryManager.Vsix
             _provider = provider;
         }
 
+        [SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "Checked for task completion before calling .Result")]
         public override bool HasActionSets
         {
             get
             {
-                var dependencies = _provider.DependenciesFactory.FromConfigFile(_provider.ConfigFilePath);
+                IDependencies dependencies = _provider.DependenciesFactory.FromConfigFile(_provider.ConfigFilePath);
                 IProvider provider = dependencies.GetProvider(_provider.InstallationState.ProviderId);
                 ILibraryCatalog catalog = provider?.GetCatalog();
 
@@ -40,7 +42,9 @@ namespace Microsoft.Web.LibraryManager.Vsix
                 _actions = GetListOfActionsAsync(catalog, CancellationToken.None);
 
                 if (_actions.IsCompleted && _actions.Result.Count == 0)
+                {
                     return false;
+                }
 
                 return true;
             }

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -447,11 +447,55 @@
   </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
+  <!--
+    Some of the VSSDK packages may pull in Microsoft.VisualStudio.SDK.EmbedInteropTypes which essentially
+    does the below but for all of the listed references. We can't just use what they have since they include
+    things like EnvDTE which is reasonable for consumers, but strange since we actually _implement_ those assemblies and
+    use it as an exchange type with generics in a few places. Instead, we run directly after the target declared
+    in the EmbedInteropTypes package and ensure only the dependencies we need are embedded and the others are
+    skipped.
   -->
+  <Target Name="CustomLinkVSSDKEmbeddableAssemblies" AfterTargets="LinkVSSDKEmbeddableAssemblies;ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferencePath Remove="$(ExtensionsReferences)\System.ValueTuple.dll" />
+      <ReferencePath Condition="
+              '%(FileName)' == 'Microsoft.VisualStudio.CommandBars'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.ProjectSystem.Interop'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Setup.Configuration.Interop'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime'
+           or '%(Filename)' == 'Microsoft.VisualStudio.TabDesigner.Embeddable'
+           or '%(FileName)' == 'Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime'
+           or '%(FileName)' == 'NuGet.SolutionRestoreManager.Interop'
+           or '%(FileName)' == 'NuGet.VisualStudio'
+           or '%(FileName)' == 'VSLangProj110'
+           or '%(FileName)' == 'mshtml'
+           or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.1.DesignTime'
+           or '%(FileName)' == 'Microsoft.Internal.VisualStudio.Shell.Interop.14.2.DesignTime'">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </ReferencePath>
+      <ReferencePath Condition="
+              '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.15.0.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.10.0'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Feedback.Interop.12.0.DesignTime'
+           or '%(FileName)' == 'microsoft.visualstudio.designer.interfaces'
+           or '%(FileName)' == 'EnvDTE80'
+           or '%(FileName)' == 'EnvDTE90'
+           or '%(FileName)' == 'EnvDTE100'
+           or '%(FileName)' == 'stdole'">
+        <EmbedInteropTypes>false</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/LibraryManager/SemanticVersion/SemanticVersion.cs
+++ b/src/LibraryManager/SemanticVersion/SemanticVersion.cs
@@ -136,6 +136,13 @@ namespace Microsoft.Web.LibraryManager
             return ver;
         }
 
+        /// <summary>
+        /// Compares this object to the other and returns a result indicating sort order.
+        /// </summary>
+        /// <remarks>
+        /// This comparison does take build metadata into account for the comparison.
+        /// </remarks>
+        /// <returns>-1 if this version is lower than other; 0 if they are equal; 1 otherwise.</returns>
         public int CompareTo(SemanticVersion other)
         {
             if (other == null)
@@ -186,24 +193,92 @@ namespace Microsoft.Web.LibraryManager
             return StringComparer.OrdinalIgnoreCase.Compare(OriginalText, other.OriginalText);
         }
 
+        /// <summary>
+        /// Returns whether the semantic verisons are equal.  This includes comparing the build metadata, and does not provide semantic equivalence.
+        /// </summary>
         public bool Equals(SemanticVersion other)
         {
             return other != null && string.Equals(OriginalText, other.OriginalText, StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Returns whether the other object is equal to this SemanticVersion.
+        /// </summary>
         public override bool Equals(object obj)
         {
             return Equals(obj as SemanticVersion);
         }
 
+        /// <summary>
+        /// Returns a hash code to uniquely identify this version.
+        /// </summary>
+        /// <remarks>
+        /// This is aware of build metadata, and should not be relied on as a semantic equality comparison.
+        /// </remarks>
         public override int GetHashCode()
         {
             return _hashCode;
         }
 
+        /// <summary>
+        /// Get a string representation of this SemanticVersion
+        /// </summary>
         public override string ToString()
         {
             return OriginalText;
+        }
+
+        /// <summary>
+        /// Equality operator
+        /// </summary>
+        public static bool operator ==(SemanticVersion left, SemanticVersion right)
+        {
+            if (ReferenceEquals(left, null))
+            {
+                return ReferenceEquals(right, null);
+            }
+
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Inequality operator
+        /// </summary>
+        public static bool operator !=(SemanticVersion left, SemanticVersion right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Less-than operator
+        /// </summary>
+        public static bool operator <(SemanticVersion left, SemanticVersion right)
+        {
+            return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Less-than-or-equal operator
+        /// </summary>
+        public static bool operator <=(SemanticVersion left, SemanticVersion right)
+        {
+            return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Greater-than operator
+        /// </summary>
+        public static bool operator >(SemanticVersion left, SemanticVersion right)
+        {
+            return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Greater-than-or-equal operator
+        /// </summary>
+        public static bool operator >=(SemanticVersion left, SemanticVersion right)
+        {
+            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
         }
     }
 }

--- a/src/LibraryManager/SemanticVersion/SemanticVersion.cs
+++ b/src/LibraryManager/SemanticVersion/SemanticVersion.cs
@@ -233,9 +233,9 @@ namespace Microsoft.Web.LibraryManager
         /// </summary>
         public static bool operator ==(SemanticVersion left, SemanticVersion right)
         {
-            if (ReferenceEquals(left, null))
+            if (left is null)
             {
-                return ReferenceEquals(right, null);
+                return right is null;
             }
 
             return left.Equals(right);
@@ -254,7 +254,7 @@ namespace Microsoft.Web.LibraryManager
         /// </summary>
         public static bool operator <(SemanticVersion left, SemanticVersion right)
         {
-            return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
+            return left is null ? !(right is null) : left.CompareTo(right) < 0;
         }
 
         /// <summary>
@@ -262,7 +262,7 @@ namespace Microsoft.Web.LibraryManager
         /// </summary>
         public static bool operator <=(SemanticVersion left, SemanticVersion right)
         {
-            return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
+            return left is null || left.CompareTo(right) <= 0;
         }
 
         /// <summary>
@@ -270,7 +270,7 @@ namespace Microsoft.Web.LibraryManager
         /// </summary>
         public static bool operator >(SemanticVersion left, SemanticVersion right)
         {
-            return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
+            return !(left is null) && left.CompareTo(right) > 0;
         }
 
         /// <summary>
@@ -278,7 +278,7 @@ namespace Microsoft.Web.LibraryManager
         /// </summary>
         public static bool operator >=(SemanticVersion left, SemanticVersion right)
         {
-            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
+            return left is null ? right is null : left.CompareTo(right) >= 0;
         }
     }
 }

--- a/src/libman/GlobalSuppressions.cs
+++ b/src/libman/GlobalSuppressions.cs
@@ -6,3 +6,8 @@
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Custom exception types require multiple parameters to be useful")]
 
+// Suppress issues in code from external sources
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1064:Exceptions should be public", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.Extensions.CommandLineUtils.CommandParsingException")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Extensions.CommandLineUtils.CommandOption.#ctor(System.String,Microsoft.Extensions.CommandLineUtils.CommandOptionType)")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Extensions.CommandLineUtils.AnsiConsole.WriteLine(System.String)")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Extensions.CommandLineUtils.CommandLineApplication.Execute(System.String[])~System.Int32")]

--- a/test/LibraryManager.IntegrationTest/Services/InstallDialogTestService.cs
+++ b/test/LibraryManager.IntegrationTest/Services/InstallDialogTestService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Test.Apex.Services;
 using Microsoft.Test.Apex.VisualStudio;
@@ -36,7 +37,7 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest.Services
                 {
                     CommandingService.ExecuteCommand(guid, commandId, null);
                 });
-            });
+            }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default );
         }
 
         private InstallDialogTestExtension GetInstallDialogTestExtension()


### PR DESCRIPTION
This addresses the remaining code analysis failures.  There are still a few MSBuild warnings left, but this significantly improves our code cleanliness in the editor/IDE.