### PR TITLE
Add support for file patterns in libman.json

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -29,6 +29,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="15.7.942-master669188BE" />
     <PackageReference Update="Microsoft.VisualStudio.Threading" Version="16.3.52" />
     <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.3.2099" PrivateAssets="All" />
+    <PackageReference Update="MiniMatch" Version="2.0.0" />
     <PackageReference Update="Moq" Version="4.10.1" PrivateAssets="All" />
     <PackageReference Update="NerdBank.GitVersioning" Version="2.1.23" PrivateAssets="All" />
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />

--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -29,7 +29,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="15.7.942-master669188BE" />
     <PackageReference Update="Microsoft.VisualStudio.Threading" Version="16.3.52" />
     <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.3.2099" PrivateAssets="All" />
-    <PackageReference Update="MiniMatch" Version="2.0.0" />
+    <PackageReference Update="MiniMatch" Version="2.0.0" NoWarn="NU1603" />
     <PackageReference Update="Moq" Version="4.10.1" PrivateAssets="All" />
     <PackageReference Update="NerdBank.GitVersioning" Version="2.1.23" PrivateAssets="All" />
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
@@ -53,5 +53,10 @@
     <PackageReference Update="Microsoft.NETCore.DotnetAppHost" Version="2.1.0" />
 
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- adding as a workaround for numerous warnings from the Minimatch package, until https://github.com/SLaks/Minimatch/issues/12 is addressed -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
+  </PropertyGroup>
 
 </Project>

