### PR TITLE
Create a package for the VS integration tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,13 +12,13 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.0.487" />
+    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.1.386" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.0.487" />
-    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="17.0.31902.203" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.31902.203" />
-    <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="16.3.250" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.0.1600" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.1.386" />
+    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="17.1.32210.191" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.1.32210.191" />
+    <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="16.4.22" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054" />
     <PackageVersion Include="MiniMatch" Version="2.0.0" />
     <PackageVersion Include="Moq" Version="4.10.1" />
     <PackageVersion Include="NerdBank.GitVersioning" Version="3.3.37" />
@@ -34,7 +34,7 @@
 
     <!-- Test references -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.0.0-previews-2-31502-208" />
+    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.1.32210.191" />
     <PackageVersion Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.3" />
 

--- a/LibraryManager.sln
+++ b/LibraryManager.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28307.3004
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32227.109
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3ABB42B4-4EF4-4CED-9A56-2B910DF710F8}"
 	ProjectSection(SolutionItems) = preProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		appveyor.yml = appveyor.yml
 		CHANGELOG.md = CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		LibraryManager.Settings.targets = LibraryManager.Settings.targets
 		README.md = README.md
 		version.json = version.json

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -5,6 +5,11 @@ steps:
 - task: UseDotNet@2
   displayName: Install .NET Core SDK
 
+- pwsh: |
+    dotnet tool install --tool-path . nbgv --add-source https://api.nuget.org/v3/index.json
+    ./nbgv cloud -a
+  displayName: Set build number
+
 - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
   - template: azure-pipeline.microbuild.before.yml
 
@@ -36,6 +41,15 @@ steps:
     projects: "**/*.Test.csproj"
     arguments: --configuration $(BuildConfiguration) --no-build --filter "TestCategory!=FailsInCloudTest" -v n
   condition: and(succeeded(), ne(variables['SignType'], 'real'))
+
+- task: NuGetCommand@2
+  displayName: Create package for VS Integration tests
+  inputs:
+    command: pack
+    packagesToPack: test\VS.TestAssets.WebTools.LibMan\VS.TestAssets.WebTools.LibMan.nuspec
+    buildProperties: version=$(NBGV_NuGetPackageVersion)
+    packDestination: artifacts\Test
+    arguments: -NoPackageAnalysis
 
 - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
   - template: azure-pipeline.microbuild.after.yml

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -47,7 +47,8 @@ steps:
   inputs:
     command: pack
     packagesToPack: test\VS.TestAssets.WebTools.LibMan\VS.TestAssets.WebTools.LibMan.nuspec
-    buildProperties: version=$(NBGV_NuGetPackageVersion)
+    # don't use $(NBGV_NugetPackageVersion) because the pipeline sets PublicRelease=true so the prerelease data wouldn't align
+    buildProperties: version=$(NBGV_SimpleVersion)
     packDestination: artifacts\Test
     arguments: -NoPackageAnalysis
 

--- a/build/CreateInsertionMetadata.proj
+++ b/build/CreateInsertionMetadata.proj
@@ -16,7 +16,7 @@
     <WriteLinesToFile Overwrite="True" File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertPayloadName]LibraryManager build $(BuildVersion)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertDescription]Commit: $(GitCommitId)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertJsonValues]Microsoft.Web.LibraryManager.vsman=$([MSBuild]::Escape($(ManifestName)))" />
-    <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertConfigValues]VS.TestAssets.WebTools.LibMan=$(NuGetPackageVersion)" />
+    <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertConfigValues]VS.TestAssets.WebTools.LibMan=$(PackageVersion)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=VstsDropNames]$(MicroBuild_ManifestDropName)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=BuildVersion]$(BuildVersion)" />
 

--- a/build/CreateInsertionMetadata.proj
+++ b/build/CreateInsertionMetadata.proj
@@ -16,6 +16,7 @@
     <WriteLinesToFile Overwrite="True" File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertPayloadName]LibraryManager build $(BuildVersion)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertDescription]Commit: $(GitCommitId)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertJsonValues]Microsoft.Web.LibraryManager.vsman=$([MSBuild]::Escape($(ManifestName)))" />
+    <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=InsertConfigValues]VS.TestAssets.WebTools.LibMan=$(NuGetPackageVersion)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=VstsDropNames]$(MicroBuild_ManifestDropName)" />
     <WriteLinesToFile File="$(InsertionParamsFile)" Lines="##vso[task.setvariable variable=BuildVersion]$(BuildVersion)" />
 

--- a/test/LibraryManager.IntegrationTest/Microsoft.Web.LibraryManager.IntegrationTest.csproj
+++ b/test/LibraryManager.IntegrationTest/Microsoft.Web.LibraryManager.IntegrationTest.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/test/VS.TestAssets.WebTools.LibMan/VS.TestAssets.WebTools.LibMan.nuspec
+++ b/test/VS.TestAssets.WebTools.LibMan/VS.TestAssets.WebTools.LibMan.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  This .nuspec generates a package in a particular non-standard format, which is used for setting up the
+  test assets to be run in internal VS automation runs.  It provides no particular value to any parties
+  beyond validation of the features within this repo.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>VS.TestAssets.WebTools.LibMan</id>
+    <version>$version$</version>
+    <description>Integration test assets for Library Manager</description>
+    <authors>webtools</authors>
+
+  </metadata>
+  <files>
+    <file src="..\..\bin\Microsoft.Web.LibraryManager.IntegrationTest\$configuration$\net472\Microsoft.Web.LibraryManager.IntegrationTest.*" target="Assets" />
+    <file src="..\..\bin\Microsoft.Web.LibraryManager.IntegrationTest\$configuration$\net472\Omni.*.dll" target="Assets" />
+    <file src="..\..\bin\Microsoft.Web.LibraryManager.IntegrationTest\$configuration$\net472\Microsoft.Test.Apex.*.dll" target="Assets" />
+    <file src="..\..\bin\Microsoft.Web.LibraryManager.IntegrationTest\$configuration$\net472\*TestPlatform*.dll" target="Assets" />
+    <file src="..\..\bin\Microsoft.Web.LibraryManager.IntegrationTest\$configuration$\net472\TestSolution\**\*" target="Assets\TestSolution" />
+    <file src="..\..\bin\Microsoft.Web.LibraryManager.IntegrationTest\$configuration$\net472\RemoteInjectorBootstrapper64.exe" target="Assets" />
+    <file src="..\..\bin\Microsoft.Web.LibraryManager.IntegrationTest\$configuration$\net472\Microsoft.VisualStudio.RpcContracts.dll" target="Assets" />
+  </files>
+</package>


### PR DESCRIPTION
This creates a package to be used for VS integration test automation runs.  It's a nonstandard package and only intended for use with the VS automation runs.

This package always uses a version that doesn't contain the prerelease data.  This is only because I couldn't find a way to force the nbgv CLI to respect the PublicRelease environment variable, so the NugetPackageVersion it generates is always prerelease.  This didn't match what was generated by CreateInsertionMetadata.proj which does respect the environment variable.

I also had to update some of the VS dependencies to get the tests running again.  