### PR TITLE
Align combo box popup with left edge

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml
@@ -25,7 +25,7 @@
                  GotKeyboardFocus="SearchTextBox_GotKeyboardForcus"
                  Padding="2 2 20 2"
                  />
-        
+
         <!-- Watermark -->
         <Label Opacity=".5"
                Target="{Binding ElementName=SearchTextBox}"
@@ -54,19 +54,19 @@
 
         <!-- Fly out -->
         <Popup x:Name="Flyout"
-               Placement="Bottom"
                StaysOpen="False"
+               Placement="Left"
                PlacementTarget="{Binding ElementName=SearchTextBox}">
             <ListBox x:Name="Options"
-                SelectionMode="Single"
-                PreviewKeyDown="HandleListBoxKeyPress"
-                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                SelectedItem="{Binding ElementName=ThisControl, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                ItemsSource="{Binding ElementName=ThisControl, Path=CompletionEntries, Mode=OneWay}"
-                MaxHeight="300" MinWidth="150"
-                AutomationProperties.LabeledBy="{Binding ElementName=SearchTextBox}"
-                AutomationProperties.Name="{Binding AutomationName}"
-                >
+                     SelectionMode="Single"
+                     PreviewKeyDown="HandleListBoxKeyPress"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                     SelectedItem="{Binding ElementName=ThisControl, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     ItemsSource="{Binding ElementName=ThisControl, Path=CompletionEntries, Mode=OneWay}"
+                     MaxHeight="300" MinWidth="150"
+                     AutomationProperties.LabeledBy="{Binding ElementName=SearchTextBox}"
+                     AutomationProperties.Name="{Binding AutomationName}"
+                     >
                 <ListBox.ItemTemplate>
                     <DataTemplate DataType="{x:Type controls:CompletionEntry}">
                         <Label ToolTip="{Binding Path=Description, Mode=OneWay}" Padding="0">

--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -212,10 +212,10 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             }
         }
 
-        private void PositionCompletionPopup(int index)
+        private void PositionCompletionPopup()
         {
-            Rect r = SearchTextBox.GetRectFromCharacterIndex(index);
-            Flyout.HorizontalOffset = r.Left - 7;
+            Flyout.VerticalOffset = SearchTextBox.ActualHeight;
+            Flyout.HorizontalOffset = -SearchTextBox.ActualWidth;
             Options.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
             Flyout.Width = Options.DesiredSize.Width;
         }
@@ -264,7 +264,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
                         CompletionEntries.Add(new CompletionEntry(entry, completionSet.Start, completionSet.Length));
                     }
 
-                    PositionCompletionPopup(completionSet.Length);
+                    PositionCompletionPopup();
 
                     if (CompletionEntries != null && CompletionEntries.Count > 0 && Options.SelectedIndex == -1)
                     {

--- a/src/LibraryManager.Vsix/UI/Theming/VsThemedComboBox.xaml
+++ b/src/LibraryManager.Vsix/UI/Theming/VsThemedComboBox.xaml
@@ -177,21 +177,46 @@
                 <platformUI:SystemDropShadowChrome x:Uid="Shdw" Name="Shdw" Color="Transparent"
                                                MinWidth="{Binding ElementName=templateRoot,Path=ActualWidth}"
                                                MaxHeight="{TemplateBinding MaxDropDownHeight}">
-                    <Border x:Name="dropDownBorder" BorderBrush="{DynamicResource {x:Static platformUI:CommonControlsColors.ComboBoxBorderBrushKey}}" BorderThickness="1" Background="{DynamicResource {x:Static platformUI:CommonControlsColors.ComboBoxBackgroundBrushKey}}">
+                    <Border x:Name="dropDownBorder"
+                            BorderThickness="1"
+                            BorderBrush="{DynamicResource {x:Static platformUI:CommonControlsColors.ComboBoxBorderBrushKey}}"
+                            Background="{DynamicResource {x:Static platformUI:CommonControlsColors.ComboBoxBackgroundBrushKey}}">
                         <ScrollViewer x:Name="DropDownScrollViewer">
                             <Grid x:Name="grid" RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas x:Name="canvas" HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">
-                                    <Rectangle x:Name="opaqueRect" Fill="{Binding Background, ElementName=dropDownBorder}" Height="{Binding ActualHeight, ElementName=dropDownBorder}" Width="{Binding ActualWidth, ElementName=dropDownBorder}"/>
+                                <Canvas x:Name="canvas"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Top"
+                                        Height="0"
+                                        Width="0">
+                                    <Rectangle x:Name="opaqueRect"
+                                               Fill="{Binding Background, ElementName=dropDownBorder}"
+                                               Height="{Binding ActualHeight, ElementName=dropDownBorder}"
+                                               Width="{Binding ActualWidth, ElementName=dropDownBorder}"/>
                                 </Canvas>
-                                <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ItemsPresenter x:Name="ItemsPresenter"
+                                                KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                             </Grid>
                         </ScrollViewer>
                     </Border>
                 </platformUI:SystemDropShadowChrome>
             </Popup>
-            <ToggleButton x:Name="toggleButton" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Grid.ColumnSpan="2" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource ComboBoxToggleButton}"/>
-            <Border x:Name="border" Background="{DynamicResource {x:Static platformUI:CommonControlsColors.ComboBoxBackgroundBrushKey}}" Margin="{TemplateBinding BorderThickness}">
-                <TextBox x:Name="PART_EditableTextBox" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsReadOnly="{Binding IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}" Margin="{TemplateBinding Padding}" Style="{StaticResource ComboBoxEditableTextBox}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+            <ToggleButton x:Name="toggleButton"
+                          Grid.ColumnSpan="2"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          Background="{TemplateBinding Background}"
+                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                          Style="{StaticResource ComboBoxToggleButton}"/>
+            <Border x:Name="border"
+                    Background="{DynamicResource {x:Static platformUI:CommonControlsColors.ComboBoxBackgroundBrushKey}}"
+                    Margin="{TemplateBinding BorderThickness}">
+                <TextBox x:Name="PART_EditableTextBox"
+                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                         IsReadOnly="{Binding IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
+                         Margin="{TemplateBinding Padding}"
+                         Style="{StaticResource ComboBoxEditableTextBox}"
+                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </Border>
         </Grid>
         <ControlTemplate.Triggers>


### PR DESCRIPTION
It's been a long-time issue that the completion popup on the search box
is not aligned with the left side of the completion window.  Originally
it was attempting to align with the cursor position, but the offsets
were calculated very incorrectly.

Aligning with the caret is hard, and also not entirely desirable.
Ideally, we would align with an inflection point for the completion
session (e.g. on for library ID, it would either align with the name or
with the start of the version; for target location, it would align with
the current path segment).

This is hard to do generically since we have no idea where the
inflection points are.  So, settling for left-alignment is still better
than being oddly not quite right aligned.

This also removes the attempt to move the offset with cursor movement,
as it was exacerbating the odd alignment.

Resolves #226 