### PR TITLE
Increment VSSDK build tools version

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -30,7 +30,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="15.0.25726-Preview5" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="15.7.942-master669188BE" />
     <PackageReference Update="Microsoft.VisualStudio.Threading" Version="16.3.52" />
-    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.3.2099" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="16.5.2044" PrivateAssets="All" />
     <PackageReference Update="MiniMatch" Version="2.0.0" NoWarn="NU1603" />
     <PackageReference Update="Moq" Version="4.10.1" PrivateAssets="All" />
     <PackageReference Update="NerdBank.GitVersioning" Version="2.1.23" PrivateAssets="All" />


### PR DESCRIPTION
In VS 16.6 there is a breaking change that requires a VSSDK version of 16.5
or newer.