### PR TITLE
fix: provide error message for unknown provider.

### DIFF
--- a/src/libman/Commands/CacheCleanCommand.cs
+++ b/src/libman/Commands/CacheCleanCommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Web.LibraryManager.Contracts;
@@ -62,6 +63,13 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
                 catch (Exception ex)
                 {
                     Logger.Log(string.Format(Resources.Text.CacheCleanFailed, ex.Message), LogLevel.Error);
+                }
+            }
+            else
+            {
+                if (!ManifestDependencies.Providers.Any(p => p.Id == Provider.Value))
+                {
+                    throw new InvalidOperationException(string.Format(Resources.Text.ProviderNotInstalled, Provider.Value));
                 }
             }
 

--- a/src/libman/Commands/CacheCleanCommand.cs
+++ b/src/libman/Commands/CacheCleanCommand.cs
@@ -65,12 +65,9 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
                     Logger.Log(string.Format(Resources.Text.CacheCleanFailed, ex.Message), LogLevel.Error);
                 }
             }
-            else
+            else if (!ManifestDependencies.Providers.Any(p => p.Id == Provider.Value))
             {
-                if (!ManifestDependencies.Providers.Any(p => p.Id == Provider.Value))
-                {
-                    throw new InvalidOperationException(string.Format(Resources.Text.ProviderNotInstalled, Provider.Value));
-                }
+                throw new InvalidOperationException(string.Format(Resources.Text.ProviderNotInstalled, Provider.Value));
             }
 
             return Task.FromResult(0);

--- a/test/libman.Test/LibmanCacheCleanTests.cs
+++ b/test/libman.Test/LibmanCacheCleanTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Tools.Commands;
 
@@ -108,6 +108,16 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             Assert.IsFalse(File.Exists(Path.Combine(CacheDir, "cdnjs", "jquery", "3.2.1", "core.js")));
 
             Assert.IsTrue(File.Exists(Path.Combine(CacheDir, "filesystem", "abc.js")));
+        }
+
+        [TestMethod]
+        public void TestCacheClean_ThrowsIfUnknownProvider()
+        {
+            var cleanCommand = new CacheCleanCommand(HostEnvironment);
+            cleanCommand.Configure();
+
+            var exception = Assert.ThrowsException<AggregateException>(() => cleanCommand.Execute("foo"));
+            Assert.IsInstanceOfType(exception.InnerExceptions.First(), typeof(InvalidOperationException));
         }
     }
 }


### PR DESCRIPTION
If a provider is given and it is not one of the available providers, output an invalid operation message like "Provider 'foo' is not installed.

Addresses #134