### PR TITLE
Create VS Installer manifest and setup for pipeline insertion to VS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <MicroBuild_DoNotStrongNameSign>true</MicroBuild_DoNotStrongNameSign>
     <BaseOutputPath>$(RepoRoot)\bin\$(MSBuildProjectName)</BaseOutputPath>
     <BaseIntermediateOutputPath>$(RepoRoot)\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <ManifestOutputPath>$(RepoRoot)\bin\Microsoft.Web.LibraryManager.Vsix\$(Configuration)</ManifestOutputPath>
 
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corp.</Company>

--- a/azure-pipelines/azure-pipeline.microbuild.after.yml
+++ b/azure-pipelines/azure-pipeline.microbuild.after.yml
@@ -8,6 +8,28 @@ steps:
       /p:Configuration=Release
       /bl:"$(Build.ArtifactStagingDirectory)/build_logs/vsmanproj.binlog"
 
+- task: CopyFiles@1
+  inputs:
+    contents: |
+      bin/**/*.vsman
+      bin/**/*.vsix
+    targetFolder: $(Build.ArtifactStagingDirectory)/insertion
+    flattenFolders: true
+  displayName: Collecting VS Insertion artifacts
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: $(Build.ArtifactStagingDirectory)/insertion
+    ArtifactName: VSInsertion
+    ArtifactType: Container
+  displayName: Publish insertion artifacts
+
+- task: MicroBuildUploadVstsDropFolder@1
+  displayName: Upload artifacts to VSTS Drop
+  inputs:
+    DropFolder: '$(Build.ArtifactStagingDirectory)/insertion'
+    condition: and(succeeded(), eq(variables['SignType'], 'Real'))
+
 - task: MicroBuildCleanup@1
   condition: succeededOrFailed()
   displayName: MicroBuild Cleanup

--- a/azure-pipelines/azure-pipeline.microbuild.after.yml
+++ b/azure-pipelines/azure-pipeline.microbuild.after.yml
@@ -8,11 +8,18 @@ steps:
       /p:Configuration=Release
       /bl:"$(Build.ArtifactStagingDirectory)/build_logs/vsmanproj.binlog"
 
+- task: MSBuild@1
+  displayName: Generate parameters for VS Insertion
+  inputs:
+    solution: build/CreateInsertionMetadata.proj
+    msbuildArguments: /r
+
 - task: CopyFiles@1
   inputs:
     contents: |
       bin/**/*.vsman
       bin/**/*.vsix
+      bin/InsertionParameters.txt
     targetFolder: $(Build.ArtifactStagingDirectory)/insertion
     flattenFolders: true
   displayName: Collecting VS Insertion artifacts

--- a/azure-pipelines/azure-pipeline.microbuild.after.yml
+++ b/azure-pipelines/azure-pipeline.microbuild.after.yml
@@ -1,4 +1,13 @@
 steps:
+- task: MSBuild@1
+  displayName: Build VS Installer Manifest
+  inputs:
+    solution: setup/Microsoft.Web.LibraryManager.vsmanproj
+    msbuildArguments: >
+      /r
+      /p:Configuration=Release
+      /bl:"$(Build.ArtifactStagingDirectory)/build_logs/vsmanproj.binlog"
+
 - task: MicroBuildCleanup@1
   condition: succeededOrFailed()
   displayName: MicroBuild Cleanup

--- a/azure-pipelines/azure-pipeline.microbuild.before.yml
+++ b/azure-pipelines/azure-pipeline.microbuild.before.yml
@@ -5,3 +5,6 @@ steps:
     signType: $(SignType)
     zipSources: false
   displayName: Install MicroBuild Signing Plugin
+
+- task: MicroBuildSwixPlugin@1
+  displayName: Install MicroBuild Swix Plugin

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -37,14 +37,6 @@ steps:
     arguments: --configuration $(BuildConfiguration) --no-build --filter "TestCategory!=FailsInCloudTest" -v n
   condition: and(succeeded(), ne(variables['SignType'], 'real'))
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)/build_logs
-    ArtifactName: build_logs
-    ArtifactType: Container
-  displayName: Publish build_logs artifacts
-  condition: succeededOrFailed()
-
 - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
   - template: azure-pipeline.microbuild.after.yml
 
@@ -63,3 +55,11 @@ steps:
     ArtifactName: artifacts
     ArtifactType: Container
   displayName: Publish artifacts
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: $(Build.ArtifactStagingDirectory)/build_logs
+    ArtifactName: build_logs
+    ArtifactType: Container
+  displayName: Publish build_logs artifacts
+  condition: succeededOrFailed()

