### PR TITLE
Workaround an assembly version conflict

### DIFF
--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Microsoft.Web.LibraryManager.Vsix.Test.csproj
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Microsoft.Web.LibraryManager.Vsix.Test.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -8,6 +10,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LibraryManager.Vsix\Microsoft.Web.LibraryManager.Vsix.csproj" />


### PR DESCRIPTION
Moq has a dependency on System.Threading.Tasks.Extensions 4.2.0.0, but our dependency graph pulls in 4.2.0.1 (gee thanks, whoever bumped that).  Setting the binding redirect in the test project fixes it at runtime.

This was likely a regression caused in c5beab72, when we bumped up the version of Microsoft.VisualStudio.Threading (which seems to be at least one source of the 4.2.0.1 transitive dependency).