### PR TITLE
Update providers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install and consume 3rd-party client-side libraries with ease.
 
 ## Features
 
-- Add any library from [cdnjs.com](https://cdnjs.com/)
+- Add any library from [cdnjs.com](https://cdnjs.com/), [jsdelivr.com](https://www.jsdelivr.com/), or [unpkg.com](https://unpkg.com/)
 - Add any file from file system, network share or remote URL
 - Only add the file(s) you need
 - Can install any file into any folder in your project/solution


### PR DESCRIPTION
People need to know that libman works with more than just cdnjs.
 - Add jsdelivr and unpkg as providers.