--- a/build/CreateInsertionMetadata.proj
+++ b/build/CreateInsertionMetadata.proj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.Build.NoTargets/1.0.94" DefaultTargets="GenerateInsertionParameters">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <InsertionParamsFile>$(RepoRoot)\bin\InsertionParameters.txt</InsertionParamsFile>
+  </PropertyGroup>
+
+  <Target Name="GenerateInsertionParameters" DependsOnTargets="GetBuildVersion" AfterTargets="Build">
+    <ItemGroup>
+      <DropManifests Include="$(RepoRoot)\bin\**\*.vsman" />
+    </ItemGroup>
+    <PropertyGroup>
+      <ManifestName>@(DropManifests->'$(ManifestPublishUrl)%(Filename)%(Extension)')</ManifestName>
+    </PropertyGroup>
+
+    <WriteLinesToFile Overwrite="True" File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertPayloadName]LibraryManager build $(BuildVersion)" />
+    <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertDescription]Commit: $(GitCommitId)" />
+    <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertJsonValues]Microsoft.VisualStudio.WebToolsExtensions.vsman=$([MSBuild]::Escape($(ManifestName)))" />
+    <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=VstsDropNames]$(MicroBuild_ManifestDropName)" />
+    <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=BuildVersion]$(BuildVersion)" />
+
+    <Message Text="$(MSBuildThisFile) -> $(InsertionParamsFile)" Importance="High" />
+  </Target>
+</Project>

--- a/build/MicroBuild.Plugins.props
+++ b/build/MicroBuild.Plugins.props
@@ -1,0 +1,27 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <!-- MicroBuild plugins can be installed in any parent directory up the tree from the project that is building.
+        The use of a sentinel file (which will be installed automatically due to package dependencies from any plugin)
+        will help us locate the plugin packages directory while being constrained to using MSBuild's intrinsic functions,
+        since we want the imports to occur at evaluation time instead of when a specific target is executing.
+        Note: All MicroBuild plugins must be installed to the same directory (under the same packages folder). If plugins
+        are installed to different directories, the plugins which are in the directories closest to the executing project
+        up the hierarchy will be discovered, and the ones higher up the tree will be ignored.
+         -->
+        <MicroBuildSentinelFile>packages\MicroBuild.Core.Sentinel.1.0.0\sentinel.txt</MicroBuildSentinelFile>
+        <MicroBuildSentinelFileV3>MicroBuild.Core.Sentinel\1.0.0\sentinel.txt</MicroBuildSentinelFileV3>
+
+        <MicroBuildPluginDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), $(MicroBuildSentinelFile)))</MicroBuildPluginDirectory>
+        <MicroBuildPluginDirectory Condition="'$(MicroBuildPluginDirectory)' != ''">$(MicroBuildPluginDirectory)\packages</MicroBuildPluginDirectory>
+
+        <!-- Some people might want to put the plugin packages directly in their Nuget v3 global cache. This doesn't happen by default,
+        but we will allow for it here. We don't support nuget.config's globalPackagesFolder setting here because we don't have a good
+        way to load/parse that file with MSBuild intrinsics. We can check the other two mechanisms though, which are the %NUGET_PACKAGES%
+        environment variable and %USERPROFILE%\.nuget\packages -->
+        <MicroBuildPluginDirectory Condition="'$(MicroBuildPluginDirectory)' == '' and '$(NUGET_PACKAGES)' != '' and Exists('$(NUGET_PACKAGES)\$(MicroBuildSentinelFileV3)')">$(NUGET_PACKAGES)</MicroBuildPluginDirectory>
+        <MicroBuildPluginDirectory Condition="'$(MicroBuildPluginDirectory)' == '' and '$(USERPROFILE)' != '' and Exists('$(USERPROFILE)\.nuget\packages\$(MicroBuildSentinelFileV3)')">$(USERPROFILE)\.nuget\packages</MicroBuildPluginDirectory>
+
+        <!-- Allow for the ability to override the plugin directory, for example in automated builds -->
+        <MicroBuildPluginDirectory Condition="'$(MicroBuildOverridePluginDirectory)' != ''">$(MicroBuildOverridePluginDirectory)</MicroBuildPluginDirectory>
+    </PropertyGroup>
+</Project>

--- a/setup/Microsoft.Web.LibraryManager.vsmanproj
+++ b/setup/Microsoft.Web.LibraryManager.vsmanproj
@@ -1,0 +1,24 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)'))" />
+  <Import Project="..\build\MicroBuild.Plugins.props" />
+
+  <PropertyGroup>
+    <TargetType>build-manifest</TargetType>
+    <FinalizeManifest>true</FinalizeManifest>
+    <FinalizeSkipLayout>true</FinalizeSkipLayout>
+    <ProductName>LibraryManagerPackagesManifest</ProductName>
+    <ProductFamily>vs</ProductFamily>
+    <ProductFamilyVersion>2016</ProductFamilyVersion>
+    <ComputeRelativeUrls>true</ComputeRelativeUrls>
+    <OutputPath>$(BaseOutputPath)\setup</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MergeManifest Include="$(ManifestOutputPath)\*.json">
+      <RelativeUrl>/</RelativeUrl>
+    </MergeManifest>
+  </ItemGroup>
+
+  <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.SwixBuild.*\build\MicroBuild.Plugins.SwixBuild.targets"/>
+
+</Project>


### PR DESCRIPTION
This PR contains the plumbing necessary to insert VSIX builds into the Visual Studio product (which will be done from an internal pipeline).  Namely:
- Creates a .vsman file
- Pushes the .vsman file and the .vsix to the VSTS Drop
- Creates a file containing variables that are easily calculated here (like build versions) but which need to be consumed in the pipeline.