### PR TITLE
When deleting text in the search box, update item filter

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -227,7 +227,10 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             // We will invoke completion on text insertion and not deletion.
             // Also, we don't want to invoke completion on dialog load as we pre populate the target
             // location textbox with name of the folder when dialog is initially loaded.
-            if (textChange.AddedLength > 0 && SearchTextBox.CaretIndex > 0)
+            // In the case of deletion or replacement, if the completion flyout is already open, we
+            // should still update the list, as the filtered items have likely changed.
+            bool textInserted = textChange.AddedLength > 0 && SearchTextBox.CaretIndex > 0;
+            if (textInserted || Flyout.IsOpen)
             {
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {


### PR DESCRIPTION
Currently we only update when new text is added, but this means that
typing an extra character may filter out a desired item, and then
deleting the character will not show the item.
