### PR TITLE
Fix warning on Dependencies node in VS

### DIFF
--- a/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
+++ b/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
@@ -14,7 +14,7 @@
   <Target Name="GetCopyToOutputDirectoryItems" />
   <Target Name="SatelliteDllsProjectOutputGroup" />
   <Target Name="DebugSymbolsProjectOutputGroup" />
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <Reference Include="System.Runtime" />
   </ItemGroup>
   <!-- Needed for Multilingual App Toolkit-->


### PR DESCRIPTION
System.Runtime was removed in netstandard20, so this reference could not
be resolved.