### PR TITLE
Explicitly include runtime dependencies in Build package

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -8,6 +8,7 @@
     <PackageId>Microsoft.Web.LibraryManager.Build</PackageId>
     <Title>$(PackageId)</Title>
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,10 +40,10 @@
   <Target Name="AddAdditionalFilesToSign" AfterTargets="CollectFilesToSign">
     <ItemGroup>
       <!-- Sign 3rd party assemblies -->
-      <FilesToSign Include="$(OutputPath)\Minimatch.dll" Condition="Exists('$(OutputPath)\Minimatch.dll')">
+      <FilesToSign Include="$(OutputPath)\Minimatch.dll">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(OutputPath)\Newtonsoft.Json.dll" Condition="Exists('$(OutputPath)\Newtonsoft.Json.dll')">
+      <FilesToSign Include="$(OutputPath)\Newtonsoft.Json.dll">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
     </ItemGroup>
@@ -54,7 +55,7 @@
         but before NuGet generates a nuspec. See https://github.com/NuGet/Home/issues/4704.
         -->
     <ItemGroup>
-      <_PackageFiles Include="$(OutputPath)\**\*.dll" Exclude="$(OutputPath)\**\Microsoft.Build.*.dll">
+      <_PackageFiles Include="$(OutputPath)\**\Microsoft.Web.LibraryManager*.dll;$(OutputPath)\**\Minimatch.dll;$(OutputPath)\**\Newtonsoft.Json.dll">
         <PackagePath>tools\%(RecursiveDir)</PackagePath>
         <Visible>false</Visible>
         <BuildAction>Content</BuildAction>


### PR DESCRIPTION
For netstandard project, the default behavior does not copylocal
dependencies from reference packages, and does not include them in the
package.  For Newtonsoft.Json, the dependency was resolved at runtime
from the SDK install path, so we never noticed it was missing.

Since we added Minimatch.dll for the file globs, it is not being
resolved when building through the .NET sdk (dotnet build).  This is
causing the build to fail with a LIB000 error (unknown failure).

The fix is to be more precise about what files we do include in the
package.  This also addresses the inconsistency about having these
assemblies in the build output path when signing package contents.