### PR TITLE
Support prerelease versions from Unpkg

### DIFF
--- a/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
@@ -43,6 +43,16 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
 
         public async Task<string> GetLatestVersion(string libraryName, bool includePreReleases, CancellationToken cancellationToken)
         {
+            if (includePreReleases)
+            {
+                // Unpkg by default only shows the latest release version, so for prereleases we need to fetch all versions.
+                // This is requires making an extra web request, so only do it if we need to consider prerelease versions.
+                var libraryGroup = new UnpkgLibraryGroup(_packageInfoFactory, libraryName);
+                string latest = (await libraryGroup.GetLibraryVersions(cancellationToken)).First();
+
+                return latest;
+            }
+            
             string latestVersion = null;
 
             try

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
@@ -294,6 +294,27 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Unpkg
         }
 
         [TestMethod]
+        public async Task GetLatestVersion_Prerelease()
+        {
+            const string libraryName = "fakeLibrary";
+            var versions = new List<SemanticVersion>()
+            {
+                SemanticVersion.Parse("2.0.0-beta"),
+                SemanticVersion.Parse("1.0.0"),
+            };
+            var fakeCache = new Mock<ICacheService>();
+            fakeCache.SetupPackageVersions(libraryName);
+            var fakePackageInfoFactory = new Mock<INpmPackageInfoFactory>();
+            fakePackageInfoFactory.Setup(f => f.GetPackageInfoAsync(It.Is<string>(s => s == libraryName), It.IsAny<CancellationToken>()))
+                                  .Returns(Task.FromResult(new NpmPackageInfo(libraryName, "test package", "1.0.0", versions)));
+            UnpkgCatalog sut = SetupCatalog(fakeCache.Object, infoFactory: fakePackageInfoFactory.Object);
+
+            string result = await sut.GetLatestVersion(libraryName, includePreReleases: true, CancellationToken.None);
+
+            Assert.AreEqual("2.0.0-beta", result);
+        }
+
+        [TestMethod]
         public async Task GetLatestVersion_WebResponseFailedButNoCachedFile_ReturnsNull()
         {
             var fakeCache = new Mock<ICacheService>();


### PR DESCRIPTION
The API call used by the Unpkg catalog only returns the latest release
version.  In order to get prerelease versions as well (e.g. for the
Upgrade lightbulb), we need to specifically get all versions.

Resolves #349.