### PR TITLE
Cleanup namespace-folder mismatch

### DIFF
--- a/src/LibraryManager.Build/Contracts/Dependencies.cs
+++ b/src/LibraryManager.Build/Contracts/Dependencies.cs
@@ -10,7 +10,7 @@ using Microsoft.Web.LibraryManager.Providers.FileSystem;
 using Microsoft.Web.LibraryManager.Providers.jsDelivr;
 using Microsoft.Web.LibraryManager.Providers.Unpkg;
 
-namespace Microsoft.Web.LibraryManager.Build
+namespace Microsoft.Web.LibraryManager.Build.Contracts
 {
     internal class Dependencies : IDependencies
     {

--- a/src/LibraryManager.Build/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Build/Contracts/HostInteraction.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Contracts.Configuration;
 
-namespace Microsoft.Web.LibraryManager.Build
+namespace Microsoft.Web.LibraryManager.Build.Contracts
 {
     internal class HostInteraction : IHostInteraction
     {
@@ -20,7 +20,7 @@ namespace Microsoft.Web.LibraryManager.Build
 
         public string WorkingDirectory { get; }
         public string CacheDirectory => CacheService.CacheFolder;
-        public ILogger Logger => Build.Logger.Instance;
+        public ILogger Logger => Contracts.Logger.Instance;
         public ISettings Settings => Configuration.Settings.DefaultSettings;
 
         public async Task<bool> WriteFileAsync(string path, Func<Stream> content, ILibraryInstallationState state, CancellationToken cancellationToken)

--- a/src/LibraryManager.Build/Contracts/Logger.cs
+++ b/src/LibraryManager.Build/Contracts/Logger.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Web.LibraryManager.Build.Contracts
         {
             switch (level)
             {
-                case LibraryManager.Contracts.LogLevel.Error:
+                case LogLevel.Error:
                     Errors.Add(message);
                     break;
-                case LibraryManager.Contracts.LogLevel.Operation:
-                case LibraryManager.Contracts.LogLevel.Task:
-                case LibraryManager.Contracts.LogLevel.Status:
+                case LogLevel.Operation:
+                case LogLevel.Task:
+                case LogLevel.Status:
                     Messages.Add(message);
                     break;
             }

--- a/src/LibraryManager.Build/Contracts/Logger.cs
+++ b/src/LibraryManager.Build/Contracts/Logger.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using LogLevel = Microsoft.Web.LibraryManager.Contracts.LogLevel;
 
 namespace Microsoft.Web.LibraryManager.Build.Contracts
 {
@@ -21,7 +22,7 @@ namespace Microsoft.Web.LibraryManager.Build.Contracts
             Errors.Clear();
         }
 
-        public void Log(string message, LibraryManager.Contracts.LogLevel level)
+        public void Log(string message, LogLevel level)
         {
             switch (level)
             {

--- a/src/LibraryManager.Build/Contracts/Logger.cs
+++ b/src/LibraryManager.Build/Contracts/Logger.cs
@@ -3,9 +3,9 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Web.LibraryManager.Build
+namespace Microsoft.Web.LibraryManager.Build.Contracts
 {
-    internal class Logger : Contracts.ILogger
+    internal class Logger : LibraryManager.Contracts.ILogger
     {
         private Logger()
         {
@@ -21,16 +21,16 @@ namespace Microsoft.Web.LibraryManager.Build
             Errors.Clear();
         }
 
-        public void Log(string message, Contracts.LogLevel level)
+        public void Log(string message, LibraryManager.Contracts.LogLevel level)
         {
             switch (level)
             {
-                case Contracts.LogLevel.Error:
+                case LibraryManager.Contracts.LogLevel.Error:
                     Errors.Add(message);
                     break;
-                case Contracts.LogLevel.Operation:
-                case Contracts.LogLevel.Task:
-                case Contracts.LogLevel.Status:
+                case LibraryManager.Contracts.LogLevel.Operation:
+                case LibraryManager.Contracts.LogLevel.Task:
+                case LibraryManager.Contracts.LogLevel.Status:
                     Messages.Add(message);
                     break;
             }

--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -10,6 +10,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Microsoft.Web.LibraryManager.Build.Contracts;
+using Logger = Microsoft.Web.LibraryManager.Build.Contracts.Logger;
 
 namespace Microsoft.Web.LibraryManager.Build
 {

--- a/src/LibraryManager.Contracts/CancellationHelpers.cs
+++ b/src/LibraryManager.Contracts/CancellationHelpers.cs
@@ -4,7 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Web.LibraryManager
+namespace Microsoft.Web.LibraryManager.Contracts
 {
     internal static class CancellationHelpers
     {

--- a/src/LibraryManager.Vsix/Commands/CleanCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/CleanCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Commands
 {
     internal sealed class CleanCommand
     {

--- a/src/LibraryManager.Vsix/Commands/CleanCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/CleanCommand.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Design;
 using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Web.LibraryManager.Vsix

--- a/src/LibraryManager.Vsix/Commands/CleanCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/CleanCommand.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Design;
 using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -20,7 +20,7 @@ using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.Web.LibraryManager.Vsix.UI.Models;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Commands
 {
     internal sealed class InstallLibraryCommand
     {

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Search;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.Web.LibraryManager.Vsix.UI.Models;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Web.LibraryManager.Vsix

--- a/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
@@ -12,7 +12,7 @@ using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Commands
 {
     internal sealed class ManageLibrariesCommand
     {

--- a/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Design;
 using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Web.LibraryManager.Vsix

--- a/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Commands
 {
     internal sealed class RestoreCommand
     {

--- a/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
@@ -15,7 +15,7 @@ using Microsoft.Web.LibraryManager.Vsix.Shared;
 using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Commands
 {
     internal sealed class RestoreOnBuildCommand
     {

--- a/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Commands
 {
     internal sealed class RestoreSolutionCommand
     {

--- a/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Web.LibraryManager.Vsix

--- a/src/LibraryManager.Vsix/Contracts/Dependencies.cs
+++ b/src/LibraryManager.Vsix/Contracts/Dependencies.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Web.LibraryManager.Contracts;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 {
     internal class Dependencies : IDependencies
     {

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Contracts.Configuration;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Web.LibraryManager.Vsix

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -12,7 +12,7 @@ using Microsoft.Web.LibraryManager.Contracts.Configuration;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 {
     internal class HostInteraction : IHostInteraction
     {

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Logging;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -10,7 +10,7 @@ using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Logging;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 {
     internal static class Logger
     {

--- a/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
+++ b/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 {

--- a/src/LibraryManager.Vsix/Json/Completion/BaseCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/BaseCompletionProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Shared.Editor.Completion;
 using Microsoft.WebTools.Languages.Shared.Editor.Host;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     internal abstract class BaseCompletionProvider : IJsonCompletionListProvider
     {

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Document;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Document;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
@@ -19,7 +18,7 @@ using Microsoft.WebTools.Languages.Shared.Parser.Nodes;
 
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     internal class CompletionController : IOleCommandTarget
     {

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Document;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionElementProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionElementProvider.cs
@@ -6,14 +6,14 @@ using Microsoft.VisualStudio.Utilities;
 using System.ComponentModel.Composition;
 using System.Windows;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
-    [Export(typeof(IUIElementProvider<Completion, ICompletionSession>))]
+    [Export(typeof(IUIElementProvider<VisualStudio.Language.Intellisense.Completion, ICompletionSession>))]
     [Name(nameof(CompletionElementProvider))]
     [ContentType("JSON")]
-    internal class CompletionElementProvider : IUIElementProvider<Completion, ICompletionSession>
+    internal class CompletionElementProvider : IUIElementProvider<VisualStudio.Language.Intellisense.Completion, ICompletionSession>
     {
-        public UIElement GetUIElement(Completion itemToRender, ICompletionSession context, UIElementType elementType)
+        public UIElement GetUIElement(VisualStudio.Language.Intellisense.Completion itemToRender, ICompletionSession context, UIElementType elementType)
         {
             if (elementType == UIElementType.Tooltip && itemToRender is SimpleCompletionEntry entry)
             {

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -15,13 +15,12 @@ using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
-using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     [Export(typeof(IJsonCompletionListProvider))]
     [Name(nameof(FilesCompletionProvider))]

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;

--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -12,11 +12,10 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
-using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     [Export(typeof(IJsonCompletionListProvider))]
     [Name(nameof(LibraryIdCompletionProvider))]

--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 

--- a/src/LibraryManager.Vsix/Json/Completion/PathCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/PathCompletionProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     [Export(typeof(IJsonCompletionListProvider))]
     [Name(nameof(PathCompletionProvider))]

--- a/src/LibraryManager.Vsix/Json/Completion/ProviderCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/ProviderCompletionProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     [Export(typeof(IJsonCompletionListProvider))]
     [Name(nameof(ProviderCompletionProvider))]

--- a/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.WebTools.Languages.Json.Editor.Completion;
 using Microsoft.WebTools.Languages.Shared.Editor.Completion;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     internal class SimpleCompletionEntry : JsonCompletionEntry
     {

--- a/src/LibraryManager.Vsix/Json/Completion/VersionCompletionEntry.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/VersionCompletionEntry.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.WebTools.Languages.Shared.Editor.Completion;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
 {
     internal class VersionCompletionEntry : SimpleCompletionEntry
     {

--- a/src/LibraryManager.Vsix/Json/JsonHelpers.cs
+++ b/src/LibraryManager.Vsix/Json/JsonHelpers.cs
@@ -9,7 +9,7 @@ using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Utility;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json
 {
     internal static class JsonHelpers
     {

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Json.VS.SuggestedActions;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
@@ -15,7 +15,7 @@ using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Json.VS.SuggestedActions;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.SuggestedActions
 {
     [Export(typeof(IJsonSuggestedActionProvider))]
     [Name(nameof(SuggestedActionProvider))]

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Json.VS.SuggestedActions;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
-using Microsoft.Web.LibraryManager.Vsix.Json;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -17,7 +17,7 @@ using Microsoft.WebTools.Languages.Shared.Utility;
 
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.SuggestedActions
 {
     internal class UninstallSuggestedAction : SuggestedActionBase
     {

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.Vsix.Json;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
@@ -11,7 +11,7 @@ using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Utility;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.SuggestedActions
 {
     internal class UpdateSuggestedAction : SuggestedActionBase
     {

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
@@ -13,7 +13,7 @@ using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Json.SuggestedActions
 {
     internal class UpdateSuggestedActionSet : SuggestedActionBase
     {

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
@@ -11,6 +11,7 @@ using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.WebTools.Languages.Shared.Editor.SuggestedActions;
 using Microsoft.VisualStudio.Threading;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 
 namespace Microsoft.Web.LibraryManager.Vsix
 {

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Json.Completion;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Json

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Json
 {

--- a/src/LibraryManager.Vsix/LibraryManagerPackage.cs
+++ b/src/LibraryManager.Vsix/LibraryManagerPackage.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.Web.LibraryManager.Vsix.Commands;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Tasks = System.Threading.Tasks;

--- a/src/LibraryManager.Vsix/LibraryManagerPackage.cs
+++ b/src/LibraryManager.Vsix/LibraryManagerPackage.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Tasks = System.Threading.Tasks;
 
 namespace Microsoft.Web.LibraryManager.Vsix

--- a/src/LibraryManager.Vsix/Shared/DefaultSolutionEvents.cs
+++ b/src/LibraryManager.Vsix/Shared/DefaultSolutionEvents.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     // EventArgs helper class that can hold various event arg information
     internal class ParamEventArgs : EventArgs

--- a/src/LibraryManager.Vsix/Shared/ILibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/ILibraryCommandService.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     /// <summary>
     /// Contains wrapper methods for Manifest operations calls.

--- a/src/LibraryManager.Vsix/Shared/ITaskStatusCenterService.cs
+++ b/src/LibraryManager.Vsix/Shared/ITaskStatusCenterService.cs
@@ -4,7 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TaskStatusCenter;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     /// <summary>
     /// Provides an interface for a Task Status Center Service

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -16,7 +16,7 @@ using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     [Export(typeof(ILibraryCommandService))]
     internal class LibraryCommandService : ILibraryCommandService, IDisposable

--- a/src/LibraryManager.Vsix/Shared/TaskStatusCenterService.cs
+++ b/src/LibraryManager.Vsix/Shared/TaskStatusCenterService.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TaskStatusCenter;
 /// <summary>
 /// Implementation of the TaskStatusCenterService allowing backaground tasks to be registered to IVsTaskStatusCenterService.
 /// </summary>
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     using Package = Microsoft.VisualStudio.Shell.Package;
 

--- a/src/LibraryManager.Vsix/Shared/Telemetry.cs
+++ b/src/LibraryManager.Vsix/Shared/Telemetry.cs
@@ -9,7 +9,7 @@ using System.Text;
 using Microsoft.VisualStudio.Telemetry;
 using Microsoft.Web.LibraryManager.Contracts;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     internal static class Telemetry
     {

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Telemetry;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Contracts;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Shared

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -19,7 +19,7 @@ using Microsoft.VisualStudio.Telemetry;
 using Microsoft.Web.LibraryManager.Contracts;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     internal static class VsHelpers
     {

--- a/src/LibraryManager.Vsix/Shared/WpfUtil.cs
+++ b/src/LibraryManager.Vsix/Shared/WpfUtil.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Color = System.Windows.Media.Color;
 
-namespace Microsoft.Web.LibraryManager.Vsix
+namespace Microsoft.Web.LibraryManager.Vsix.Shared
 {
     internal static class WpfUtil
     {

--- a/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml.cs
@@ -3,6 +3,7 @@
 
 using System.Windows.Controls;
 using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 {

--- a/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml.cs
@@ -3,6 +3,7 @@
 
 using System.Windows.Controls;
 using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.Web.LibraryManager.Vsix.Json.Completion;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls

--- a/src/LibraryManager.Vsix/UI/Converters/PackageItemIconConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/PackageItemIconConverter.cs
@@ -5,6 +5,7 @@ using System.Windows.Data;
 using System.Windows.Media;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.Web.LibraryManager.Vsix.UI.Models;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters

--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -21,6 +21,7 @@ using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.Json;
 using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.Web.LibraryManager.Vsix.Resources;
 using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Document;

--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.Json;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Vsix.Resources;

--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -22,6 +22,7 @@ using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.Json;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Vsix.Resources;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Microsoft.WebTools.Languages.Json.Editor.Document;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Parser.Nodes;

--- a/src/LibraryManager/CacheService/WebRequestHandler.cs
+++ b/src/LibraryManager/CacheService/WebRequestHandler.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Configuration;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 
 namespace Microsoft.Web.LibraryManager
 {

--- a/src/LibraryManager/Helpers/CancellationHelpers.cs
+++ b/src/LibraryManager/Helpers/CancellationHelpers.cs
@@ -4,7 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Web.LibraryManager
+namespace Microsoft.Web.LibraryManager.Helpers
 {
     internal static class CancellationHelpers
     {

--- a/src/LibraryManager/Helpers/Extensions.cs
+++ b/src/LibraryManager/Helpers/Extensions.cs
@@ -11,7 +11,7 @@ using Microsoft.Web.LibraryManager.Contracts;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Web.LibraryManager
+namespace Microsoft.Web.LibraryManager.Helpers
 {
     /// <summary>
     /// A collection of extension methods.

--- a/src/LibraryManager/Helpers/LibraryStateTypeConverter.cs
+++ b/src/LibraryManager/Helpers/LibraryStateTypeConverter.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.Web.LibraryManager
+namespace Microsoft.Web.LibraryManager.Helpers
 {
     internal class LibraryStateTypeConverter : JsonConverter
     {

--- a/src/LibraryManager/LibrariesValidator.cs
+++ b/src/LibraryManager/LibrariesValidator.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 
 namespace Microsoft.Web.LibraryManager
 {

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.Json;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Newtonsoft.Json;

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Utilities;
 

--- a/src/LibraryManager/Providers/Unpkg/NpmPackageInfo.cs
+++ b/src/LibraryManager/Providers/Unpkg/NpmPackageInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.Web.LibraryManager.Helpers;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg

--- a/src/LibraryManager/Providers/Unpkg/NpmPackageInfoFactory.cs
+++ b/src/LibraryManager/Providers/Unpkg/NpmPackageInfoFactory.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using Microsoft.Web.LibraryManager.Helpers;
 using Newtonsoft.Json.Linq;
 
 #if NET472

--- a/src/LibraryManager/Providers/Unpkg/NpmPackageSearch.cs
+++ b/src/LibraryManager/Providers/Unpkg/NpmPackageSearch.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using Microsoft.Web.LibraryManager.Helpers;
 using Newtonsoft.Json.Linq;
 
 #if NET472

--- a/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Newtonsoft.Json.Linq;
 

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Providers.Unpkg;
 using Newtonsoft.Json.Linq;

--- a/test/LibraryManager.Test/ExtensionsTest.cs
+++ b/test/LibraryManager.Test/ExtensionsTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.Mocks;
 
 namespace Microsoft.Web.LibraryManager.Test

--- a/test/LibraryManager.Test/LibraryInstallationStateTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationStateTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Mocks;
 using Microsoft.Web.LibraryManager.Providers.Cdnjs;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/JSONHelpersTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/JSONHelpersTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Vsix;
+using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.WebTools.Languages.Json.Parser;
 using Microsoft.WebTools.Languages.Json.Parser.Nodes;
 using Microsoft.WebTools.Languages.Shared.Parser;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Shared/LibraryCommandServiceTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Shared/LibraryCommandServiceTest.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Vsix.Contracts;
+using Microsoft.Web.LibraryManager.Vsix.Shared;
 using Moq;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Test.Shared


### PR DESCRIPTION
Consistently follow the common .NET namespace convention by using the AssemblyName.Folder.Path pattern.

The following namespaces were **not** created because a class exists with the same name as its folder:
 * Microsoft.Web.LibraryManager.CacheService
 * Microsoft.Web.LibraryManager.SemanticVersion
 * Microsoft.Web.LibraryManager.Vsix.ErrorList

No changes done to the "libman" project in the Microsoft.Web.LibraryManager.Tools namespace.

Partially addresses #107 