### PR TITLE
Make restore faster by copying files

### DIFF
--- a/src/LibraryManager.Build/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Build/Contracts/HostInteraction.cs
@@ -77,8 +77,12 @@ namespace Microsoft.Web.LibraryManager.Build
             cancellationToken.ThrowIfCancellationRequested();
 
             string absoluteDestinationPath = Path.Combine(WorkingDirectory, destinationPath);
-            bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
+            if (!FileHelpers.IsUnderRootDirectory(absoluteDestinationPath, WorkingDirectory))
+            {
+                throw new UnauthorizedAccessException();
+            }
 
+            bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
             if (result)
             {
                 Logger.Log(string.Format(Resources.Text.FileWrittenToDisk, destinationPath.Replace('\\', '/')), LogLevel.Operation);

--- a/src/LibraryManager.Build/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Build/Contracts/HostInteraction.cs
@@ -71,14 +71,20 @@ namespace Microsoft.Web.LibraryManager.Build
             return FileHelpers.ReadFileAsStreamAsync(relativeFilePath, cancellationToken);
         }
 
-        public Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        /// <inheritdoc />
+        public async Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
-            return Task.Run(() =>
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
-                return FileHelpers.CopyFile(sourcePath, destinationPath);
-            }, cancellationToken);
+            string absoluteDestinationPath = Path.Combine(WorkingDirectory, destinationPath);
+            bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
+
+            if (result)
+            {
+                Logger.Log(string.Format(Resources.Text.FileWrittenToDisk, destinationPath.Replace('\\', '/')), LogLevel.Operation);
+            }
+
+            return result;
         }
     }
 }

--- a/src/LibraryManager.Build/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Build/Contracts/HostInteraction.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Web.LibraryManager.Build
             return FileHelpers.ReadFileAsStreamAsync(relativeFilePath, cancellationToken);
         }
 
-        public Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        public Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
             return Task.Run(() =>
             {

--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
         {
             try
             {
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationFile));
                 File.Copy(sourceFile, destinationFile, true);
 
                 return true;

--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -133,15 +133,18 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// <summary>
         /// Copies a file from source to destination
         /// </summary>
-        /// <param name="sourceFile"></param>
-        /// <param name="destinationFile"></param>
-        /// <returns></returns>
-        public static bool CopyFile(string sourceFile, string destinationFile)
+        /// <param name="sourceFile">Full path to the source file</param>
+        /// <param name="destinationFile">Full path to the destination file</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A boolean indicating whether the file was copied successfully</returns>
+        public static async Task<bool> CopyFileAsync(string sourceFile, string destinationFile, CancellationToken cancellationToken)
         {
             try
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(destinationFile));
-                File.Copy(sourceFile, destinationFile, true);
+                using (FileStream sourceStream = File.Open(sourceFile, FileMode.Open))
+                {
+                    await WriteToFileAsync(destinationFile, sourceStream, cancellationToken);
+                }
 
                 return true;
             }

--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -357,7 +357,13 @@ namespace Microsoft.Web.LibraryManager.Contracts
             return new Uri(rootPath).IsUnc;
         }
 
-        internal static bool IsUnderRootDirectory(string filePath, string rootDirectory)
+        /// <summary>
+        /// Returns whether <paramref name="filePath"/> is under <paramref name="rootDirectory"/>
+        /// </summary>
+        /// <param name="filePath">File path</param>
+        /// <param name="rootDirectory">Ancestor directory</param>
+        /// <returns>Whether <paramref name="filePath"/> is under <paramref name="rootDirectory"/></returns>
+        public static bool IsUnderRootDirectory(string filePath, string rootDirectory)
         {
             string normalizedFilePath = NormalizePath(filePath);
             string normalizedRootDirectory = NormalizePath(rootDirectory);

--- a/src/LibraryManager.Contracts/IHostInteraction.cs
+++ b/src/LibraryManager.Contracts/IHostInteraction.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// <summary>
         /// Copies a file
         /// </summary>
-        /// <param name="sourcePath"></param>
-        /// <param name="destinationPath"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="sourcePath">The absolute path to the source file</param>
+        /// <param name="destinationPath">The relative path to the destination file</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A boolean indicating if the copy was successful</returns>
         Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken);
     }
 }

--- a/src/LibraryManager.Contracts/IHostInteraction.cs
+++ b/src/LibraryManager.Contracts/IHostInteraction.cs
@@ -71,6 +71,6 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// <param name="destinationPath"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken);
+        Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken);
     }
 }

--- a/src/LibraryManager.Contracts/IHostInteraction.cs
+++ b/src/LibraryManager.Contracts/IHostInteraction.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
         Task<Stream> ReadFileAsync(string filePath, CancellationToken cancellationToken);
 
         /// <summary>
-        /// 
+        /// Copies a file
         /// </summary>
         /// <param name="sourcePath"></param>
         /// <param name="destinationPath"></param>

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -113,6 +113,11 @@ namespace Microsoft.Web.LibraryManager.Vsix
             cancellationToken.ThrowIfCancellationRequested();
 
             string absoluteDestinationPath = Path.Combine(WorkingDirectory, destinationPath);
+            if (!FileHelpers.IsUnderRootDirectory(absoluteDestinationPath, WorkingDirectory))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
             await VsHelpers.CheckFileOutOfSourceControlAsync(absoluteDestinationPath);
             bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
 

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Web.LibraryManager.Vsix
 
         public Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
