### PR TITLE
Remove '@' from recommended installation path

### DIFF
--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
         /// <returns></returns>
         public override string GetSuggestedDestination(ILibrary library)
         {
-            if (library != null && library is UnpkgLibrary unpkgLibrary)
+            if (library is UnpkgLibrary unpkgLibrary)
             {
-                return unpkgLibrary.Name.TrimStart('@');
+                return unpkgLibrary.Name?.TrimStart('@');
             }
 
             return string.Empty;

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
         {
             if (library != null && library is UnpkgLibrary unpkgLibrary)
             {
-                return unpkgLibrary.Name;
+                return unpkgLibrary.Name.TrimStart('@');
             }
 
             return string.Empty;

--- a/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
+++ b/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
         /// <returns></returns>
         public override string GetSuggestedDestination(ILibrary library)
         {
-            if (library != null && library is JsDelivrLibrary jsDelivrLibrary)
+            if (library is JsDelivrLibrary jsDelivrLibrary)
             {
-                return jsDelivrLibrary.Name.TrimStart('@');
+                return jsDelivrLibrary.Name?.TrimStart('@');
             }
 
             return string.Empty;

--- a/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
+++ b/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
@@ -1,14 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;
-using Microsoft.Web.LibraryManager.LibraryNaming;
 using Microsoft.Web.LibraryManager.Providers.Unpkg;
 
 namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
@@ -49,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
         {
             if (library != null && library is JsDelivrLibrary jsDelivrLibrary)
             {
-                return jsDelivrLibrary.Name;
+                return jsDelivrLibrary.Name.TrimStart('@');
             }
 
             return string.Empty;

--- a/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderTest.cs
@@ -222,23 +222,24 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.JsDelivr
         }
 
         [TestMethod]
-        public void GetSuggestedDestination()
+        public void GetSuggestedDestination_NullLibrary_ReturnsEmptyString()
         {
-
             Assert.AreEqual(string.Empty, _provider.GetSuggestedDestination(null));
+        }
 
+        [DataTestMethod]
+        [DataRow("jquery", "jquery")]
+        [DataRow("@angular/cli", "angular/cli")]
+        public void GetSuggestedDestination(string libraryName, string expected)
+        {
             var library = new JsDelivrLibrary()
             {
-                Name = "jquery",
+                Name = libraryName,
                 Version = "3.3.1",
                 Files = null
             };
 
-            Assert.AreEqual(library.Name, _provider.GetSuggestedDestination(library));
-
-            library.Name = @"@angular/cli";
-
-            Assert.AreEqual("@angular/cli", _provider.GetSuggestedDestination(library));
+            Assert.AreEqual(expected, _provider.GetSuggestedDestination(library));
         }
     }
 }

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
@@ -197,23 +197,24 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         }
 
         [TestMethod]
-        public void GetSuggestedDestination()
+        public void GetSuggestedDestination_NullLibrary_ReturnsEmptyString()
         {
-
             Assert.AreEqual(string.Empty, _provider.GetSuggestedDestination(null));
+        }
 
+        [DataTestMethod]
+        [DataRow("jquery", "jquery")]
+        [DataRow("@angular/cli", "angular/cli")]
+        public void GetSuggestedDestination(string libraryName, string expected)
+        {
             var library = new UnpkgLibrary()
             {
-                Name = "jquery",
+                Name = libraryName,
                 Version = "3.3.1",
                 Files = null
             };
 
-            Assert.AreEqual(library.Name, _provider.GetSuggestedDestination(library));
-
-            library.Name = @"@angular/cli";
-
-            Assert.AreEqual("@angular/cli", _provider.GetSuggestedDestination(library));
+            Assert.AreEqual(expected, _provider.GetSuggestedDestination(library));
         }
     }
 }


### PR DESCRIPTION
In some contexts, notably ASP.NET Razor, the @@ escape sequence wasn't
supported in tag attributes (such as <script src="lib/@@foo"/>).

Removing the @ sign avoids the headache when this issue is encountered.
Scoped packages will still be pathed uniquely, just without the @
prefix.

This addresses https://developercommunity.visualstudio.com/content/problem/923113/signalr-issue-with.html.