### PR TITLE
Ensure completions in Add wizard are sorted

### DIFF
--- a/src/LibraryManager.Vsix/UI/Models/LibraryIdViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/LibraryIdViewModel.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
             return Task.FromResult(result);
         }
 
-        public override async Task<CompletionItem> GetRecommendedSelectedCompletionAsync(CompletionSet completionSet, CompletionItem? lastSelected)
+        public override async Task<CompletionItem> GetRecommendedSelectedCompletionAsync(IEnumerable<CompletionItem> completions, CompletionItem? lastSelected)
         {
             int atIndex = SearchText.IndexOf('@');
             var result = default(CompletionItem);
@@ -52,15 +52,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
                 // if we're in the version portion, try to select the first item that starts with the version
                 string versionPortion = SearchText.Substring(atIndex + 1);
                 Func<CompletionItem, bool> predicate = x => x.DisplayText.StartsWith(versionPortion, StringComparison.OrdinalIgnoreCase);
-                result = completionSet.Completions.FirstOrDefault(predicate);
+                result = completions.FirstOrDefault(predicate);
                 if (result == default(CompletionItem))
                 {
-                    result = completionSet.Completions.FirstOrDefault();
+                    result = completions.FirstOrDefault();
                 }
             }
             else
             {
-                result = await base.GetRecommendedSelectedCompletionAsync(completionSet, lastSelected);
+                result = await base.GetRecommendedSelectedCompletionAsync(completions, lastSelected);
             }
 
             return result;

--- a/src/LibraryManager.Vsix/UI/Models/SearchTextBoxViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/SearchTextBoxViewModel.cs
@@ -73,14 +73,14 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
             return Task.FromResult(input);
         }
 
-        public virtual Task<CompletionItem> GetRecommendedSelectedCompletionAsync(CompletionSet completionSet, CompletionItem? lastSelected)
+        public virtual Task<CompletionItem> GetRecommendedSelectedCompletionAsync(IEnumerable<CompletionItem> completions, CompletionItem? lastSelected)
         {
             // by default, try to select the same as before, else fall back on the first item in the list
             string lastSelectedText = lastSelected?.InsertionText;
-            CompletionItem selectedItem = completionSet.Completions.FirstOrDefault(x => x.InsertionText == lastSelectedText);
+            CompletionItem selectedItem = completions.FirstOrDefault(x => x.InsertionText == lastSelectedText);
             if (selectedItem == default(CompletionItem))
             {
-                selectedItem = completionSet.Completions.FirstOrDefault();
+                selectedItem = completions.FirstOrDefault();
             }
 
             return Task.FromResult(selectedItem);

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
@@ -126,19 +126,14 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
         public async Task GetRecommendedSelectedCompletionAsync_DoesNotContainAt_ReturnsFirstItem()
         {
             ILibraryCatalog testCatalog = CreateLibraryCatalogWithUnscopedLibrary();
-            
+
             var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test");
-            var completionSet = new CompletionSet
-            {
-                Start = 0,
-                Length = 4,
-                Completions = new[] {
-                    new CompletionItem { DisplayText = "test@1.2" },
-                    new CompletionItem { DisplayText = "test@2.1" },
-                },
+            CompletionItem[] completions = new[] {
+                new CompletionItem { DisplayText = "test@1.2" },
+                new CompletionItem { DisplayText = "test@2.1" },
             };
 
-            CompletionItem result = await testObj.GetRecommendedSelectedCompletionAsync(completionSet, null);
+            CompletionItem result = await testObj.GetRecommendedSelectedCompletionAsync(completions, null);
 
             Assert.AreEqual("test@1.2", result.DisplayText);
         }
@@ -149,17 +144,12 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
             ILibraryCatalog testCatalog = CreateLibraryCatalogWithUnscopedLibrary();
 
             var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test@2");
-            var completionSet = new CompletionSet
-            {
-                Start = 0,
-                Length = 4,
-                Completions = new[] {
-                    new CompletionItem { DisplayText = "1.2" },
-                    new CompletionItem { DisplayText = "2.1" },
-                },
+            CompletionItem[] completions = new[] {
+                new CompletionItem { DisplayText = "1.2" },
+                new CompletionItem { DisplayText = "2.1" },
             };
 
-            CompletionItem result = await testObj.GetRecommendedSelectedCompletionAsync(completionSet, null);
+            CompletionItem result = await testObj.GetRecommendedSelectedCompletionAsync(completions, null);
 
             Assert.AreEqual("2.1", result.DisplayText);
         }
@@ -170,17 +160,12 @@ namespace Microsoft.Web.LibraryManager.Vsix.Test.UI.Models
             ILibraryCatalog testCatalog = CreateLibraryCatalogWithUnscopedLibrary();
 
             var testObj = new LibraryIdViewModel(GetTestSearchService(testCatalog), "test@3");
-            var completionSet = new CompletionSet
-            {
-                Start = 0,
-                Length = 4,
-                Completions = new[] {
-                    new CompletionItem { DisplayText = "1.2" },
-                    new CompletionItem { DisplayText = "2.1" },
-                },
+            CompletionItem[] completions = new[] {
+                new CompletionItem { DisplayText = "1.2" },
+                new CompletionItem { DisplayText = "2.1" },
             };
 
-            CompletionItem result = await testObj.GetRecommendedSelectedCompletionAsync(completionSet, null);
+            CompletionItem result = await testObj.GetRecommendedSelectedCompletionAsync(completions, null);
 
             Assert.AreEqual("1.2", result.DisplayText);
         }


### PR DESCRIPTION
There isn't a guarantee that the data from providers is sorted in the
desired order (e.g. for versions, sorted descending).  This change
ensures we sort the completion items before showing them in the search
box flyout.

In the JSON completion scenario (which is similar), each completion item
is instead represented by a CompletionEntry implementation which
implements IComparable<T> for that completion type.  The editor
completion stack handles the sorting for us already.

Fixes #531.