### PR TITLE
Ensure that libraries added via wizard set the provider

### DIFF
--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -504,7 +504,11 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
                         libraryInstallationState.Files = SelectedFiles.ToList();
                     }
 
-                    manifest.AddLibrary(libraryInstallationState);
+                    // When adding libraries via the wizard, always leave it as an explicit value on the individual library.
+                    // This doesn't set the default, but it's easier than generating a separate edit for the library entry
+                    // as well as the defaultProvider line.  Possibly worth re-visiting this in the future if we can make
+                    // both edits work well.
+                    manifest.AddLibrary(libraryInstallationState, setDefaultProvider: false);
 
                     await Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -275,7 +275,8 @@ namespace Microsoft.Web.LibraryManager
         /// Adds a library to the <see cref="Libraries"/> collection.
         /// </summary>
         /// <param name="state">An instance of <see cref="ILibraryInstallationState"/> representing the library to add.</param>
-        internal void AddLibrary(ILibraryInstallationState state)
+        /// <param name="setDefaultProvider">Set the defaultProvider if it doesn't exist, using the added library's provider</param>
+        internal void AddLibrary(ILibraryInstallationState state, bool setDefaultProvider = true)
         {
             ILibraryInstallationState existing = _libraries.Find(p => p.Name == state.Name && p.Version == state.Version && p.ProviderId == state.ProviderId);
 
@@ -284,7 +285,7 @@ namespace Microsoft.Web.LibraryManager
                 _libraries.Remove(existing);
             }
 
-            if (state is LibraryInstallationState desiredState)
+            if (setDefaultProvider && state is LibraryInstallationState desiredState)
             {
                 _libraries.Add(SetDefaultProviderIfNeeded(desiredState));
             }


### PR DESCRIPTION
The default behavior when adding a library, if the defaultProvider was
not yet set, was to promote the new library's provider as the default.
This requires multiple edits to the file.  When the document is open in
the editor, we only calculate the edit for inserting the library.

This change does imply that adding via the UI wizard will have a
different output than using the CLI.  At least we'll no longer generate
an invalid manifest.  We may want to consider a more advanced edit
generation such that we apply both edits instead.

Resolves #393.