### PR TITLE
Adapt to Cdnjs API changes

### DIFF
--- a/test/LibraryManager.Test/CacheServiceTest.cs
+++ b/test/LibraryManager.Test/CacheServiceTest.cs
@@ -31,12 +31,14 @@ namespace Microsoft.Web.LibraryManager.Test
             _cacheService = new CacheService(new Mocks.WebRequestHandler());
 
             Directory.CreateDirectory(_projectFolder);
+            Directory.CreateDirectory(_cacheFolder);
         }
 
         [TestCleanup]
         public void Cleanup()
         {
             TestUtils.DeleteDirectoryWithRetries(_projectFolder);
+            TestUtils.DeleteDirectoryWithRetries(_cacheFolder);
         }
 
         [TestMethod]


### PR DESCRIPTION
The Cdnjs API is changing to stop including the assets for all versions of a library in the /libraries/:library API.  We were using this to determine both library versions and library files.

The changes are fairly straightforward:
- for versions, we can just use the "versions" property from the library.  It's probably easier than what we were doing before (parsing each version from an "assets" entry).
- for files, we need to invoke the /libraries/:library/:version API instead.  However, the default file (which we use for selecting the default checked box in the wizard) is on the library group, not the library-version, so we still need to get that from the first request.
- Lastly, I included fields on each API call, so that we're not downloading any data that we aren't intending to use.  This drops 10s of KB from most library group queries, since there's a lot of metadata we don't care about.  We can always add more back later.

Addresses #685 but this will also need to be backported for servicing VS2017 and VS2019.
