### PR TITLE
Add a flag to disable the Multilingual App Toolkit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   BuildConfiguration: Release
   BuildPlatform: Any CPU
+  DisableMAT: true
 
 jobs:
   - job: Windows

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -10,8 +10,13 @@
     <SuppressPseudoWarning Condition="'$(Configuration)' == 'Debug'">true</SuppressPseudoWarning>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">
+  <Import Label="MultilingualAppToolkit"
+          Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets"
+          Condition="'$(DisableMAT)'!='true' AND Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />
+  <Target Name="MATPrerequisite"
+          BeforeTargets="PrepareForBuild"
+          Condition="'$(DisableMAT)'!='true' AND !Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')"
+          Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
   </Target>
 


### PR DESCRIPTION
MAT needn't run on CI builds (resources should change there).  It should
still run by default on dev machines, but this switch can also be used
to turn it off when it's being annoying.  This should save us a bunch of
warnings in the build output.