### PR TITLE
Remove extra "Client Side Library" menu item in WSP

### DIFF
--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.cs.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.cs.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.de.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.de.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.en.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.en.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.es.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.es.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.fr.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.fr.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.it.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.it.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ja.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ja.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ko.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ko.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pl.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pl.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pt-BR.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.pt-BR.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ru.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.ru.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.tr.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.tr.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hans.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hans.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />

--- a/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hant.vsct
+++ b/src/LibraryManager.Vsix/Commands/CommandTable/VSCommandTable.zh-Hant.vsct
@@ -79,9 +79,6 @@
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0100">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_PROJECT_ADD" />
     </CommandPlacement>
-    <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="InstallPackage" priority="0x0500">
-      <Parent guid="guidVenusCmdId" id="IDG_CTX_REFERENCE" />
-    </CommandPlacement>
     <!-- Config file menu -->
     <CommandPlacement guid="guidLibraryManagerPackageCmdSet" id="ConfigMenuGruop" priority="0x0300">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />


### PR DESCRIPTION
This shows up when right-clicking the project or any folder.  It's the
same command as mapped in the project Add menu, it's just duplicated in
the wrong placement.

Resolves #222.