### PR TITLE
Remove '--libraries' flag from cache list command

### DIFF
--- a/src/libman/Commands/CacheListCommand.cs
+++ b/src/libman/Commands/CacheListCommand.cs
@@ -27,18 +27,11 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
         /// </summary>
         public CommandOption Files { get; private set; }
 
-        /// <summary>
-        /// Option to restrict output to only library names.
-        /// </summary>
-        /// <remarks>This option is implicit if nothing is specified.</remarks>
-        public CommandOption Libraries { get; private set; }
-
         public override BaseCommand Configure(CommandLineApplication parent = null)
         {
             base.Configure(parent);
 
             Files = Option("--files", Resources.Text.CacheListFilesOptionDesc, CommandOptionType.NoValue);
-            Libraries = Option("--libraries", Resources.Text.CacheListLibrariesOptionDesc, CommandOptionType.NoValue);
 
             return this;
         }


### PR DESCRIPTION
This flag didn't offer any behavior so it should just be removed.

Resolves #127.