### PR TITLE
Download files in parallel

### DIFF
--- a/src/LibraryManager/CacheService/CacheService.cs
+++ b/src/LibraryManager/CacheService/CacheService.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Web.LibraryManager
         // TO DO: Move these expirations to the provider
         private const int CatalogExpiresAfterDays = 1;
         private const int MetadataExpiresAfterDays = 1;
-        private const int LibraryExpiresAfterDays = 30;
         private const int MaxConcurrentDownloads = 10;
 
         private readonly IWebRequestHandler _requestHandler;
@@ -134,7 +133,7 @@ namespace Microsoft.Web.LibraryManager
 
             async Task DownloadFileIfNecessaryAsync(CacheFileMetadata metadata)
             {
-                if (!File.Exists(metadata.DestinationPath) || File.GetLastWriteTime(metadata.DestinationPath) < DateTime.Now.AddDays(-LibraryExpiresAfterDays))
+                if (!File.Exists(metadata.DestinationPath))
                 {
                     logger.Log(string.Format(Resources.Text.DownloadingFile, metadata.Source), LogLevel.Operation);
                     await DownloadToFileAsync(metadata.Source, metadata.DestinationPath, attempts: 5, cancellationToken: cancellationToken);

--- a/src/LibraryManager/CacheService/CacheService.cs
+++ b/src/LibraryManager/CacheService/CacheService.cs
@@ -140,7 +140,6 @@ namespace Microsoft.Web.LibraryManager
                 if (!File.Exists(metadata.DestinationPath) || File.GetLastWriteTime(metadata.DestinationPath) < DateTime.Now.AddDays(-_libraryExpiresAfterDays))
                 {
                     Task readFileTask = DownloadToFileAsync(metadata.Source, metadata.DestinationPath, attempts: 5, cancellationToken: cancellationToken);
-                    await readFileTask;
                     refreshTasks.Add(readFileTask);
                 }
             }

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Web.LibraryManager.Providers
                         librariesMetadata.Add(new CacheFileMetadata(url, cacheFile));
                     }
                 }
