### PR TITLE
Add a better message if a file entry has an empty name

### DIFF
--- a/src/LibraryManager.Contracts/PredefinedErrors.cs
+++ b/src/LibraryManager.Contracts/PredefinedErrors.cs
@@ -190,7 +190,13 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// <param name="duplicateLibrary"></param>
         /// <returns></returns>
         public static IError DuplicateLibrariesInManifest(string duplicateLibrary)
-        => new Error("LIB019", string.Format(Text.ErrorDuplicateLibraries, duplicateLibrary));
+            => new Error("LIB019", string.Format(Text.ErrorDuplicateLibraries, duplicateLibrary));
+
+        /// <summary>
+        /// There is a file specified with an empty name
+        /// </summary>
+        public static IError FileNameMustNotBeEmpty(string libraryId)
+            => new Error("LIB020", string.Format(Text.ErrorFilePathIsEmpty, libraryId));
 
         /// <summary>
         /// Unknown error occurred

--- a/src/LibraryManager.Contracts/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Contracts/Resources/Text.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Web.LibraryManager.Contracts.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Text {
@@ -102,6 +102,15 @@ namespace Microsoft.Web.LibraryManager.Contracts.Resources {
         internal static string ErrorDuplicateLibraries {
             get {
                 return ResourceManager.GetString("ErrorDuplicateLibraries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The library &quot;{0}&quot; cannot specify a file with an empty name.
+        /// </summary>
+        internal static string ErrorFilePathIsEmpty {
+            get {
+                return ResourceManager.GetString("ErrorFilePathIsEmpty", resourceCulture);
             }
         }
         

--- a/src/LibraryManager.Contracts/Resources/Text.resx
+++ b/src/LibraryManager.Contracts/Resources/Text.resx
@@ -184,4 +184,7 @@ Valid files are {2}</value>
   <data name="ErrorDuplicateLibraries" xml:space="preserve">
     <value>Cannot restore. Multiple definitions for libraries: {0}</value>
   </data>
+  <data name="ErrorFilePathIsEmpty" xml:space="preserve">
+    <value>The library "{0}" cannot specify a file with an empty name</value>
+  </data>
 </root>

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -187,7 +187,8 @@ namespace Microsoft.Web.LibraryManager.Providers
 
                         if (string.IsNullOrEmpty(file))
                         {
-                            return new LibraryOperationResult(state, PredefinedErrors.CouldNotWriteFile(file));
+                            string id = LibraryNamingScheme.GetLibraryId(state.Name, state.Version);
+                            return new LibraryOperationResult(state, PredefinedErrors.FileNameMustNotBeEmpty(id));
                         }
 
                         string destinationPath = Path.Combine(state.DestinationPath, file);


### PR DESCRIPTION
This came up during the PR review for #534 but we held off at the time due to the new localized string.