### PR TITLE
Fix warnings related to NuGet packages

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -11,14 +11,14 @@ steps:
 - script: dotnet --info
   displayName: Show dotnet SDK info
 
-- task: DotNetCoreCLI@2
-  displayName: Restore
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate with NuGet'
+
+- task: PowerShell@2
+  displayName: 'dotnet restore'
   inputs:
-    command: restore
-    verbosityRestore: normal # detailed, normal, minimal
-    projects: LibraryManager.sln
-    feedsToUse: config
-    nugetConfigPath: nuget.config
+    targetType: 'inline'
+    script: 'dotnet restore --nologo'
 
 - task: MSBuild@1
   inputs:

--- a/nuget.config
+++ b/nuget.config
@@ -6,4 +6,18 @@
     <add key="dotnet-myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="vs" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
   </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-myget-legacy">
+      <package pattern="Microsoft.Extensions.CommandLineUtils.Sources" />
+    </packageSource>
+    <packageSource key="vs">
+      <package pattern="Microsoft.Test.Apex.VisualStudio" />
+      <package pattern="Microsoft.VisualStudio.Internal.MicroBuild" />
+      <package pattern="Microsoft.WebTools.Languages.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/test/LibraryManager.IntegrationTest/Microsoft.Web.LibraryManager.IntegrationTest.csproj
+++ b/test/LibraryManager.IntegrationTest/Microsoft.Web.LibraryManager.IntegrationTest.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.WebTools.Languages.Json.VS" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
-    <PackageReference Include="Nerdbank.GitVersioning" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="TestSolution\**\*" />


### PR DESCRIPTION
Summary of the changes:
 - Sets nuget package source mappings
 - Removes duplicate PackageReference in integration test project.
 - Change to use NugetAuthenticate and dotnet restore instead of DotNetCoreCLI@2 task (the DotNetCoreCLI task breaks package source mappings)