-                await _cacheService.RefreshCacheAsync(librariesMetadata, cancellationToken);
+                await _cacheService.RefreshCacheAsync(librariesMetadata, HostInteraction.Logger, cancellationToken);
             }
             catch (ResourceDownloadException ex)
             {

--- a/src/LibraryManager/Resources/Text.Designer.cs
+++ b/src/LibraryManager/Resources/Text.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Text {
@@ -138,6 +138,15 @@ namespace Microsoft.Web.LibraryManager.Resources {
         public static string Clean_OperationStarted {
             get {
                 return ResourceManager.GetString("Clean_OperationStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloading file {0}....
+        /// </summary>
+        public static string DownloadingFile {
+            get {
+                return ResourceManager.GetString("DownloadingFile", resourceCulture);
             }
         }
         

--- a/src/LibraryManager/Resources/Text.resx
+++ b/src/LibraryManager/Resources/Text.resx
@@ -274,4 +274,7 @@
   <data name="JsDelivrProviderHintText" xml:space="preserve">
     <value>Example: &lt;library&gt;@&lt;version&gt;</value>
   </data>
+  <data name="DownloadingFile" xml:space="preserve">
+    <value>Downloading file {0}...</value>
+  </data>
 </root>

--- a/src/LibraryManager/Utilities/ParallelUtility.cs
+++ b/src/LibraryManager/Utilities/ParallelUtility.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Web.LibraryManager.Utilities
+{
+    internal static class ParallelUtility
+    {
+        /// <summary>
+        /// Executes an action over each element of a collection, up to the specified degree of parallelism.
+        /// </summary>
+        /// <param name="action">The action to be applied to each element</param>
+        /// <param name="degreeOfParallelism">How many tasks to run in parallel</param>
+        /// <param name="items">The items to operate over</param>
+        public static Task ForEachAsync<T>(Func<T, Task> action, int degreeOfParallelism, IEnumerable<T> items)
+        {
+            return ForEachAsync<T>(action, degreeOfParallelism, items, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Executes an action over each element of a collection, up to the specified degree of parallelism.
+        /// </summary>
+        /// <param name="action">The action to be applied to each element</param>
+        /// <param name="degreeOfParallelism">How many tasks to run in parallel</param>
+        /// <param name="items">The items to operate over</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public static async Task ForEachAsync<T>(Func<T, Task> action, int degreeOfParallelism, IEnumerable<T> items, CancellationToken cancellationToken)
+        {
+            action = action ?? throw new ArgumentNullException(nameof(action));
+            items = items ?? throw new ArgumentNullException(nameof(items));
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var semaphore = new SemaphoreSlim(degreeOfParallelism, degreeOfParallelism);
+            var allTasks = new List<Task>();
+
+            foreach (T item in items)
+            {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Task task = DoActionAndRelease(action, item, semaphore);
+                allTasks.Add(task);
+            }
+
+            await Task.WhenAll(allTasks).ConfigureAwait(false);
+        }
+
+        private static async Task DoActionAndRelease<T>(Func<T, Task> act, T input, SemaphoreSlim s)
+        {
+            try
+            {
+                await act(input).ConfigureAwait(false);
+            }
+            finally
+            {
+                s.Release();
+            }
+        }
+    }
+}

--- a/test/LibraryManager.Test/CacheServiceTest.cs
+++ b/test/LibraryManager.Test/CacheServiceTest.cs
@@ -109,45 +109,42 @@ namespace Microsoft.Web.LibraryManager.Test
         }
 
         [TestMethod]
-        [ExpectedException(typeof(OperationCanceledException))]
         public async Task HydrateCache_Throws_OperationCanceled_WhenCancelled()
         {
-            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
-            CancellationTokenSource tokenSource = new CancellationTokenSource();
+            var logger = new Logger();
+            var tokenSource = new CancellationTokenSource();
             string libraryFile1_Path = Path.Combine(_cacheFolder, "Library1", "file1.txt");
             string libraryFile2_Path = Path.Combine(_cacheFolder, "Library1", "file2.txt");
             string validUrl = "";
-            string destinationFile = _cacheFolder;
 
-            List<CacheFileMetadata> desiredCasheFiles = new List<CacheFileMetadata>()
+            var desiredCacheFiles = new List<CacheFileMetadata>()
             {
                 new CacheFileMetadata(validUrl, libraryFile1_Path),
                 new CacheFileMetadata(validUrl, libraryFile2_Path)
             };
 
             tokenSource.Cancel();
-            await _cacheService.RefreshCacheAsync(desiredCasheFiles, tokenSource.Token);
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+                await _cacheService.RefreshCacheAsync(desiredCacheFiles, logger, tokenSource.Token));
 
         }
 
         [TestMethod]
         public async Task HydrateCache_WriteLibraryFilesToCacheFolder()
         {
-            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
-            CancellationTokenSource tokenSource = new CancellationTokenSource();
+            var logger = new Logger();
             string libraryFile1_Path = Path.Combine(_cacheFolder, "Library1", "file1.txt");
             string libraryFile2_Path = Path.Combine(_cacheFolder, "Library1", "file2.txt");
             string validUrl = "";
-            string destinationFile = _cacheFolder;
 
-            List<CacheFileMetadata> desiredCasheFiles = new List<CacheFileMetadata>()
+            var desiredCasheFiles = new List<CacheFileMetadata>()
             {
                 new CacheFileMetadata(validUrl, libraryFile1_Path),
                 new CacheFileMetadata(validUrl, libraryFile2_Path)
             };
 
             // act 
-            await _cacheService.RefreshCacheAsync(desiredCasheFiles, CancellationToken.None);
+            await _cacheService.RefreshCacheAsync(desiredCasheFiles, logger, CancellationToken.None);
 
             // verify
             Assert.IsTrue(File.Exists(libraryFile1_Path));

--- a/test/LibraryManager.Test/Utilities/ParallelUtilityTests.cs
+++ b/test/LibraryManager.Test/Utilities/ParallelUtilityTests.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Utilities;
+
+namespace Microsoft.Web.LibraryManager.Test.Utilities
+{
+    [TestClass]
+    public class ParallelUtilityTests
+    {
+        [TestMethod]
+        public async Task ForEachAsync_NullAction_ShouldThrow()
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await ParallelUtility.ForEachAsync(null, 1, Array.Empty<object>())
+            );
+        }
+
+        [TestMethod]
+        public async Task ForEachAsync_0DegreesParallelism_ShouldThrow()
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(async () =>
+                await ParallelUtility.ForEachAsync((i) => Task.CompletedTask, 0, Array.Empty<object>())
+            );
+        }
+
+        [TestMethod]
+        public async Task ForEachAsync_NegativeDegreesParallelism_ShouldThrow()
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(async () =>
+                await ParallelUtility.ForEachAsync((i) => Task.CompletedTask, -5, Array.Empty<object>())
+            );
+        }
+
+        [TestMethod]
+        public async Task ForEachAsync_NullItems_ShouldThrow()
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await ParallelUtility.ForEachAsync((i) => Task.CompletedTask, 1, (object[])null)
+            );
+        }
+
+        [TestMethod]
+        public async Task ForEachAsync_ValidEmptyArguments_ShouldRunWithoutExceptions()
+        {
+            await ParallelUtility.ForEachAsync((i) => Task.CompletedTask, 1, Array.Empty<object>());
+        }
+
+        [TestMethod]
+        public async Task ForEachAsync_IfOneTaskFails_AllTasksGetRun()
+        {
+            int counter = 0;
+
+            Exception exception = await Assert.ThrowsExceptionAsync<Exception>(async () =>
+                await ParallelUtility.ForEachAsync((i) =>
+                {
+                    if (i % 2 == 0)
+                    {
+                        throw new Exception("Expected Failure");
+                    }
+                    counter++;
+                    return Task.CompletedTask;
+                }, 1, Enumerable.Range(1, 3))
+            );
+
+            Assert.AreEqual("Expected Failure", exception.Message);
+            Assert.AreEqual(2, counter); // both 1 and 3 ran, 2 threw the exception
+        }
+
+        [TestMethod]
+        public async Task ForEachAsync_CancellationTokenSet_DoesNotRunAllTasks()
+        {
+            int counter = 0;
+            var cts = new CancellationTokenSource();
+
+            Exception exception = await Assert.ThrowsExceptionAsync<TaskCanceledException>(async () =>
+                await ParallelUtility.ForEachAsync((i) =>
+                {
+                    if (i % 2 == 0)
+                    {
+                        cts.Cancel();
+                    }
+                    counter++;
+                    return Task.CompletedTask;
+                }, 1, Enumerable.Range(1, 3), cts.Token)
+            );
+
+            Assert.AreEqual(2, counter); // both 1 and 2 ran, but operation was cancelled before 3
+        }
+
+        [TestMethod]
+        public async Task ForEachAsync_IfMultipleTasksFail_AllTasksGetRun_OnlyFirstExceptionIsReported()
+        {
+            int counter = 0;
+
+            Exception exception = await Assert.ThrowsExceptionAsync<Exception>(async () =>
+                await ParallelUtility.ForEachAsync((i) =>
+                {
+                    if (i % 2 == 0)
+                    {
+                        throw new Exception($"Expected Failure (iteration {i})");
+                    }
+                    counter++;
+                    return Task.CompletedTask;
+                }, 1, Enumerable.Range(1, 5))
+            );
+
+            Assert.AreEqual("Expected Failure (iteration 2)", exception.Message);
+            Assert.AreEqual(3, counter); // both 1, 3, and 5 ran, 2 and 4 threw the exception
+        }
+    }
+}


### PR DESCRIPTION
Attempting to address poor performance when restoring libraries (such as #389 and #512).  There are two parts to this change:

1. Introducing parallel downloads when populating the file cache.  Until now, we have downloaded files in serial order, which is very slow.  With these changes, we will allow up to 10 simultaneous requests for files (slightly more than most browsers).  Keeping the limit is important to avoid DDoSing a server, and to avoid queuing too many TPL tasks or exploding the load on the thread pool.
2. Adding new output messages showing when files are being downloaded.  This mitigates the perception that libman is hung by reporting progress more regularly throughout the operation.