--- a/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
+++ b/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
@@ -10,6 +10,7 @@
     <XliffResource Include="MultilingualResources\*.xlf" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Minimatch" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageReference Include="System.ValueTuple" Condition="'$(TargetFramework)' != 'netstandard2.0'" />

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -1,0 +1,298 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.LibraryNaming;
+
+namespace Microsoft.Web.LibraryManager.Providers
+{
+    /// <summary>
+    /// Default implenentation for a provider, since most provider implementations are very similar.
+    /// </summary>
+    internal abstract class BaseProvider : IProvider
+    {
+        private readonly CacheService _cacheService;
+        private string _cacheFolder;
+
+        public BaseProvider(IHostInteraction hostInteraction, CacheService cacheService)
+        {
+            HostInteraction = hostInteraction;
+            _cacheService = cacheService;
+        }
+
+        #region IProvider implementation
+
+        /// <inheritdoc />
+        public abstract string Id { get; }
+
+        /// <inheritdoc />
+        public virtual string NuGetPackageId => "Microsoft.Web.LibraryManager.Build";
+
+        /// <inheritdoc />
+        public abstract string LibraryIdHintText { get; }
+
+        /// <inheritdoc />
+        public IHostInteraction HostInteraction { get; }
+
+        /// <inheritdoc />
+        public virtual bool SupportsLibraryVersions => true;
+
+        /// <inheritdoc />
+        public abstract ILibraryCatalog GetCatalog();
+
+        /// <inheritdoc />
+        public abstract string GetSuggestedDestination(ILibrary library);
+
+        /// <inheritdoc />
+        public virtual async Task<ILibraryOperationResult> InstallAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return LibraryOperationResult.FromCancelled(desiredState);
+            }
+
+            //Expand the files property if needed
+            ILibraryOperationResult updateResult = await UpdateStateAsync(desiredState, cancellationToken);
+            if (!updateResult.Success)
+            {
+                return updateResult;
+            }
+
+            desiredState = updateResult.InstallationState;
+
+            // Refresh cache if needed
+            ILibraryOperationResult cacheUpdateResult = await RefreshCacheAsync(desiredState, cancellationToken);
+            if (!cacheUpdateResult.Success)
+            {
+                return cacheUpdateResult;
+            }
+
+            // Check if Library is already up to date
+            if (IsLibraryUpToDate(desiredState))
+            {
+                return LibraryOperationResult.FromUpToDate(desiredState);
+            }
+
+            // Write files to destination
+            return await WriteToFilesAsync(desiredState, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual async Task<ILibraryOperationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return LibraryOperationResult.FromCancelled(desiredState);
+            }
+            
+            string libraryId = LibraryNamingScheme.GetLibraryId(desiredState.Name, desiredState.Version);
+            try
+            {
+                ILibraryCatalog catalog = GetCatalog();
+                ILibrary library = await catalog.GetLibraryAsync(desiredState.Name, desiredState.Version, cancellationToken).ConfigureAwait(false);
+
+                if (library == null)
+                {
+                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.Name, desiredState.ProviderId));
+                }
+
+                if (desiredState.Files != null && desiredState.Files.Count > 0)
+                {
+                    return CheckForInvalidFiles(desiredState, libraryId, library);
+                }
+
+                desiredState = new LibraryInstallationState
+                {
+                    ProviderId = Id,
+                    Name = desiredState.Name,
+                    Version = desiredState.Version,
+                    DestinationPath = desiredState.DestinationPath,
+                    Files = library.Files.Keys.ToList(),
+                    IsUsingDefaultDestination = desiredState.IsUsingDefaultDestination,
+                    IsUsingDefaultProvider = desiredState.IsUsingDefaultProvider
+                };
+            }
+            catch (InvalidLibraryException)
+            {
+                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(libraryId, desiredState.ProviderId));
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return new LibraryOperationResult(desiredState, PredefinedErrors.PathOutsideWorkingDirectory());
+            }
+            catch (Exception ex)
+            {
+                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
+                return new LibraryOperationResult(desiredState, PredefinedErrors.UnknownException());
+            }
+
+            return LibraryOperationResult.FromSuccess(desiredState);
+        }
+
+        #endregion
+
+        protected virtual ILibraryOperationResult CheckForInvalidFiles(ILibraryInstallationState desiredState, string libraryId, ILibrary library)
+        {
+            IReadOnlyList<string> invalidFiles = library.GetInvalidFiles(desiredState.Files);
+            if (invalidFiles.Count > 0)
+            {
+                IError invalidFilesError = PredefinedErrors.InvalidFilesInLibrary(libraryId, invalidFiles, library.Files.Keys);
+                return new LibraryOperationResult(desiredState, invalidFilesError);
+            }
+            else
+            {
+                return LibraryOperationResult.FromSuccess(desiredState);
+            }
+        }
+
+        protected virtual ILibraryNamingScheme LibraryNamingScheme { get; } = new VersionedLibraryNamingScheme();
+
+        public string CacheFolder
+        {
+            get { return _cacheFolder ?? (_cacheFolder = Path.Combine(HostInteraction.CacheDirectory, Id)); }
+        }
+
+        protected async Task<ILibraryOperationResult> WriteToFilesAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
+        {
+            if (state.Files != null)
+            {
+                try
+                {
+                    foreach (string file in state.Files)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return LibraryOperationResult.FromCancelled(state);
+                        }
+
+                        if (string.IsNullOrEmpty(file))
+                        {
+                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
+                        }
+
+                        string destinationPath = Path.Combine(state.DestinationPath, file);
+                        var sourceStream = new Func<Stream>(() => GetStreamAsync(state, file, cancellationToken).Result);
+                        bool writeOk = await HostInteraction.WriteFileAsync(destinationPath, sourceStream, state, cancellationToken).ConfigureAwait(false);
+
+                        if (!writeOk)
+                        {
+                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
+                        }
+                    }
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return new LibraryOperationResult(state, PredefinedErrors.PathOutsideWorkingDirectory());
+                }
+                catch (Exception ex)
+                {
+                    HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
+                    return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
+                }
+            }
+
+            return LibraryOperationResult.FromSuccess(state);
+        }
+
+        private async Task<Stream> GetStreamAsync(ILibraryInstallationState state, string sourceFile, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(state.Name) && !string.IsNullOrEmpty(state.Version))
+            {
+                string absolute = Path.Combine(CacheFolder, state.Name, state.Version, sourceFile);
+
+                if (File.Exists(absolute))
+                {
+                    return await HostInteraction.ReadFileAsync(absolute, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return null;
+        }
+
+        private bool IsLibraryUpToDate(ILibraryInstallationState state)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(state.Name) && !string.IsNullOrEmpty(state.Version))
+                {
+                    string cacheDir = Path.Combine(CacheFolder, state.Name, state.Version);
+                    string destinationDir = Path.Combine(HostInteraction.WorkingDirectory, state.DestinationPath);
+
+                    foreach (string sourceFile in state.Files)
+                    {
+                        var destinationFile = new FileInfo(Path.Combine(destinationDir, sourceFile).Replace('\\', '/'));
+                        var cacheFile = new FileInfo(Path.Combine(cacheDir, sourceFile).Replace('\\', '/'));
+
+                        if (!destinationFile.Exists || !cacheFile.Exists || !FileHelpers.AreFilesUpToDate(destinationFile, cacheFile))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Copies ILibraryInstallationState files to cache
+        /// </summary>
+        /// <param name="state"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task<ILibraryOperationResult> RefreshCacheAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return LibraryOperationResult.FromCancelled(state);
+            }
+
+            string libraryDir = Path.Combine(CacheFolder, state.Name, state.Version);
+
+            try
+            {
+                var librariesMetadata = new List<CacheFileMetadata>();
+                foreach (string sourceFile in state.Files)
+                {
+                    string cacheFile = Path.Combine(libraryDir, sourceFile);
+                    string url = GetDownloadUrl(state, sourceFile);
+
+                    var newEntry = new CacheFileMetadata(url, cacheFile);
+                    if (!librariesMetadata.Contains(newEntry))
+                    {
+                        librariesMetadata.Add(new CacheFileMetadata(url, cacheFile));
+                    }
+                }
+                await _cacheService.RefreshCacheAsync(librariesMetadata, cancellationToken);
+            }
+            catch (ResourceDownloadException ex)
+            {
+                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
+                return new LibraryOperationResult(state, PredefinedErrors.FailedToDownloadResource(ex.Url));
+            }
+            catch (OperationCanceledException)
+            {
+                return LibraryOperationResult.FromCancelled(state);
+            }
+            catch (Exception ex)
+            {
+                HostInteraction.Logger.Log(ex.InnerException.ToString(), LogLevel.Error);
+                return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
+            }
+
+            return LibraryOperationResult.FromSuccess(state);
+        }
+
+        protected abstract string GetDownloadUrl(ILibraryInstallationState state, string sourceFile);
+    }
+}

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
@@ -1,120 +1,37 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Resources;
 
 namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
 {
     /// <summary>Internal use only</summary>
-    internal class CdnjsProvider : IProvider
+    internal sealed class CdnjsProvider : BaseProvider
     {
-        // TO DO: This should become Provider properties to be passed to CacheService
         private const string DownloadUrlFormat = "https://cdnjs.cloudflare.com/ajax/libs/{0}/{1}/{2}"; // https://aka.ms/ezcd7o/{0}/{1}/{2}
 
         private CdnjsCatalog _catalog;
-        private readonly CacheService _cacheService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CdnjsProvider"/> class.
         /// </summary>
         /// <param name="hostInteraction">The host interaction.</param>
-        public CdnjsProvider(IHostInteraction hostInteraction)
+        public CdnjsProvider(IHostInteraction hostInteraction, CacheService cacheService)
+            :base(hostInteraction, cacheService)
         {
-            HostInteraction = hostInteraction;
-            _cacheService = new CacheService(WebRequestHandler.Instance);
         }
 
-        /// <summary>
-        /// The unique identifier of the provider.
-        /// </summary>
-        public string Id { get; } = "cdnjs";
+        /// <inheritdoc />
+        public override string Id => "cdnjs";
 
-        /// <summary>
-        /// Hint text for the library id.
-        /// </summary>
-        public string LibraryIdHintText { get; } = Text.CdnjsLibraryIdHintText;
+        /// <inheritdoc />
+        public override string LibraryIdHintText => Text.CdnjsLibraryIdHintText;
 
-        /// <summary>
-        /// The NuGet Package id for the package including the provider for use by MSBuild.
-        /// </summary>
-        /// <remarks>
-        /// If the provider doesn't have a NuGet package, then return <code>null</code>.
-        /// </remarks>
-        public string NuGetPackageId { get; } = "Microsoft.Web.LibraryManager.Build";
-
-        /// <summary>
-        /// An object specified by the host to interact with the file system etc.
-        /// </summary>
-        public IHostInteraction HostInteraction { get; }
-
-        internal string CacheFolder
-        {
-            get { return Path.Combine(HostInteraction.CacheDirectory, Id); }
-        }
-
-        /// <summary>
-        /// Supports libraries with versions.
-        /// </summary>
-        public bool SupportsLibraryVersions => true;
-
-        /// <summary>
-        /// Gets the <see cref="Microsoft.Web.LibraryManager.Contracts.ILibraryCatalog" /> for the <see cref="Microsoft.Web.LibraryManager.Contracts.IProvider" />. May be <code>null</code> if no catalog is supported.
-        /// </summary>
-        /// <returns></returns>
-        public ILibraryCatalog GetCatalog()
+        /// <inheritdoc />
+        public override ILibraryCatalog GetCatalog()
         {
             return _catalog ?? (_catalog = new CdnjsCatalog(this));
-        }
-
-        /// <summary>
-        /// Installs a library as specified in the <paramref name="desiredState" /> parameter.
-        /// </summary>
-        /// <param name="desiredState">The details about the library to install.</param>
-        /// <param name="cancellationToken">A token that allows for the operation to be cancelled.</param>
-        /// <returns>
-        /// The <see cref="Microsoft.Web.LibraryManager.Contracts.ILibraryOperationResult" /> from the installation process.
-        /// </returns>
-        /// <exception cref="InvalidLibraryException"></exception>
-        public async Task<ILibraryOperationResult> InstallAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(desiredState);
-            }
-
-            //Expand the files property if needed
-            ILibraryOperationResult updateResult = await UpdateStateAsync(desiredState, cancellationToken);
-            if (!updateResult.Success)
-            {
-                return updateResult;
-            }
-
-            desiredState = updateResult.InstallationState;
-
-            // Refresh cache if needed
-            ILibraryOperationResult cacheUpdateResult = await RefreshCacheAsync(desiredState, cancellationToken);
-            if (!cacheUpdateResult.Success)
-            {
-                return cacheUpdateResult;
-            }
-
-            // Check if Library is already up tp date
-            if (IsLibraryUpToDate(desiredState))
-            {
-                return LibraryOperationResult.FromUpToDate(desiredState);
-            }
-
-            // Write files to destination
-            return await WriteToFilesAsync(desiredState, cancellationToken);
-
         }
 
         /// <summary>
