### PR TITLE
Make build task messages not important by default

### DIFF
--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Web.LibraryManager.Build
         {
             foreach (string message in logger.Messages)
             {
-                Log.LogMessage(MessageImportance.High, message);
+                Log.LogMessage(message);
             }
 
             foreach (string error in logger.Errors)


### PR DESCRIPTION
Currently, we show all libman build messages as Important, which means
that every detail comes through even when using /verbosity:minimal.

With this change, most messages will be shown only in normal/detailed
verbosity.  We will still show the opening and closing lines for when we
start and complete restore for minimal verbosity.