### PR TITLE
Make tests less prone to breaking when jQuery releases.

### DIFF
--- a/test/libman.Test/LibmanInstallTest.cs
+++ b/test/libman.Test/LibmanInstallTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             var command = new InstallCommand(HostEnvironment);
             command.Configure(null);
 
-            _ = command.Execute("jquery@3.2.1", "--provider", "cdnjs", "--destination", "wwwroot");
+            command.Execute("jquery@3.2.1", "--provider", "cdnjs", "--destination", "wwwroot");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -58,7 +58,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             var command = new InstallCommand(HostEnvironment);
             command.Configure(null);
 
-            _ = command.Execute("jquery@3.2.1", "--destination", "wwwroot");
+            command.Execute("jquery@3.2.1", "--destination", "wwwroot");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -93,7 +93,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             var command = new InstallCommand(HostEnvironment);
             command.Configure(null);
 
-            _ = command.Execute("jquery@3.2.1", "--destination", "wwwroot");
+            command.Execute("jquery@3.2.1", "--destination", "wwwroot");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -128,7 +128,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
 
-            _ = command.Execute("jquery@3.2.1");
+            command.Execute("jquery@3.2.1");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -165,7 +165,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
 
-            _ = command.Execute("jquery@3.2.1", "--provider", "cdnjs");
+            command.Execute("jquery@3.2.1", "--provider", "cdnjs");
 
             var testLogger = HostEnvironment.Logger as TestLogger;
             Assert.AreEqual("[LIB019]: Cannot restore. Multiple definitions for libraries: jquery", testLogger.Messages.Last().Value);
@@ -186,7 +186,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 }";
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
-            _ = command.Execute("jquery@3.2.1", "--files", "jquery.min.js");
+            command.Execute("jquery@3.2.1", "--files", "jquery.min.js");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 

--- a/test/libman.Test/LibmanInstallTest.cs
+++ b/test/libman.Test/LibmanInstallTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             var command = new InstallCommand(HostEnvironment);
             command.Configure(null);
 
-            int result = command.Execute("jquery@3.2.1", "--provider", "cdnjs", "--destination", "wwwroot");
+            _ = command.Execute("jquery@3.2.1", "--provider", "cdnjs", "--destination", "wwwroot");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -58,7 +58,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             var command = new InstallCommand(HostEnvironment);
             command.Configure(null);
 
-            int result = command.Execute("jquery@3.2.1", "--destination", "wwwroot");
+            _ = command.Execute("jquery@3.2.1", "--destination", "wwwroot");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -93,7 +93,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             var command = new InstallCommand(HostEnvironment);
             command.Configure(null);
 
-            int result = command.Execute("jquery@3.2.1", "--destination", "wwwroot");
+            _ = command.Execute("jquery@3.2.1", "--destination", "wwwroot");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -128,7 +128,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
 
-            int result = command.Execute("jquery@3.2.1");
+            _ = command.Execute("jquery@3.2.1");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -165,7 +165,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
 
-            int result = command.Execute("jquery@3.2.1", "--provider", "cdnjs");
+            _ = command.Execute("jquery@3.2.1", "--provider", "cdnjs");
 
             var testLogger = HostEnvironment.Logger as TestLogger;
             Assert.AreEqual("[LIB019]: Cannot restore. Multiple definitions for libraries: jquery", testLogger.Messages.Last().Value);
@@ -186,8 +186,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 }";
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
-
-            int result = command.Execute("jquery@3.2.1", "--files", "jquery.min.js");
+            _ = command.Execute("jquery@3.2.1", "--files", "jquery.min.js");
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "libman.json")));
 
@@ -223,7 +222,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 }";
 
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), initialContent);
-            command.Execute("jquery", "--files", "abc.js");
+            command.Execute("jquery@3.5.0", "--files", "abc.js");
             string expectedMessage = @"[LIB018]: ""jquery@3.5.0"" does not contain the following: abc.js
 Valid files are jquery.js, jquery.min.js, jquery.min.map, jquery.slim.js, jquery.slim.min.js, jquery.slim.min.map";
 

--- a/test/libman.Test/LibmanUpdateTest.cs
+++ b/test/libman.Test/LibmanUpdateTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.min.js")));
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.js")));
 
-            int result = command.Execute("jquery");
+            int result = command.Execute("jquery", "--to", "3.5.0");
 
             Assert.AreEqual(0, result);
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.min.js")));
@@ -138,20 +138,15 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
   ""defaultProvider"": ""cdnjs"",
   ""defaultDestination"": ""wwwroot"",
   ""libraries"": [
-    {
-      ""library"": ""jquery@3.5.0"",
-      ""files"": [ ""jquery.min.js"", ""jquery.js"" ]
-    }
   ]
 }";
 
             string libmanjsonPath = Path.Combine(WorkingDir, "libman.json");
             File.WriteAllText(libmanjsonPath, contents);
 
-            var restoreCommand = new RestoreCommand(HostEnvironment);
-            restoreCommand.Configure(null);
-
-            restoreCommand.Execute();
+            var installCommand = new InstallCommand(HostEnvironment);
+            installCommand.Configure(null);
+            installCommand.Execute("jquery --files jquery.min.js --files jquery.js".Split(' '));
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.min.js")));
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.js")));
@@ -161,10 +156,6 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             Assert.AreEqual(0, result);
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.min.js")));
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.js")));
-
-            string actualText = File.ReadAllText(libmanjsonPath);
-
-            Assert.AreEqual(StringHelper.NormalizeNewLines(contents), StringHelper.NormalizeNewLines(actualText));
 
             var logger = HostEnvironment.Logger as TestLogger;
 
@@ -196,8 +187,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             restoreCommand.Configure(null);
 
             restoreCommand.Execute();
-
-            int result = command.Execute("jqu");
+            _ = command.Execute("jqu");
 
             string actualText = File.ReadAllText(libmanjsonPath);
 


### PR DESCRIPTION
Ideally these wouldn't make any live web requests, but we don't have that level of DI built into the CLI commands yet (or their tests) yet.  Using specific versions will still test the scenarios, but we won't have tests break whenever a new jQuery release is published.