@@ -122,7 +39,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
         /// </summary>
         /// <param name="library"></param>
         /// <returns></returns>
-        public string GetSuggestedDestination(ILibrary library)
+        public override string GetSuggestedDestination(ILibrary library)
         {
             if (library != null && library is CdnjsLibrary cdnjsLibrary)
             {
@@ -132,211 +49,9 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
             return string.Empty;
         }
 
-        private async Task<ILibraryOperationResult> WriteToFilesAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
+        protected override string GetDownloadUrl(ILibraryInstallationState state, string sourceFile)
         {
-            if (state.Files != null)
-            {
-                try
-                {
-                    foreach (string file in state.Files)
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            return LibraryOperationResult.FromCancelled(state);
-                        }
-
-                        if (string.IsNullOrEmpty(file))
-                        {
-                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
-                        }
-
-                        string destinationPath = Path.Combine(state.DestinationPath, file);
-                        var sourceStream = new Func<Stream>(() => GetStreamAsync(state, file, cancellationToken).Result);
-                        bool writeOk = await HostInteraction.WriteFileAsync(destinationPath, sourceStream, state, cancellationToken).ConfigureAwait(false);
-
-                        if (!writeOk)
-                        {
-                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
-                        }
-                    }
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    return new LibraryOperationResult(state, PredefinedErrors.PathOutsideWorkingDirectory());
-                }
-                catch (Exception ex)
-                {
-                    HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                    return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
-                }
-            }
-
-            return LibraryOperationResult.FromSuccess(state);
-        }
-
-        /// <summary>
-        /// Updates file set on the passed in ILibraryInstallationState in case user selected to have all files included
-        /// </summary>
-        /// <param name="desiredState"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public async Task<ILibraryOperationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(desiredState);
-            }
-
-            string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(desiredState.Name, desiredState.Version, Id);
-            try
-            {
-                ILibraryCatalog catalog = GetCatalog();
-                ILibrary library = await catalog.GetLibraryAsync(desiredState.Name, desiredState.Version, cancellationToken).ConfigureAwait(false);
-
-                if (library == null)
-                {
-                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.Name, desiredState.ProviderId));
-                }
-
-                if (desiredState.Files != null && desiredState.Files.Count > 0)
-                {
-                    IReadOnlyList<string> invalidFiles = library.GetInvalidFiles(desiredState.Files);
-                    if (invalidFiles.Any())
-                    {
-                        IError invalidFilesError = PredefinedErrors.InvalidFilesInLibrary(libraryId, invalidFiles, library.Files.Keys);
-                        return new LibraryOperationResult(desiredState, invalidFilesError);
-                    }
-                    else
-                    {
-                        return LibraryOperationResult.FromSuccess(desiredState);
-                    }
-                }
-
-                desiredState = new LibraryInstallationState
-                {
-                    ProviderId = Id,
-                    Name = desiredState.Name,
-                    Version = desiredState.Version,
-                    DestinationPath = desiredState.DestinationPath,
-                    Files = library.Files.Keys.ToList(),
-                    IsUsingDefaultDestination = desiredState.IsUsingDefaultDestination,
-                    IsUsingDefaultProvider = desiredState.IsUsingDefaultProvider
-                };
-            }
-            catch (InvalidLibraryException)
-            {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(libraryId, desiredState.ProviderId));
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.PathOutsideWorkingDirectory());
-            }
-            catch (Exception ex)
-            {
-                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnknownException());
-            }
-
-            return LibraryOperationResult.FromSuccess(desiredState);
-        }
-
-        private async Task<Stream> GetStreamAsync(ILibraryInstallationState state, string sourceFile, CancellationToken cancellationToken)
-        {
-            if (!string.IsNullOrEmpty(state.Name) && !string.IsNullOrEmpty(state.Version))
-            {
-                string absolute = Path.Combine(CacheFolder, state.Name, state.Version, sourceFile);
-
-                if (File.Exists(absolute))
-                {
-                    return await HostInteraction.ReadFileAsync(absolute, cancellationToken).ConfigureAwait(false);
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Copies ILibraryInstallationState files to cache
-        /// </summary>
-        /// <param name="state"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        private async Task<ILibraryOperationResult> RefreshCacheAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(state);
-            }
-
-            var tasks = new List<Task>();
-
-            try
-            {
-                if (!string.IsNullOrEmpty(state.Name) && !string.IsNullOrEmpty(state.Version))
-                {
-                    string libraryDir = Path.Combine(CacheFolder, state.Name);
-                    List<CacheFileMetadata> librariesMetadata = new List<CacheFileMetadata>();
-
-                    foreach (string sourceFile in state.Files)
-                    {
-                        string cacheFile = Path.Combine(libraryDir, state.Version, sourceFile);
-                        string url = string.Format(DownloadUrlFormat, state.Name, state.Version, sourceFile);
-
-                        CacheFileMetadata newEntry = new CacheFileMetadata(url, cacheFile);
-                        if (!librariesMetadata.Contains(newEntry))
-                        {
-                            librariesMetadata.Add(new CacheFileMetadata(url, cacheFile));
-                        }
-                    }
-
-                    await _cacheService.RefreshCacheAsync(librariesMetadata, cancellationToken);
-                }
-            }
-            catch (ResourceDownloadException ex)
-            {
-                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(state, PredefinedErrors.FailedToDownloadResource(ex.Url));
-            }
-            catch (OperationCanceledException)
-            {
-                return LibraryOperationResult.FromCancelled(state);
-            }
-            catch (Exception ex)
-            {
-                HostInteraction.Logger.Log(ex.InnerException.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
-            }
-
-            return LibraryOperationResult.FromSuccess(state);
-        }
-
-        private bool IsLibraryUpToDate(ILibraryInstallationState state)
-        {
-            try
-            {
-                if (!string.IsNullOrEmpty(state.Name) && !string.IsNullOrEmpty(state.Version))
-                {
-                    string cacheDir = Path.Combine(CacheFolder, state.Name, state.Version);
-                    string destinationDir = Path.Combine(HostInteraction.WorkingDirectory, state.DestinationPath);
-
-                    foreach (string sourceFile in state.Files)
-                    {
-                        var destinationFile = new FileInfo(Path.Combine(destinationDir, sourceFile).Replace('\\', '/'));
-                        var cacheFile = new FileInfo(Path.Combine(cacheDir, sourceFile).Replace('\\', '/'));
-
-                        if (!destinationFile.Exists || !cacheFile.Exists || !FileHelpers.AreFilesUpToDate(destinationFile, cacheFile))
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                return false;
-            }
-
-            return true;
+            return string.Format(DownloadUrlFormat, state.Name, state.Version, sourceFile);
         }
     }
 }

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProviderFactory.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProviderFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
                 throw new ArgumentNullException(nameof(hostInteraction));
             }
 
-            return new CdnjsProvider(hostInteraction);
+            return new CdnjsProvider(hostInteraction, new CacheService(WebRequestHandler.Instance));
         }
     }
 }

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -1,98 +1,41 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 {
-    internal class UnpkgProvider : IProvider
+    internal sealed class UnpkgProvider : BaseProvider
     {
         public const string IdText = "unpkg";
         public const string DownloadUrlFormat = "https://unpkg.com/{0}@{1}/{2}";
         private readonly INpmPackageSearch _packageSearch;
         private readonly INpmPackageInfoFactory _infoFactory;
-        private CacheService _cacheService;
         private ILibraryCatalog _catalog;
 
-        public UnpkgProvider(IHostInteraction hostInteraction, INpmPackageSearch packageSearch, INpmPackageInfoFactory infoFactory)
+        public UnpkgProvider(IHostInteraction hostInteraction, CacheService cacheService, INpmPackageSearch packageSearch, INpmPackageInfoFactory infoFactory)
+            :base(hostInteraction, cacheService)
         {
             _packageSearch = packageSearch;
             _infoFactory = infoFactory;
-
-            HostInteraction = hostInteraction;
-            // TODO: {alexgav} Do we need multiple instances of CacheService?
-            _cacheService = new CacheService(WebRequestHandler.Instance);
         }
 
-        public string Id => IdText;
+        public override string Id => IdText;
 
-        public string NuGetPackageId { get; } = "Microsoft.Web.LibraryManager.Build";
-
-        public IHostInteraction HostInteraction { get; }
-
-        private ILibraryNamingScheme LibraryNamingScheme { get; } = new VersionedLibraryNamingScheme();
-
-        public ILibraryCatalog GetCatalog()
+        public override ILibraryCatalog GetCatalog()
         {
+            // TODO: sort out the WebRequestHandler dependency
             return _catalog ?? (_catalog = new UnpkgCatalog(Id, LibraryNamingScheme, HostInteraction.Logger, WebRequestHandler.Instance, _infoFactory, _packageSearch));
         }
 
-        // TODO: {alexgav} Could got to a command provider base class
-        internal string CacheFolder
-        {
-            get { return Path.Combine(HostInteraction.CacheDirectory, Id); }
-        }
-
-        public string LibraryIdHintText => Resources.Text.UnpkgProviderHintText;
-
-        public bool SupportsLibraryVersions => true;
-
-        public async Task<ILibraryOperationResult> InstallAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(desiredState);
-            }
-
-            //Expand the files property if needed
-            ILibraryOperationResult updateResult = await UpdateStateAsync(desiredState, cancellationToken);
-            if (!updateResult.Success)
-            {
-                return updateResult;
-            }
-
-            desiredState = updateResult.InstallationState;
-
-            // Refresh cache if needed
-            ILibraryOperationResult cacheUpdateResult = await RefreshCacheAsync(desiredState, cancellationToken);
-            if (!cacheUpdateResult.Success)
-            {
-                return cacheUpdateResult;
-            }
-
-            // Check if Library is already up tp date
-            if (IsLibraryUpToDate(desiredState, cancellationToken))
-            {
-                return LibraryOperationResult.FromUpToDate(desiredState);
-            }
-
-            // Write files to destination
-            return await WriteToFilesAsync(desiredState, cancellationToken);
-        }
+        public override string LibraryIdHintText => Resources.Text.UnpkgProviderHintText;
 
         /// <summary>
         /// Returns the UnpkgLibrary's name.
         /// </summary>
         /// <param name="library"></param>
         /// <returns></returns>
