### PR TITLE
Use netsdk 5 for the VS2019 build

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -4,6 +4,8 @@ steps:
 
 - task: UseDotNet@2
   displayName: Install .NET Core SDK
+  inputs:
+    version: 6.x
 
 - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
   - template: azure-pipeline.microbuild.before.yml

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -5,7 +5,7 @@ steps:
 - task: UseDotNet@2
   displayName: Install .NET Core SDK
   inputs:
-    version: 6.x
+    version: 5.x
 
 - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
   - template: azure-pipeline.microbuild.before.yml

--- a/test/LibraryManager.Test/Microsoft.Web.LibraryManager.Test.csproj
+++ b/test/LibraryManager.Test/Microsoft.Web.LibraryManager.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net472</TargetFrameworks>
+        <TargetFrameworks>net5.0;net472</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
       <Compile Remove="FileHelperTest.cs" />

--- a/test/Microsoft.Web.LibraryManager.Build.Test/Microsoft.Web.LibraryManager.Build.Test.csproj
+++ b/test/Microsoft.Web.LibraryManager.Build.Test/Microsoft.Web.LibraryManager.Build.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/libman.Test/libman.Test.csproj
+++ b/test/libman.Test/libman.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Microsoft.Web.LibraryManager.Tools.Test</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Netsdk 6 requires MSBuild 17 (the VS2022) version.  It was already present on the PR build pipeline, but for the official signed CI builds the agent machines only have VS2019.