### PR TITLE
Update unit tests to target net6.0

### DIFF
--- a/test/LibraryManager.Test/Microsoft.Web.LibraryManager.Test.csproj
+++ b/test/LibraryManager.Test/Microsoft.Web.LibraryManager.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
       <Compile Remove="FileHelperTest.cs" />

--- a/test/Microsoft.Web.LibraryManager.Build.Test/Microsoft.Web.LibraryManager.Build.Test.csproj
+++ b/test/Microsoft.Web.LibraryManager.Build.Test/Microsoft.Web.LibraryManager.Build.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/libman.Test/libman.Test.csproj
+++ b/test/libman.Test/libman.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Web.LibraryManager.Tools.Test</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
As netcore2.1 is out of support, these tests fail to run on the CI
agents.  Updating to net6.0 will allow the tests to continue running.

Updating the src projects to net6.0 would also mean that they would stop
functioning for customers who did not have net6.0 installed.  This can
be a concern for both the MSBuild package and the CLI.  Such a change
should only be made when we are bumping the major version.