-        public string GetSuggestedDestination(ILibrary library)
+        public override string GetSuggestedDestination(ILibrary library)
         {
             if (library != null && library is UnpkgLibrary unpkgLibrary)
             {
@@ -102,197 +45,9 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
             return string.Empty;
         }
 
-        /// <summary>
-        /// Copies ILibraryInstallationState files to cache
-        /// </summary>
-        /// <param name="state"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        private async Task<LibraryOperationResult> RefreshCacheAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
+        protected override string GetDownloadUrl(ILibraryInstallationState state, string sourceFile)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(state);
-            }
-
-            var tasks = new List<Task>();
-            string libraryDir = Path.Combine(CacheFolder, state.Name);
-
-            try
-            {
-                    List<CacheFileMetadata> librariesMetadata = new List<CacheFileMetadata>();
-                    foreach (string sourceFile in state.Files)
-                    {
-                        string cacheFile = Path.Combine(libraryDir, state.Version, sourceFile);
-                        string url = string.Format(DownloadUrlFormat, state.Name, state.Version, sourceFile);
-
-                        CacheFileMetadata newEntry = new CacheFileMetadata(url, cacheFile);
-                        if (!librariesMetadata.Contains(newEntry))
-                        {
-                            librariesMetadata.Add(new CacheFileMetadata(url, cacheFile));
-                        }
-                    }
-                    await _cacheService.RefreshCacheAsync(librariesMetadata, cancellationToken);
-            }
-            catch (ResourceDownloadException ex)
-            {
-                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(state, PredefinedErrors.FailedToDownloadResource(ex.Url));
-            }
-            catch (OperationCanceledException)
-            {
-                return LibraryOperationResult.FromCancelled(state);
-            }
-            catch (Exception ex)
-            {
-                HostInteraction.Logger.Log(ex.InnerException.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
-            }
-
-            return LibraryOperationResult.FromSuccess(state);
-        }
-
-        private bool IsLibraryUpToDate(ILibraryInstallationState state, CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (!string.IsNullOrEmpty(state.Name) && !string.IsNullOrEmpty(state.Version))
-                {
-                    string cacheDir = Path.Combine(CacheFolder, state.Name, state.Version);
-                    string destinationDir = Path.Combine(HostInteraction.WorkingDirectory, state.DestinationPath);
-
-
-                    foreach (string sourceFile in state.Files)
-                    {
-                        var destinationFile = new FileInfo(Path.Combine(destinationDir, sourceFile).Replace('\\', '/'));
-                        var cacheFile = new FileInfo(Path.Combine(cacheDir, sourceFile).Replace('\\', '/'));
-
-                        if (!destinationFile.Exists || !cacheFile.Exists || !FileHelpers.AreFilesUpToDate(destinationFile, cacheFile))
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private async Task<ILibraryOperationResult> WriteToFilesAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
-        {
-            if (state.Files != null)
-            {
-                try
-                {
-                    foreach (string file in state.Files)
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            return LibraryOperationResult.FromCancelled(state);
-                        }
-
-                        if (string.IsNullOrEmpty(file))
-                        {
-                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
-                        }
-
-                        string destinationPath = Path.Combine(state.DestinationPath, file);
-                        var sourceStream = new Func<Stream>(() => GetStreamAsync(state, file, cancellationToken).Result);
-                        bool writeOk = await HostInteraction.WriteFileAsync(destinationPath, sourceStream, state, cancellationToken).ConfigureAwait(false);
-
-                        if (!writeOk)
-                        {
-                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
-                        }
-                    }
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    return new LibraryOperationResult(state, PredefinedErrors.PathOutsideWorkingDirectory());
-                }
-                catch (Exception ex)
-                {
-                    HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                    return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
-                }
-            }
-
-            return LibraryOperationResult.FromSuccess(state);
-        }
-
-        private async Task<Stream> GetStreamAsync(ILibraryInstallationState state, string sourceFile, CancellationToken cancellationToken)
-        {
-            string absolute = Path.Combine(CacheFolder, state.Name, state.Version, sourceFile);
-
-            if (File.Exists(absolute))
-            {
-                return await HostInteraction.ReadFileAsync(absolute, cancellationToken).ConfigureAwait(false);
-            }
-
-            return null;
-        }
-
-        public async Task<ILibraryOperationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(desiredState);
-            }
-
-            string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(desiredState.Name, desiredState.Version, desiredState.ProviderId);
-            try
-            {
-                ILibraryCatalog catalog = GetCatalog();
-                ILibrary library = await catalog.GetLibraryAsync(desiredState.Name, desiredState.Version, cancellationToken).ConfigureAwait(false);
-
-
-                if (library == null)
-                {
-                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(libraryId, desiredState.ProviderId));
-                }
-
-                if (desiredState.Files != null && desiredState.Files.Count > 0)
-                {
-                    IReadOnlyList<string> invalidFiles = library.GetInvalidFiles(desiredState.Files);
-                    if (invalidFiles.Any())
-                    {
-                        var invalidFilesError = PredefinedErrors.InvalidFilesInLibrary(libraryId, invalidFiles, library.Files.Keys);
-                        return new LibraryOperationResult(desiredState, invalidFilesError);
-                    }
-                    else
-                    {
-                        return LibraryOperationResult.FromSuccess(desiredState);
-                    }
-                }
-
-                desiredState = new LibraryInstallationState
-                {
-                    ProviderId = Id,
-                    Name = desiredState.Name,
-                    Version = desiredState.Version,
-                    DestinationPath = desiredState.DestinationPath,
-                    Files = library.Files.Keys.ToList(),
-                };
-            }
-            catch (InvalidLibraryException)
-            {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(libraryId, desiredState.ProviderId));
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.PathOutsideWorkingDirectory());
-            }
-            catch (Exception ex)
-            {
-                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnknownException());
-            }
-
-            return LibraryOperationResult.FromSuccess(desiredState);
+            return string.Format(DownloadUrlFormat, state.Name, state.Version, sourceFile);
         }
     }
 }

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProviderFactory.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProviderFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
                 throw new ArgumentNullException(nameof(hostInteraction));
             }
 
