### PR TITLE
Fix VS integration tests

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -42,7 +42,7 @@
 
     <!-- Test references -->
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.0.28117-pre" />
+    <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.3.29003.189" />
     <PackageReference Update="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Update="MSTest.TestFramework" Version="1.4.0" />
 

--- a/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
+++ b/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
@@ -93,7 +93,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.Caret.MoveDown(1);
             Editor.KeyboardCommands.Type("{");
             Editor.KeyboardCommands.Enter();
-            Editor.KeyboardCommands.Type("\"provider\": \"cdnjs\",");
+            Editor.KeyboardCommands.Type("\"provider\":");
+            Editor.KeyboardCommands.Type("cdnjs\","); // auto-format will put the space & quote after the colon
             Editor.KeyboardCommands.Enter();
 
             Editor.KeyboardCommands.Type("\"library\":");
@@ -109,7 +110,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.Caret.MoveDown(1);
             Editor.KeyboardCommands.Type("{");
             Editor.KeyboardCommands.Enter();
-            Editor.KeyboardCommands.Type("\"provider\": \"cdnjs\",");
+            Editor.KeyboardCommands.Type("\"provider\":");
+            Editor.KeyboardCommands.Type("cdnjs\","); // auto-format will put the space & quote after the colon
             Editor.KeyboardCommands.Enter();
 
             Editor.KeyboardCommands.Type("\"library\":");
@@ -132,7 +134,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.Caret.MoveDown(1);
             Editor.KeyboardCommands.Type("{");
             Editor.KeyboardCommands.Enter();
-            Editor.KeyboardCommands.Type("\"provider\": \"filesystem\",");
+            Editor.KeyboardCommands.Type("\"provider\":");
+            Editor.KeyboardCommands.Type("filesystem\","); // auto-format will put the space & quote after the colon
             Editor.KeyboardCommands.Enter();
 
             Editor.KeyboardCommands.Type("\"library\":");
@@ -149,7 +152,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.Caret.MoveDown(1);
             Editor.KeyboardCommands.Type("{");
             Editor.KeyboardCommands.Enter();
-            Editor.KeyboardCommands.Type("\"provider\": \"unpkg\",");
+            Editor.KeyboardCommands.Type("\"provider\":");
+            Editor.KeyboardCommands.Type("unpkg\","); // auto-format will put the space & quote after the colon
             Editor.KeyboardCommands.Enter();
 
             Editor.KeyboardCommands.Type("\"library\":");
@@ -157,7 +161,7 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Helpers.Completion.WaitForCompletionEntries(Editor, new[] { "bootstrap" }, caseInsensitive: true, timeout: 5000);
 
             Editor.KeyboardCommands.Backspace(7);
-            Editor.KeyboardCommands.Type("jqu");
+            Editor.KeyboardCommands.Type("jque");
             Helpers.Completion.WaitForCompletionEntries(Editor, new[] { "jquery" }, caseInsensitive: true, timeout: 5000);
         }
 
@@ -170,7 +174,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.Caret.MoveDown(1);
             Editor.KeyboardCommands.Type("{");
             Editor.KeyboardCommands.Enter();
-            Editor.KeyboardCommands.Type("\"provider\": \"cdnjs\",");
+            Editor.KeyboardCommands.Type("\"provider\":");
+            Editor.KeyboardCommands.Type("cdnjs\","); // auto-format will put the space & quote after the colon
             Editor.KeyboardCommands.Enter();
 
             Editor.KeyboardCommands.Type("\"library\":");
@@ -189,7 +194,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             Editor.Caret.MoveDown(1);
             Editor.KeyboardCommands.Type("{");
             Editor.KeyboardCommands.Enter();
-            Editor.KeyboardCommands.Type("\"provider\": \"unpkg\",");
+            Editor.KeyboardCommands.Type("\"provider\":");
+            Editor.KeyboardCommands.Type("unpkg\","); // auto-format will put the space & quote after the colon
             Editor.KeyboardCommands.Enter();
 
             Editor.KeyboardCommands.Type("\"library\":");
@@ -198,9 +204,8 @@ namespace Microsoft.Web.LibraryManager.IntegrationTest
             CompletionList items = Helpers.Completion.WaitForCompletionItems(Editor, 5000);
             Assert.IsNotNull(items, "Time out waiting for the version completion list");
 
-            List<SemanticVersion> semanticVersions = new List<SemanticVersion>();
+            var semanticVersions = new List<SemanticVersion>();
 
-            // CompletionList implements the List, so foreach can guarentee its iteration order as original.
             foreach (CompletionItem item in items)
             {
                 semanticVersions.Add(SemanticVersion.Parse(item.Text));


### PR DESCRIPTION
Several of these tests were encountering issues where VS's auto-format would interfere with the contents being typed.

I also updated the version of the VS test framework (Apex) used to the latest available package.