### PR TITLE
Changes for consuming merged interop assemblies in Dev17

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.34" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="16.2.29122.156" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.0-preview-1-30928-1112" />
-    <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="16.3.104" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework" Version="17.0.0-preview-1-30928-1112" />
+    <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="16.3.109" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.10.41-alpha" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.0.38-dev17-g08fcf558" />
     <PackageVersion Include="MiniMatch" Version="2.0.0" NoWarn="NU1603" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="EnvDTE" Version="16.9.31023.347" />
-    <PackageVersion Include="EnvDTE80" Version="16.9.31023.347" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.9.0" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="16.9.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
@@ -22,17 +20,10 @@
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.65" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-1-30928-1112" />
     <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.0.20-g94c95b8006" />
-    <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="17.0.0-preview-1-31115-307" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="16.9.31025.194" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.34" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="16.2.29122.156" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.0-preview-1-30928-1112" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop" Version="16.9.30921.310" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="16.9.30921.310" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="16.9.30921.310" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="16.9.30921.310" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="16.9.30921.310" />
-    <PackageVersion Include="Microsoft.VisualStudio.TextManager.Interop" Version="16.9.30921.310" />
     <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="16.3.104" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.10.41-alpha" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.0.38-dev17-g08fcf558" />
@@ -41,7 +32,6 @@
     <PackageVersion Include="NerdBank.GitVersioning" Version="3.3.37" />
     <PackageVersion Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageVersion Include="Nuget.VisualStudio" Version="6.0.0-preview.0.2" />
-    <PackageVersion Include="VSSDK.DTE" Version="7.0.4" />
 
     <PackageVersion Include="System.Net.Http" Version="4.3.1" />
     <PackageVersion Include="System.Runtime" Version="4.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,28 +14,34 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="16.9.227" />
-    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="16.9.227" />
-    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog" Version="16.9.30921.310" />
-    <PackageVersion Include="Microsoft.VisualStudio.Imaging" Version="16.9.30921.310" />
-    <PackageVersion Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="16.9.30921.310" />
+    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.0.21-g76e5c064cb" />
+    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.0.20-g94c95b8006" />
+    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog" Version="17.0.0-preview-1-30928-1112" />
+    <PackageVersion Include="Microsoft.VisualStudio.Imaging" Version="17.0.0-preview-1-30928-1112" />
+    <PackageVersion Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="17.0.0-preview-1-30928-1111" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.9.227" />
+    <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.0.0-preview-1-30928-1112" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.0.20-g94c95b8006" />
+    <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="17.0.0-preview-1-31115-307" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="16.9.31025.194" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.34" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="16.2.29122.156" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="16.9.30921.310" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.0-preview-1-30928-1112" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop" Version="16.9.30921.310" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="16.9.30921.310" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="16.9.30921.310" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="16.9.30921.310" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="16.9.30921.310" />
+    <PackageVersion Include="Microsoft.VisualStudio.TextManager.Interop" Version="16.9.30921.310" />
     <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="16.3.104" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.9.51" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="16.10.41-alpha" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.0.38-dev17-g08fcf558" />
     <PackageVersion Include="MiniMatch" Version="2.0.0" NoWarn="NU1603" />
     <PackageVersion Include="Moq" Version="4.10.1" />
     <PackageVersion Include="NerdBank.GitVersioning" Version="3.3.37" />
     <PackageVersion Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageVersion Include="Nuget.VisualStudio" Version="5.9.0" />
+    <PackageVersion Include="Nuget.VisualStudio" Version="6.0.0-preview.0.2" />
+    <PackageVersion Include="VSSDK.DTE" Version="7.0.4" />
 
     <PackageVersion Include="System.Net.Http" Version="4.3.1" />
     <PackageVersion Include="System.Runtime" Version="4.3.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -6,5 +6,7 @@
     <add key="dotnet-myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <!-- this can be removed after the VS Interop changes are fully flushed out, when NuGet.VisualStudio will publish in one of the above feeds -->
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
                 // the command was invoked.
                 if (item != null)
                 {
-                    target = item.FileNames[1];
+                    target = item.get_FileNames(1);
                 }
                 else
                 {

--- a/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
 
             if (configProjectItem != null)
             {
-                await _libraryCommandService.RestoreAsync(configProjectItem.FileNames[1], CancellationToken.None);
+                await _libraryCommandService.RestoreAsync(configProjectItem.get_FileNames(1), CancellationToken.None);
             }
         }
     }

--- a/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
 
             try
             {
-                var dependencies = _dependenciesFactory.FromConfigFile(projectItem.FileNames[1]);
+                var dependencies = _dependenciesFactory.FromConfigFile(projectItem.get_FileNames(1));
                 IEnumerable<string> packageIds = dependencies.Providers
                                                              .Where(p => p.NuGetPackageId != null)
                                                              .Select(p => p.NuGetPackageId)

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -200,6 +200,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -191,8 +191,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EnvDTE" />
-    <PackageReference Include="EnvDTE80" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" />
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
@@ -201,9 +200,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Shared
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
-                string configFileName = configProjectItem.FileNames[1];
+                string configFileName = configProjectItem.get_FileNames(1);
                 var dependencies = _dependenciesFactory.FromConfigFile(configFileName);
                 Project project = VsHelpers.GetDTEProjectFromConfig(configFileName);
 


### PR DESCRIPTION
The most temporary of these is the Nuget.VisualStudio package, which is
on its own feed.  Once the NuGet team can fully publish their changes,
it should be published again on the dotnet-public feed, and we can clean
it up from our nuget.config at that time.