-            return new UnpkgProvider(hostInteraction, _packageSearch, _packageInfoFactory);
+            return new UnpkgProvider(hostInteraction, new CacheService(WebRequestHandler.Instance), _packageSearch, _packageInfoFactory);
         }
     }
 }

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrProviderFactory.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrProviderFactory.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
                 throw new ArgumentNullException(nameof(hostInteraction));
             }
 
-            return new JsDelivrProvider(hostInteraction, _packageSearch, _packageInfoFactory);
+            return new JsDelivrProvider(hostInteraction, new CacheService(WebRequestHandler.Instance), _packageSearch, _packageInfoFactory);
         }
     }
 }

--- a/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
+++ b/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
@@ -13,7 +13,7 @@ using Microsoft.Web.LibraryManager.Providers.Unpkg;
 
 namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
 {
-    internal class JsDelivrProvider : IProvider
+    internal sealed class JsDelivrProvider : BaseProvider
     {
         private readonly INpmPackageSearch _packageSearch;
         private readonly INpmPackageInfoFactory _infoFactory;
@@ -22,79 +22,30 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
         public const string DownloadUrlFormat = "https://cdn.jsdelivr.net/npm/{0}@{1}/{2}";
         public const string DownloadUrlFormatGH = "https://cdn.jsdelivr.net/gh/{0}@{1}/{2}";
 
-        private readonly CacheService _cacheService;
         private ILibraryCatalog _catalog;
 
-        public JsDelivrProvider(IHostInteraction hostInteraction, INpmPackageSearch packageSearch, INpmPackageInfoFactory infoFactory)
+        public JsDelivrProvider(IHostInteraction hostInteraction, CacheService cacheService, INpmPackageSearch packageSearch, INpmPackageInfoFactory infoFactory)
+            :base(hostInteraction, cacheService)
         {
             _packageSearch = packageSearch;
             _infoFactory = infoFactory;
-
-            HostInteraction = hostInteraction;
-            _cacheService = new CacheService(WebRequestHandler.Instance);
         }
 
-        public string Id => IdText;
+        public override string Id => IdText;
 
-        public string NuGetPackageId { get; } = "Microsoft.Web.LibraryManager.Build";
-
-        public IHostInteraction HostInteraction { get; }
-
-        private ILibraryNamingScheme LibraryNamingScheme { get; } = new VersionedLibraryNamingScheme();
-
-        public ILibraryCatalog GetCatalog()
+        public override ILibraryCatalog GetCatalog()
         {
             return _catalog ?? (_catalog = new JsDelivrCatalog(Id, LibraryNamingScheme, HostInteraction.Logger, WebRequestHandler.Instance, _infoFactory, _packageSearch));
         }
-        
-        internal string CacheFolder
-        {
-            get { return Path.Combine(HostInteraction.CacheDirectory, Id); }
-        }
 
-        public string LibraryIdHintText => Resources.Text.JsDelivrProviderHintText;
-
-        public bool SupportsLibraryVersions => true;
-
-        public async Task<ILibraryOperationResult> InstallAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(desiredState);
-            }
-
-            //Expand the files property if needed
-            ILibraryOperationResult updateResult = await UpdateStateAsync(desiredState, cancellationToken);
-            if (!updateResult.Success)
-            {
-                return updateResult;
-            }
-
-            desiredState = updateResult.InstallationState;
-
-            // Refresh cache if needed
-            ILibraryOperationResult cacheUpdateResult = await RefreshCacheAsync(desiredState, cancellationToken);
-            if (!cacheUpdateResult.Success)
-            {
-                return cacheUpdateResult;
-            }
-
-            // Check if Library is already up tp date
-            if (IsLibraryUpToDate(desiredState, cancellationToken))
-            {
-                return LibraryOperationResult.FromUpToDate(desiredState);
-            }
-
-            // Write files to destination
-            return await WriteToFilesAsync(desiredState, cancellationToken);
-        }
+        public override string LibraryIdHintText => Resources.Text.JsDelivrProviderHintText;
 
         /// <summary>
         /// Returns the JsDelivrLibrary's name.
         /// </summary>
         /// <param name="library"></param>
         /// <returns></returns>
