### PR TITLE
Read lines from file once when assigning lines to error items

### DIFF
--- a/src/LibraryManager.Vsix/ErrorList/ErrorListPropagator.cs
+++ b/src/LibraryManager.Vsix/ErrorList/ErrorListPropagator.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Web.LibraryManager.Vsix.ErrorList
 
         public bool HandleErrors(IEnumerable<ILibraryOperationResult> results)
         {
-            IEnumerable<string> json = File.Exists(ConfigFileName) ? File.ReadLines(ConfigFileName) : Array.Empty<string>();
+            string[] jsonLines = File.Exists(ConfigFileName) ? File.ReadLines(ConfigFileName).ToArray() : Array.Empty<string>();
 
             foreach (ILibraryOperationResult result in results)
             {
                 if (!result.Success)
                 {
                     DisplayError[] displayErrors = result.Errors.Select(error => new DisplayError(error)).ToArray();
-                    AddLineAndColumn(json, result.InstallationState, displayErrors);
+                    AddLineAndColumn(jsonLines, result.InstallationState, displayErrors);
 
                     Errors.AddRange(displayErrors);
                 }
@@ -42,7 +42,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.ErrorList
             return Errors.Count > 0;
         }
 
-        private static void AddLineAndColumn(IEnumerable<string> lines, ILibraryInstallationState state, DisplayError[] errors)
+        private static void AddLineAndColumn(string[] lines, ILibraryInstallationState state, DisplayError[] errors)
         {
             string libraryId = LibraryIdToNameAndVersionConverter.Instance.GetLibraryId(state?.Name, state?.Version, state?.ProviderId);
 
@@ -55,9 +55,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.ErrorList
             {
                 int index = 0;
 
-                for (int i = 0; i < lines.Count(); i++)
+                for (int i = 0; i < lines.Length; i++)
                 {
-                    string line = lines.ElementAt(i);
+                    string line = lines[i];
 
                     if (line.Trim() == "{")
                         index = i;

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -100,7 +100,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
 
             if (e.FileActionType == FileActionTypes.ContentSavedToDisk && textDocument != null)
             {
-                _ = Task.Run(async () =>
+                _ = Task.Run(async () => await DoRestoreOnSaveAsync());
+
+                async Task DoRestoreOnSaveAsync()
                 {
                     try
                     {
@@ -151,7 +153,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                         Logger.LogEvent(ex.ToString(), LogLevel.Error);
                         Telemetry.TrackException("RestoreOnSaveFailed", ex);
                     }
-                });
+                };
             }
         }
 


### PR DESCRIPTION
File.ReadLines is implemented with an iterator that opens a stream to the file.  We were iterating it several times (calling `.Count()` and `.Element(i)` would clone the iterator, which meant constantly reiterating the underlying file stream), and keeping it the iterator in scope kept the file handle open.  This caused repeated file saves in VS to be unable to execute (because the file was locked), so VS would pop up a Save As dialog.

Iterating the lines once and then realizing the result into an array allows us to more efficiently compute the results using the string array rather than relying of repetitive file IO and keeping the file handle open.

Resolves #137
Also reported internally as https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1576158