### PR TITLE
Create a pipeline for internal builds

### DIFF
--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -1,0 +1,17 @@
+trigger:
+  branches:
+    include: ["master", "rel/*"]
+  paths:
+    exclude: ["*.md"]
+
+variables:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  BuildConfiguration: Release
+  BuildPlatform: Any CPU
+  DisableMAT: true
+
+jobs:
+  - job: Windows
+    pool: VSEng-MicroBuildVS2019
+    steps:
+      - template: build.yml


### PR DESCRIPTION
This is separate from the PR/CI pipeline, as it needs to run in a different pool.  The build logic was already extracted to be shared in build.yml.