-        public string GetSuggestedDestination(ILibrary library)
+        public override string GetSuggestedDestination(ILibrary library)
         {
             if (library != null && library is JsDelivrLibrary jsDelivrLibrary)
             {
@@ -104,197 +55,10 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
             return string.Empty;
         }
 
-        /// <summary>
-        /// Copies ILibraryInstallationState files to cache
-        /// </summary>
-        /// <param name="state"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        private async Task<LibraryOperationResult> RefreshCacheAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
+        protected override string GetDownloadUrl(ILibraryInstallationState state, string sourceFile)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(state);
-            }
-
-            var tasks = new List<Task>();
-            string libraryDir = Path.Combine(CacheFolder, state.Name);
-
-            try
-            {
-                List<CacheFileMetadata> librariesMetadata = new List<CacheFileMetadata>();
-                foreach (string sourceFile in state.Files)
-                {
-                    string cacheFile = Path.Combine(libraryDir, state.Version, sourceFile);
-                    string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(state.Name, state.Version, state.ProviderId);
-                    string url = string.Format(JsDelivrCatalog.IsGitHub(libraryId) ? DownloadUrlFormatGH : DownloadUrlFormat, state.Name, state.Version, sourceFile);
-
-                    CacheFileMetadata newEntry = new CacheFileMetadata(url, cacheFile);
-                    if (!librariesMetadata.Contains(newEntry))
-                    {
-                        librariesMetadata.Add(new CacheFileMetadata(url, cacheFile));
-                    }
-                }
-                await _cacheService.RefreshCacheAsync(librariesMetadata, cancellationToken);
-            }
-            catch (ResourceDownloadException ex)
-            {
-                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(state, PredefinedErrors.FailedToDownloadResource(ex.Url));
-            }
-            catch (OperationCanceledException)
-            {
-                return LibraryOperationResult.FromCancelled(state);
-            }
-            catch (Exception ex)
-            {
-                HostInteraction.Logger.Log(ex.InnerException.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
-            }
-
-            return LibraryOperationResult.FromSuccess(state);
-        }
-
-        private bool IsLibraryUpToDate(ILibraryInstallationState state, CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (!string.IsNullOrEmpty(state.Name) && !string.IsNullOrEmpty(state.Version))
-                {
-                    string cacheDir = Path.Combine(CacheFolder, state.Name, state.Version);
-                    string destinationDir = Path.Combine(HostInteraction.WorkingDirectory, state.DestinationPath);
-
-
-                    foreach (string sourceFile in state.Files)
-                    {
-                        var destinationFile = new FileInfo(Path.Combine(destinationDir, sourceFile).Replace('\\', '/'));
-                        var cacheFile = new FileInfo(Path.Combine(cacheDir, sourceFile).Replace('\\', '/'));
-
-                        if (!destinationFile.Exists || !cacheFile.Exists || !FileHelpers.AreFilesUpToDate(destinationFile, cacheFile))
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private async Task<ILibraryOperationResult> WriteToFilesAsync(ILibraryInstallationState state, CancellationToken cancellationToken)
-        {
-            if (state.Files != null)
-            {
-                try
-                {
-                    foreach (string file in state.Files)
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            return LibraryOperationResult.FromCancelled(state);
-                        }
-
-                        if (string.IsNullOrEmpty(file))
-                        {
-                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
-                        }
-
-                        string destinationPath = Path.Combine(state.DestinationPath, file);
-                        var sourceStream = new Func<Stream>(() => GetStreamAsync(state, file, cancellationToken).Result);
-                        bool writeOk = await HostInteraction.WriteFileAsync(destinationPath, sourceStream, state, cancellationToken).ConfigureAwait(false);
-
-                        if (!writeOk)
-                        {
-                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
-                        }
-                    }
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    return new LibraryOperationResult(state, PredefinedErrors.PathOutsideWorkingDirectory());
-                }
-                catch (Exception ex)
-                {
-                    HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                    return new LibraryOperationResult(state, PredefinedErrors.UnknownException());
-                }
-            }
-
-            return LibraryOperationResult.FromSuccess(state);
-        }
-
-        private async Task<Stream> GetStreamAsync(ILibraryInstallationState state, string sourceFile, CancellationToken cancellationToken)
-        {
-            string absolute = Path.Combine(CacheFolder, state.Name, state.Version, sourceFile);
-
-            if (File.Exists(absolute))
-            {
-                return await HostInteraction.ReadFileAsync(absolute, cancellationToken).ConfigureAwait(false);
-            }
-
-            return null;
-        }
-
-        public async Task<ILibraryOperationResult> UpdateStateAsync(ILibraryInstallationState desiredState, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return LibraryOperationResult.FromCancelled(desiredState);
-            }
-
-            try
-            {
-                ILibraryCatalog catalog = GetCatalog();
-                ILibrary library = await catalog.GetLibraryAsync(desiredState.Name, desiredState.Version, cancellationToken).ConfigureAwait(false);
-                string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(desiredState.Name, desiredState.Version, Id);
-
-                if (library == null)
-                {
-                    return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.Name, desiredState.Version, desiredState.ProviderId));
-                }
-
-                if (desiredState.Files != null && desiredState.Files.Count > 0)
-                {
-                    IReadOnlyList<string> invalidFiles = library.GetInvalidFiles(desiredState.Files);
-                    if (invalidFiles.Any())
-                    {
-                        var invalidFilesError = PredefinedErrors.InvalidFilesInLibrary(libraryId, invalidFiles, library.Files.Keys);
-                        return new LibraryOperationResult(desiredState, invalidFilesError);
-                    }
-                    else
-                    {
-                        return LibraryOperationResult.FromSuccess(desiredState);
-                    }
-                }
-
-                desiredState = new LibraryInstallationState
-                {
-                    ProviderId = Id,
-                    Name = desiredState.Name,
-                    Version = desiredState.Version,
-                    DestinationPath = desiredState.DestinationPath,
-                    Files = library.Files.Keys.ToList(),
-                };
-            }
-            catch (InvalidLibraryException)
-            {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnableToResolveSource(desiredState.Name, desiredState.Version, desiredState.ProviderId));
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return new LibraryOperationResult(desiredState, PredefinedErrors.PathOutsideWorkingDirectory());
-            }
-            catch (Exception ex)
-            {
-                HostInteraction.Logger.Log(ex.ToString(), LogLevel.Error);
-                return new LibraryOperationResult(desiredState, PredefinedErrors.UnknownException());
-            }
-
-            return LibraryOperationResult.FromSuccess(desiredState);
+            string libraryId = LibraryNamingScheme.GetLibraryId(state.Name, state.Version);
+            return string.Format(JsDelivrCatalog.IsGitHub(libraryId) ? DownloadUrlFormatGH : DownloadUrlFormat, state.Name, state.Version, sourceFile);
         }
     }
 }

