### PR TITLE
Make the restore-on-build task run in its own app-domain

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="System.Runtime.Loader" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
   </ItemGroup>
 

--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -13,7 +13,12 @@ using System.Threading;
 
 namespace Microsoft.Web.LibraryManager.Build
 {
-    public class RestoreTask : Task
+    public class RestoreTask
+#if NET472
+        : AppDomainIsolatedTask
+#else
+        : Task
+#endif
     {
         [Required]
         public string FileName { get; set; }


### PR DESCRIPTION
This addresses a recurring issue where doing a WebDeploy-based publish from within Visual Studio encounteres MissingMethodExceptions when running LibMan's Restore-on-build.  The issue is that VS Publish runs MSBuild in-proc, so it loads the build task DLL from the NuGet package, but the other LibMan assemblies are already loaded into the VS appdomain from the VSIX (often a newer version).  Any incompatibilities between these cause the build task to throw.

This fix causes the build task to be executed in its own appdomain, and as such it resolves all of its dependent assemblies from the nuget package.  The appdomain gets cleared when the build is finished, so we're not leaving duplicates of all the assmeblies loaded into VS.  Note: the Build task DLL itself is loaded into VS' primary appdomain, and will linger - this isn't a change from how it works today.

Even though AppDomainIsolatedTask is only available on net472, that's the build type that VS uses for the in-proc build, even for projects that only target netcoreapp*.