### PR TITLE
Correct the aligment of the completion flyout

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml
@@ -55,7 +55,7 @@
         <!-- Fly out -->
         <Popup x:Name="Flyout"
                StaysOpen="False"
-               Placement="Left"
+               Placement="Bottom"
                PlacementTarget="{Binding ElementName=SearchTextBox}">
             <ListBox x:Name="Options"
                      SelectionMode="Single"

--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
         {
             InitializeComponent();
 
-            Loaded += HandleLoaded;
             DataContextChanged += HandleDataContextChanged;
         }
 
@@ -62,29 +61,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 UIElementAutomationPeer.FromElement(SearchTextBox).RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
             });
-        }
-
-        private void HandleLoaded(object sender, RoutedEventArgs e)
-        {
-            var window = Window.GetWindow(this);
-
-            // Simple hack to make the popup dock to the textbox, so that the popup will be repositioned whenever
-            // the dialog is dragged or resized.
-            // In the below section, we will bump up the HorizontalOffset property of the popup whenever the dialog window
-            // location is changed or window is resized so that the popup gets repositioned.
-            if (window != null)
-            {
-                window.LocationChanged += RepositionPopup;
-                window.SizeChanged += RepositionPopup;
-            }
-        }
-
-        private void RepositionPopup(object sender, EventArgs e)
-        {
-            double offset = Flyout.HorizontalOffset;
-
-            Flyout.HorizontalOffset = offset + 1;
-            Flyout.HorizontalOffset = offset;
         }
 
         public bool IsMouseOverFlyout => Options.IsMouseOver;

--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 
         private void NotifyScreenReaderOfTextChanged(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 UIElementAutomationPeer.FromElement(SearchTextBox).RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
@@ -214,14 +214,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             }
         }
 
-        private void PositionCompletionPopup()
-        {
-            Flyout.VerticalOffset = SearchTextBox.ActualHeight;
-            Flyout.HorizontalOffset = -SearchTextBox.ActualWidth;
-            Options.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
-            Flyout.Width = Options.DesiredSize.Width;
-        }
-
         private void SearchTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
             TextChange textChange = e.Changes.Last();
@@ -234,7 +226,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
             bool textInserted = textChange.AddedLength > 0 && SearchTextBox.CaretIndex > 0;
             if (textInserted || Flyout.IsOpen)
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     // grab these WPF dependant things while we're still on the UI thread
                     int caretIndex = SearchTextBox.CaretIndex;
@@ -281,8 +273,6 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
                     {
                         CompletionEntries.Add(new CompletionEntry(entry, completionSet.Start, completionSet.Length));
                     }
-
-                    PositionCompletionPopup();
 
                     if (CompletionEntries != null && CompletionEntries.Count > 0 && Options.SelectedIndex == -1)
                     {


### PR DESCRIPTION
Not sure why the old offset was calculated like that, it's as though the flyout had used `Placement="Right"` in XAML instead of `Placement="Left"`.

Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1468930
