### PR TITLE
Fix latest prerelease version for Cdnjs and JSDelivr

### DIFF
--- a/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
@@ -194,7 +194,10 @@ namespace Microsoft.Web.LibraryManager.Providers.Cdnjs
             }
 
             string first = includePreReleases
-                ? (await GetLibraryVersionsAsync(group.DisplayName, cancellationToken).ConfigureAwait(false)).First()
+                ? (await GetLibraryVersionsAsync(group.DisplayName, cancellationToken).ConfigureAwait(false))
+                                                                                      .Select(v => SemanticVersion.Parse(v))
+                                                                                      .Max()
+                                                                                      .ToString()
                 : group.Version;
 
             if (!string.IsNullOrEmpty(first))

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
             CdnjsCatalog sut = SetupCatalog();
 
             const string libraryName = "sampleLibrary";
-            const string oldVersion = "4.0.0-beta.1";
+            const string oldVersion = "4.0.0-beta.2";
             string result = await sut.GetLatestVersion(libraryName, true, CancellationToken.None);
 
             Assert.AreEqual(oldVersion, result);


### PR DESCRIPTION
Cdnjs changed the ordering when they report package versions, so we need to correctly search for the latest.  (Ironically, our test mock data was already setup for this, but we didn't test it correctly.)

The JsDelivrCatalog implementation never handled prerelease versions, nor did it handle versions at all for GitHub releases.  These were both added.

Unpkg curently doesn't expose package versions via an API that we can easily consume (it's available, but as JSON content embedded in an HTML page... ew) so it was not changed as a part of this.

This change should address https://developercommunity.visualstudio.com/content/problem/1167156/check-for-updates-quick-action-broken-in-libmanjso.html