--- a/src/LibraryManager/Utilities/FileGlobbingUtility.cs
+++ b/src/LibraryManager/Utilities/FileGlobbingUtility.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Minimatch;
+
+namespace Microsoft.Web.LibraryManager.Utilities
+{
+    internal class FileGlobbingUtility
+    {
+        private static readonly char[] GlobIndicatorCharacters = "*?[".ToCharArray();
+
+        public static IEnumerable<string> ExpandFileGlobs(IEnumerable<string> potentialGlobs, IEnumerable<string> libraryFiles)
+        {
+            var finalSetOfFiles = new HashSet<string>();
+            var negatedOptions = new Minimatch.Options { FlipNegate = true };
+
+            foreach (string potentialGlob in potentialGlobs)
+            {
+                // only process globs where we find them, otherwise it can get expensive
+                if (potentialGlob.StartsWith("!", StringComparison.Ordinal))
+                {
+                    // Remove matches from the files list
+                    var filesToRemove = finalSetOfFiles.Where(f => Minimatcher.Check(f, potentialGlob, negatedOptions)).ToList();
+                    foreach (string file in filesToRemove)
+                    {
+                        finalSetOfFiles.Remove(file);
+                    }
+                }
+                else if (potentialGlob.IndexOfAny(GlobIndicatorCharacters) >= 0)
+                {
+                    IEnumerable<string> filterResult = libraryFiles.Where(f => Minimatcher.Check(f, potentialGlob));
+                    if (filterResult.Any())
+                    {
+                        finalSetOfFiles.UnionWith(filterResult);
+                    }
+                }
+                else
+                {
+                    // not a glob pattern, so just include the file literally
+                    finalSetOfFiles.Add(potentialGlob);
+                }
+            }
+
+            return finalSetOfFiles;
+        }
+    }
+}

--- a/test/LibraryManager.Test/Configuration/SettingsTest.cs
+++ b/test/LibraryManager.Test/Configuration/SettingsTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Configuration;
-using Microsoft.Web.LibraryManager.Test.Utilities;
+using Microsoft.Web.LibraryManager.Test.TestUtilities;
 
 namespace Microsoft.Web.LibraryManager.Test.Configuration
 {

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
 
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.Cancelled);
-            Assert.AreSame(desiredState, result.InstallationState);
             Assert.AreEqual(0, result.Errors.Count);
         }
 
@@ -181,6 +180,24 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         }
 
         [TestMethod]
+        public async Task InstallAsync_WithGlobPatterns_CorrectlyInstallsAllMatchingFiles()
+        {
+            var desiredState = new LibraryInstallationState
+            {
+                Name = "jquery",
+                Version = "1.2.3",
+                DestinationPath = "lib",
+                Files = new[] { "*.js", "!*.min.js" },
+            };
+
+            // Install library
+            ILibraryOperationResult result = await _provider.InstallAsync(desiredState, CancellationToken.None).ConfigureAwait(false);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.InstallationState.Files.Count == 1); // jquery.min.js file was excluded
+            Assert.AreEqual("jquery.js", result.InstallationState.Files.First());
+        }
+
+        [TestMethod]
         public void GetSuggestedDestination()
         {
             Assert.AreEqual(string.Empty, _provider.GetSuggestedDestination(null));
@@ -196,7 +213,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         }
 
         [TestMethod]
-        private void GetCatalog()
+        public void GetCatalog()
         {
             ILibraryCatalog catalog = _provider.GetCatalog();
 

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
@@ -99,7 +99,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             string copiedFile = Path.Combine(_projectFolder, desiredState.DestinationPath, desiredState.Files[0]);
             Assert.IsTrue(File.Exists(copiedFile), "File1 wasn't copied");
             Assert.IsFalse(result.Cancelled);
-            Assert.AreSame(desiredState, result.InstallationState);
             Assert.AreEqual(0, result.Errors.Count);
 
             var manifest = Manifest.FromJson("{}", _dependencies);
@@ -138,7 +137,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             Assert.IsTrue(File.Exists(file2), "File2 wasn't copied");
 
             Assert.IsFalse(result.Cancelled);
-            Assert.AreSame(desiredState, result.InstallationState);
             Assert.AreEqual(0, result.Errors.Count);
         }
 
@@ -174,7 +172,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.FileSystem
             Assert.IsTrue(File.Exists(file2), "File1 wasn't copied");
 
             Assert.IsFalse(result.Cancelled);
-            Assert.AreSame(desiredState, result.InstallationState);
             Assert.AreEqual(0, result.Errors.Count);
         }
 

--- a/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderTest.cs
@@ -89,7 +89,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
             //GitHub library test
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.Cancelled);
-            Assert.AreSame(desiredState, result.InstallationState);
             Assert.AreEqual(0, result.Errors.Count);
 
             var desiredStateGH = new LibraryInstallationState
@@ -112,7 +111,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
 
             Assert.IsTrue(resultGH.Success);
             Assert.IsFalse(resultGH.Cancelled);
-            Assert.AreSame(desiredStateGH, resultGH.InstallationState);
             Assert.AreEqual(0, resultGH.Errors.Count);
         }
 