-            return System.Threading.Tasks.Task.Run(() =>
+            return Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Web.LibraryManager.Providers
 
                         string sourcePath = GetCachedFileLocalPath(state, file);
                         string destinationPath = Path.Combine(state.DestinationPath, file);
-                        bool writeOk = await HostInteraction.CopyFile(sourcePath, destinationPath, cancellationToken);
+                        bool writeOk = await HostInteraction.CopyFileAsync(sourcePath, destinationPath, cancellationToken);
 
                         if (!writeOk)
                         {

--- a/src/libman/Contracts/HostInteraction.cs
+++ b/src/libman/Contracts/HostInteraction.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
             return FileHelpers.ReadFileAsStreamAsync(relativeFilePath, cancellationToken);
         }
 
-        public Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        public Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/libman/Contracts/HostInteraction.cs
+++ b/src/libman/Contracts/HostInteraction.cs
@@ -97,11 +97,14 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
             return FileHelpers.ReadFileAsStreamAsync(relativeFilePath, cancellationToken);
         }
 
-        public async Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        public Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await Task.Run(() => { return FileHelpers.CopyFile(sourcePath, destinationPath); });
+            bool writeSuccessful = FileHelpers.CopyFile(sourcePath, destinationPath);
+            Logger.Log(string.Format(Resources.Text.FileWrittenToDisk, destinationPath.Replace('\\', '/')), LogLevel.Operation);
+
+            return Task.FromResult(writeSuccessful);
         }
     }
 }

--- a/src/libman/Contracts/HostInteraction.cs
+++ b/src/libman/Contracts/HostInteraction.cs
@@ -97,14 +97,20 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
             return FileHelpers.ReadFileAsStreamAsync(relativeFilePath, cancellationToken);
         }
 
-        public Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        /// <inheritdoc />
+        public async Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            bool writeSuccessful = FileHelpers.CopyFile(sourcePath, destinationPath);
-            Logger.Log(string.Format(Resources.Text.FileWrittenToDisk, destinationPath.Replace('\\', '/')), LogLevel.Operation);
+            string absoluteDestinationPath = Path.Combine(WorkingDirectory, destinationPath);
+            bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
 
-            return Task.FromResult(writeSuccessful);
+            if(result)
+            {
+                Logger.Log(string.Format(Resources.Text.FileWrittenToDisk, destinationPath.Replace('\\', '/')), LogLevel.Operation);
+            }
+
+            return result;
         }
     }
 }

--- a/src/libman/Contracts/HostInteraction.cs
+++ b/src/libman/Contracts/HostInteraction.cs
@@ -103,8 +103,12 @@ namespace Microsoft.Web.LibraryManager.Tools.Contracts
             cancellationToken.ThrowIfCancellationRequested();
 
             string absoluteDestinationPath = Path.Combine(WorkingDirectory, destinationPath);
-            bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
+            if (!FileHelpers.IsUnderRootDirectory(absoluteDestinationPath, WorkingDirectory))
+            {
+                throw new UnauthorizedAccessException();
+            }
 
+            bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
             if(result)
             {
                 Logger.Log(string.Format(Resources.Text.FileWrittenToDisk, destinationPath.Replace('\\', '/')), LogLevel.Operation);

--- a/test/LibraryManager.Mocks/HostInteraction.cs
+++ b/test/LibraryManager.Mocks/HostInteraction.cs
@@ -142,9 +142,19 @@ namespace Microsoft.Web.LibraryManager.Mocks
         /// <param name="destinationPath"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        public async Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string absoluteDestinationPath = Path.Combine(WorkingDirectory, destinationPath);
+            if (!FileHelpers.IsUnderRootDirectory(absoluteDestinationPath, WorkingDirectory))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            bool result = await FileHelpers.CopyFileAsync(sourcePath, absoluteDestinationPath, cancellationToken);
+
+            return result;
         }
     }
 }

--- a/test/LibraryManager.Mocks/HostInteraction.cs
+++ b/test/LibraryManager.Mocks/HostInteraction.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Web.LibraryManager.Mocks
         /// <param name="destinationPath"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        public Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/test/libman.Test/Mocks/HostInteractionInternal.cs
+++ b/test/libman.Test/Mocks/HostInteractionInternal.cs
@@ -36,7 +36,19 @@ namespace Microsoft.Web.LibraryManager.Tools.Test.Mocks
 
         public Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            if (File.Exists(sourcePath))
+            {
+                if (!Path.IsPathRooted(destinationPath))
+                {
+                    destinationPath = Path.Combine(WorkingDirectory, destinationPath);
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+                File.Copy(sourcePath, destinationPath, overwrite: true);
+                return Task.FromResult(true);
+            }
+
+            return Task.FromResult(false);
         }
 
         public Task<bool> DeleteFilesAsync(IEnumerable<string> filePaths, CancellationToken cancellationToken)

--- a/test/libman.Test/Mocks/HostInteractionInternal.cs
+++ b/test/libman.Test/Mocks/HostInteractionInternal.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test.Mocks
 
         public ISettings Settings { get; set; }
 
-        public Task<bool> CopyFile(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+        public Task<bool> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
         {
             if (File.Exists(sourcePath))
             {


### PR DESCRIPTION
Compared to the original implementation of reading files in from the cache and writing them back out to the destination, a simple file copy seems to be several times faster on average.