### PR TITLE
Remove "..." for past tense strings

### DIFF
--- a/src/LibraryManager.Vsix/Resources/Text.Designer.cs
+++ b/src/LibraryManager.Vsix/Resources/Text.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Text {
@@ -106,7 +106,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clean libraries started....
+        ///   Looks up a localized string similar to Clean libraries started.
         /// </summary>
         public static string CleanLibrariesStarted {
             get {

--- a/src/LibraryManager.Vsix/Resources/Text.resx
+++ b/src/LibraryManager.Vsix/Resources/Text.resx
@@ -122,7 +122,7 @@
     <comment>Add Client-Side Library</comment>
   </data>
   <data name="CleanLibrariesStarted" xml:space="preserve">
-    <value>Clean libraries started...</value>
+    <value>Clean libraries started</value>
     <comment>When the "Clean" command is being executed</comment>
   </data>
   <data name="CleanLibrariesSucceeded" xml:space="preserve">

--- a/src/LibraryManager/Resources/Text.Designer.cs
+++ b/src/LibraryManager/Resources/Text.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Text {
@@ -133,7 +133,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clean libraries operation started....
+        ///   Looks up a localized string similar to Clean libraries operation started.
         /// </summary>
         public static string Clean_OperationStarted {
             get {
@@ -205,7 +205,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Install library {0} started....
+        ///   Looks up a localized string similar to Install library {0} started.
         /// </summary>
         public static string Install_LibraryStarted {
             get {
@@ -367,7 +367,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restore operation started....
+        ///   Looks up a localized string similar to Restore operation started.
         /// </summary>
         public static string Restore_OperationStarted {
             get {
@@ -421,7 +421,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uninstall of library {0} started....
+        ///   Looks up a localized string similar to Uninstall of library {0} started.
         /// </summary>
         public static string Uninstall_LibraryStarted {
             get {
@@ -484,7 +484,7 @@ namespace Microsoft.Web.LibraryManager.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Update of library {0} started... .
+        ///   Looks up a localized string similar to Update of library {0} started.
         /// </summary>
         public static string Update_LibraryStarted {
             get {

--- a/src/LibraryManager/Resources/Text.resx
+++ b/src/LibraryManager/Resources/Text.resx
@@ -159,7 +159,7 @@
     <value>{0} libraries failed to be deleted</value>
   </data>
   <data name="Clean_OperationStarted" xml:space="preserve">
-    <value>Clean libraries operation started...</value>
+    <value>Clean libraries operation started</value>
   </data>
   <data name="Clean_NumberOfLibrariesSucceeded" xml:space="preserve">
     <value>{0} libraries were successfully deleted in {1} secs</value>
@@ -175,7 +175,7 @@
     <value>Install library {0} failed</value>
   </data>
   <data name="Install_LibraryStarted" xml:space="preserve">
-    <value>Install library {0} started...</value>
+    <value>Install library {0} started</value>
   </data>
   <data name="Restore_LibraryRestoreSucceeded" xml:space="preserve">
     <value>Library {0}  was successfuly restored restored</value>
@@ -197,13 +197,13 @@
     <value>Time Elapsed: {0}</value>
   </data>
   <data name="Uninstall_LibraryStarted" xml:space="preserve">
-    <value>Uninstall of library {0} started...</value>
+    <value>Uninstall of library {0} started</value>
   </data>
   <data name="Update_LibraryFailed" xml:space="preserve">
     <value>Update library {0} failed</value>
   </data>
   <data name="Update_LibraryStarted" xml:space="preserve">
-    <value>Update of library {0} started... </value>
+    <value>Update of library {0} started</value>
   </data>
   <data name="Update_LibrarySucceeded" xml:space="preserve">
     <value>Update of library {0} succeeded</value>
@@ -227,7 +227,7 @@
     <value>Restore operation failed for {0} libraries</value>
   </data>
   <data name="Restore_OperationStarted" xml:space="preserve">
-    <value>Restore operation started...</value>
+    <value>Restore operation started</value>
   </data>
   <data name="Uninstall_LibrarySucceeded" xml:space="preserve">
     <value>Uninstall of library {0} succeeded</value>


### PR DESCRIPTION
The ellipsis should be used to indicate things which are still in
progress, not things which have completed.  In most cases, this was used
in a string like "X started...".

It would be acceptable to use "Starting X..." as that is the present
progressive tense, but we can also simply remove the ellipsis without
having to re-translate a bunch of strings.

Addresses #212 