@@ -204,6 +202,23 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
             ILibraryOperationResult result = await _provider.InstallAsync(desiredState, CancellationToken.None).ConfigureAwait(false);
             Assert.IsFalse(result.Success);
             Assert.AreEqual("LIB018", result.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public async Task InstallAsync_WithGlobPatterns_CorrectlyInstallsAllMatchingFiles()
+        {
+            var desiredState = new LibraryInstallationState
+            {
+                Name = "jquery",
+                Version = "3.3.1",
+                DestinationPath = "lib",
+                Files = new[] { "dist/*.js", "!dist/*min*" },
+            };
+
+            // Install library
+            ILibraryOperationResult result = await _provider.InstallAsync(desiredState, CancellationToken.None).ConfigureAwait(false);
+            Assert.IsTrue(result.Success);
+            CollectionAssert.AreEquivalent(new[] { "dist/core.js", "dist/jquery.js", "dist/jquery.slim.js" }, result.InstallationState.Files.ToList());
         }
 
         [TestMethod]

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
@@ -12,7 +12,6 @@ using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.Unpkg;
-using Moq;
 
 namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
 {
@@ -87,7 +86,6 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
 
             Assert.IsTrue(result.Success);
             Assert.IsFalse(result.Cancelled);
-            Assert.AreSame(desiredState, result.InstallationState);
             Assert.AreEqual(0, result.Errors.Count);
         }
 
@@ -179,6 +177,23 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
             ILibraryOperationResult result = await _provider.InstallAsync(desiredState, CancellationToken.None).ConfigureAwait(false);
             Assert.IsFalse(result.Success);
             Assert.AreEqual("LIB018", result.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public async Task InstallAsync_WithGlobPatterns_CorrectlyInstallsAllMatchingFiles()
+        {
+            var desiredState = new LibraryInstallationState
+            {
+                Name = "jquery",
+                Version = "3.3.1",
+                DestinationPath = "lib",
+                Files = new[] { "dist/*.js", "!dist/*min*" },
+            };
+
+            // Install library
+            ILibraryOperationResult result = await _provider.InstallAsync(desiredState, CancellationToken.None).ConfigureAwait(false);
+            Assert.IsTrue(result.Success);
+            CollectionAssert.AreEquivalent(new[] { "dist/core.js", "dist/jquery.js", "dist/jquery.slim.js" }, result.InstallationState.Files.ToList());
         }
 
         [TestMethod]

--- a/test/LibraryManager.Test/TestUtilities/StringUtility.cs
+++ b/test/LibraryManager.Test/TestUtilities/StringUtility.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.Web.LibraryManager.Test.Utilities
+namespace Microsoft.Web.LibraryManager.Test.TestUtilities
 {
     internal static class StringUtility
     {

--- a/test/LibraryManager.Test/Utilities/FileGlobbingUtilityTests.cs
+++ b/test/LibraryManager.Test/Utilities/FileGlobbingUtilityTests.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Utilities;
+
+namespace Microsoft.Web.LibraryManager.Test.Utilities
+{
+    [TestClass]
+    public class FileGlobbingUtilityTests
+    {
+        [TestMethod]
+        public void GetMatchedFiles_NoGlobsSpecified_ReturnsInputList()
+        {
+            string[] libraryFiles = new[]
+            {
+                "file.css",
+                "folder/file.css",
+            };
+            string[] fileSpec = new[]
+            {
+                "file.css",
+            };
+
+            IEnumerable<string> result = FileGlobbingUtility.ExpandFileGlobs(fileSpec, libraryFiles);
+
+            CollectionAssert.AreEqual(fileSpec, result.ToList());
+        }
+
+        [TestMethod]
+        public void GetMatchedFiles_NoGlobsSpecifiedAndNoMatches_ReturnsInputList()
+        {
+            string[] libraryFiles = new[]
+            {
+                "folder/file.css",
+            };
+            string[] fileSpec = new[]
+            {
+                "file.css",
+            };
+
+            IEnumerable<string> result = FileGlobbingUtility.ExpandFileGlobs(fileSpec, libraryFiles);
+
+            CollectionAssert.AreEqual(fileSpec, result.ToList());
+        }
+
+        [TestMethod]
+        public void GetMatchedFiles_ContainsGlobMatchingZeroFiles_EmptyList()
+        {
+            string[] libraryFiles = new[]
+            {
+                "file.js",
+            };
+            string[] fileSpec = new[]
+            {
+                "*.css",
+            };
+
+            IEnumerable<string> result = FileGlobbingUtility.ExpandFileGlobs(fileSpec, libraryFiles);
+
+            CollectionAssert.AreEqual(Array.Empty<string>(), result.ToList());
+        }
+
+        [TestMethod]
+        public void GetMatchedFiles_ContainsGlobMatchingMultipleFiles_ReturnsAllMatches()
+        {
+            string[] libraryFiles = new[]
+            {
+                "a.css",
+                "b.css",
+            };
+            string[] fileSpec = new[]
+            {
+                "*.css",
+            };
+
+            IEnumerable<string> result = FileGlobbingUtility.ExpandFileGlobs(fileSpec, libraryFiles);
+
+            CollectionAssert.AreEqual(libraryFiles, result.ToList());
+        }
+
+        [TestMethod]
+        public void GetMatchedFiles_ContainsGlobsUsingGlobStar_ReturnsMatches()
+        {
+            string[] libraryFiles = new[] {
+                "notMatch/foo/file.css",
+                "match/foo/a.css",
+                "match/bar/baz/b.css",
+            };
+            string[] fileSpec = new[] {
+                "match/**/*.css",
+            };
+
+            IEnumerable<string> result = FileGlobbingUtility.ExpandFileGlobs(fileSpec, libraryFiles);
+
+            string[] expected = new[] {
+                "match/foo/a.css",
+                "match/bar/baz/b.css",
+            };
+            CollectionAssert.AreEqual(expected, result.ToList());
+        }
+
+        [TestMethod]
+        public void GetMatchedFiles_ContainsGlobsWithExclusion_ReturnsRemovesFilesMatchingExclusion()
+        {
+            string[] libraryFiles = new[] {
+                "notMatch/foo/file.css",
+                "match/foo/a.css",
+                "match/bar/baz/b.css",
+            };
+            string[] fileSpec = new[] {
+                "match/**/*.css",
+                "!**/b.css",
+            };
+
+            IEnumerable<string> result = FileGlobbingUtility.ExpandFileGlobs(fileSpec, libraryFiles);
+
+            string[] expected = new[] {
+                "match/foo/a.css",
+            };
+            CollectionAssert.AreEqual(expected, result.ToList());
+        }
+
+        [TestMethod]
+        public void GetMatchedFiles_ContainsGlobsWithExclusion_ProcessedInOrderSeen()
+        {
+            string[] libraryFiles = new[] {
+                "match/foo/a.css",
+                "match/bar/baz/b.css",
+                "other/foo/b.css",
+            };
+            string[] fileSpec = new[] {
+                "match/**/*.css",
+                "!**/b.css",
+                "other/**/*.css"
+            };
+
+            IEnumerable<string> result = FileGlobbingUtility.ExpandFileGlobs(fileSpec, libraryFiles);
+
+            string[] expected = new[] {
+                "match/foo/a.css",
+                "other/foo/b.css",
+            };
+            CollectionAssert.AreEqual(expected, result.ToList());
+        }
+    }
+}

--- a/test/libman.Test/LibmanCacheCleanTests.cs
+++ b/test/libman.Test/LibmanCacheCleanTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             Assert.IsFalse(File.Exists(Path.Combine(CacheDir, "cdnjs", "jquery", "3.2.1", "jquery.min.js")));
             Assert.IsFalse(File.Exists(Path.Combine(CacheDir, "cdnjs", "jquery", "3.2.1", "core.js")));
 
-            Assert.IsTrue(File.Exists(Path.Combine(CacheDir, "fileSystem", "abc.js")));
+            Assert.IsTrue(File.Exists(Path.Combine(CacheDir, "filesystem", "abc.js")));
         }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0",
+  "version": "2.1",
   "publicRefSpec": [
     "^refs/tags/v\\d+\\.\\d+" // we release tags starting with vN.N
   ]


### PR DESCRIPTION
This change adds support for file patterns (`*.js`, or `**/*.css`, or even negations like `!*.map`) in the libman.json file.  This has been a top requested feature since day 1.

File pattern support is a pretty big behavioral change (even if the diff is small).  While it is technically a breaking change (e.g. a file named `*.js` will now be expanded), I doubt it will actually impact anyone negatively.  It is easier though with the version bump to say that file patterns are supported on 2.1+ instead of 2.0.113+ (or whatever the actual release version is).