### PR TITLE
Include the cache location in 'libman cache list'

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,1 @@
-msbuild /r LibraryManager.sln /clp:Verbosity=Minimal;Summary;ForceNoAlign %*
+msbuild /r %~dp0LibraryManager.sln /clp:Verbosity=Minimal;Summary;ForceNoAlign %*

--- a/src/libman/Commands/CacheListCommand.cs
+++ b/src/libman/Commands/CacheListCommand.cs
@@ -45,8 +45,13 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
         protected override Task<int> ExecuteInternalAsync()
         {
-            var outputStr = new StringBuilder(Resources.Text.CacheContentMessage);
+            var outputStr = new StringBuilder();
+            outputStr.AppendLine(Resources.Text.CacheLocationMessage);
+            outputStr.Append('-', Resources.Text.CacheLocationMessage.Length);
             outputStr.Append(Environment.NewLine);
+            outputStr.AppendLine(HostEnvironment.HostInteraction.CacheDirectory);
+            outputStr.Append(Environment.NewLine);
+            outputStr.AppendLine(Resources.Text.CacheContentMessage);
             outputStr.Append('-', Resources.Text.CacheContentMessage.Length);
             outputStr.Append(Environment.NewLine);
 

--- a/src/libman/Resources/Text.Designer.cs
+++ b/src/libman/Resources/Text.Designer.cs
@@ -160,6 +160,15 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cache root directory:.
+        /// </summary>
+        internal static string CacheLocationMessage {
+            get {
+                return ResourceManager.GetString("CacheLocationMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select an option:.
         /// </summary>
         internal static string ChooseAnOption {

--- a/src/libman/Resources/Text.resx
+++ b/src/libman/Resources/Text.resx
@@ -425,4 +425,7 @@ Please specify a different destination.</value>
     To remove a setting, set it to an empty string (--set key=).
     Retrieving decrypted values for encrypted settings is not supported.</value>
   </data>
+  <data name="CacheLocationMessage" xml:space="preserve">
+    <value>Cache root directory:</value>
+  </data>
 </root>

--- a/test/libman.Test/LibmanCacheListTest.cs
+++ b/test/libman.Test/LibmanCacheListTest.cs
@@ -42,7 +42,11 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             var logger = HostEnvironment.Logger as TestLogger;
 
-            string expectedString = @"Cache contents:
+            string expectedString = $@"Cache root directory:
+---------------------
+{CacheDir}
+
+Cache contents:
 ---------------
 unpkg:
     (empty)
@@ -76,7 +80,11 @@ cdnjs:
 
             var logger = HostEnvironment.Logger as TestLogger;
 
-            var expectedString = @"Cache contents:
+            var expectedString = $@"Cache root directory:
+---------------------
+{CacheDir}
+
+Cache contents:
 ---------------
 unpkg:
     (empty)


### PR DESCRIPTION
I only applied this to the 'cache list' command, as that's used when a user is looking to find the cache contents.

Fixes #234.