### PR TITLE
Pin the .NET SDK install version

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -4,6 +4,8 @@ steps:
 
 - task: UseDotNet@2
   displayName: Install .NET Core SDK
+  inputs:
+      version: 3.1.101 # When using the current latest (3.1.201) the GenerateShims target fails on hosted agents.
 
 - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
   - template: azure-pipeline.microbuild.before.yml


### PR DESCRIPTION
Builds suddenly started failing with this error:

>##[error]C:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.PackTool.targets(107,5): Error MSB4018: The "GenerateShims" task failed unexpectedly.
Microsoft.NET.HostModel.HResultException: 80070002
   at Microsoft.NET.HostModel.AppHost.HostWriter.<>c__DisplayClass2_0.<CreateAppHost>g__UpdateResources|1()
   at Microsoft.NET.HostModel.RetryUtil.RetryOnWin32Error(Action func)
   at Microsoft.NET.HostModel.AppHost.HostWriter.CreateAppHost(String appHostSourceFilePath, String appHostDestinationFilePath, String appBinaryFilePath, Boolean windowsGraphicalUserInterface, String assemblyToCopyResorcesFrom)
   at Microsoft.NET.Build.Tasks.GenerateShims.ExecuteCore()
   at Microsoft.NET.Build.Tasks.TaskBase.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

This began when the UseDotNet@2 task started pulling in SDK 3.1.201, where builds using 3.1.101 passed (same commit).