### PR TITLE
Update VS references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- This is due to noise caused from the Minimatch package, tracked at https://github.com/SLaks/Minimatch/issues/12 -->
     <NoWarn>$(NoWarn);NU1603</NoWarn>
-    <WebToolsPackageVersion>17.4.271-preview-0003</WebToolsPackageVersion>
+    <WebToolsPackageVersion>17.7.273</WebToolsPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.9.0" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="16.9.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
@@ -18,7 +19,9 @@
     <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.7.188" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="17.5.33428.388" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.7.37355" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.7.30" />
     <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="17.7.57" />
+    <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.6.11" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.7.2196" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Css" Version="$(WebToolsPackageVersion)" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Shared" Version="$(WebToolsPackageVersion)" />
@@ -32,15 +35,18 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nuget.VisualStudio" Version="6.0.0" />
 
+    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Net.Http" Version="4.3.1" />
     <PackageVersion Include="System.Runtime" Version="4.3.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
     <PackageVersion Include="System.ValueTuple" Version="4.3.0" />
 
     <!-- Test references -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.0.0-previews-2-31502-208" />
     <PackageVersion Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,9 +47,9 @@
 
     <!-- Test references -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.0.0-previews-2-31502-208" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.7.34031.279" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.0.3" />
 
     <!-- CommandLine utils -->
     <!-- This version should be kept in sync with the value of RuntimeFrameworkVersion where this package is consumed -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.0.487" />
+    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.7.188" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.65" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.0.487" />
-    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="17.0.31902.203" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.31902.203" />
-    <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="16.3.250" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.0.1600" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.7.188" />
+    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="17.5.33428.388" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.7.37355" />
+    <PackageVersion Include="Microsoft.VisualStudio.Telemetry" Version="17.7.57" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.7.2196" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Css" Version="$(WebToolsPackageVersion)" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Shared" Version="$(WebToolsPackageVersion)" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Shared.Editor" Version="$(WebToolsPackageVersion)" />
@@ -29,7 +29,7 @@
     <PackageVersion Include="MiniMatch" Version="2.0.0" />
     <PackageVersion Include="Moq" Version="4.10.1" />
     <PackageVersion Include="NerdBank.GitVersioning" Version="3.3.37" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nuget.VisualStudio" Version="6.0.0" />
 
     <PackageVersion Include="System.Net.Http" Version="4.3.1" />

--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,1 @@
-msbuild /r %~dp0LibraryManager.sln /clp:Verbosity=Minimal;Summary;ForceNoAlign %*
+msbuild /r %~dp0LibraryManager.sln /clp:Verbosity=Minimal;Summary;ForceNoAlign /bl:%~dp0artifacts/Build.binlog %*

--- a/src/LibraryManager.Vsix/Commands/CleanCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/CleanCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.Clean);
             var cmd = new OleMenuCommand((s, e) => _ = package.JoinableTaskFactory.RunAsync(() => ExecuteAsync()),
                                          cmdId);
-            cmd.BeforeQueryStatus += (s, e) => package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
+            cmd.BeforeQueryStatus += (s, e) => _ = package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);
 
             _buildEvents = VsHelpers.DTE.Events.BuildEvents;

--- a/src/LibraryManager.Vsix/Commands/CleanCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/CleanCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             _libraryCommandService = libraryCommandService;
 
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.Clean);
-            var cmd = new OleMenuCommand((s, e) => package.JoinableTaskFactory.RunAsync(() => ExecuteAsync()),
+            var cmd = new OleMenuCommand((s, e) => _ = package.JoinableTaskFactory.RunAsync(() => ExecuteAsync()),
                                          cmdId);
             cmd.BeforeQueryStatus += (s, e) => package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
         private InstallLibraryCommand(AsyncPackage package, OleMenuCommandService commandService, ILibraryCommandService libraryCommandService, IDependenciesFactory dependenciesFactory)
         {
             CommandID cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.InstallPackage);
-            OleMenuCommand cmd = new OleMenuCommand((s, e) => package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
+            OleMenuCommand cmd = new OleMenuCommand((s, e) => _ = package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                                     cmdId);
             cmd.BeforeQueryStatus += (s, e) => package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             CommandID cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.InstallPackage);
             OleMenuCommand cmd = new OleMenuCommand((s, e) => _ = package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                                     cmdId);
-            cmd.BeforeQueryStatus += (s, e) => package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
+            cmd.BeforeQueryStatus += (s, e) => _ = package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);
 
             _libraryCommandService = libraryCommandService;

--- a/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             _dependenciesFactory = dependenciesFactory;
 
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.ManageLibraries);
-            var cmd = new OleMenuCommand((s, e) => package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
+            var cmd = new OleMenuCommand((s, e) => _ = package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                          cmdId);
             cmd.BeforeQueryStatus += BeforeQueryStatus;
             commandService.AddCommand(cmd);

--- a/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.Restore);
             var cmd = new OleMenuCommand((s, e) => package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                          cmdId);
-            cmd.BeforeQueryStatus += (s, e) => package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
+            cmd.BeforeQueryStatus += (s, e) => _ = package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);
         }
 

--- a/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             _libraryCommandService = libraryCommandService;
 
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.Restore);
-            var cmd = new OleMenuCommand((s, e) => package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
+            var cmd = new OleMenuCommand((s, e) => _ = package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                          cmdId);
             cmd.BeforeQueryStatus += (s, e) => _ = package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);

--- a/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             _dependenciesFactory = dependenciesFactory;
 
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.RestoreOnBuild);
-            var cmd = new OleMenuCommand((s, e) => _package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
+            var cmd = new OleMenuCommand((s, e) => _ = _package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                          cmdId);
             cmd.BeforeQueryStatus += (s, e) => _package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);

--- a/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.RestoreOnBuild);
             var cmd = new OleMenuCommand((s, e) => _ = _package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                          cmdId);
-            cmd.BeforeQueryStatus += (s, e) => _package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
+            cmd.BeforeQueryStatus += (s, e) => _ = _package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);
         }
 

--- a/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.RestoreSolution);
             var cmd = new OleMenuCommand((s, e) => _ = _package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                          cmdId);
-            cmd.BeforeQueryStatus += (s, e) => _package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
+            cmd.BeforeQueryStatus += (s, e) => _ = _package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);
         }
 

--- a/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Commands
             _libraryCommandService = libraryCommandService;
 
             var cmdId = new CommandID(PackageGuids.guidLibraryManagerPackageCmdSet, PackageIds.RestoreSolution);
-            var cmd = new OleMenuCommand((s, e) => _package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
+            var cmd = new OleMenuCommand((s, e) => _ = _package.JoinableTaskFactory.RunAsync(() => ExecuteAsync(s, e)),
                                          cmdId);
             cmd.BeforeQueryStatus += (s, e) => _package.JoinableTaskFactory.RunAsync(() => BeforeQueryStatusAsync(s, e));
             commandService.AddCommand(cmd);

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Contracts
         public static void ClearOutputWindow()
         {
             // Don't access _outputWindowPane through the property here so that we don't force creation
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 OutputWindowPaneValue?.Clear();
@@ -193,7 +193,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 
         private static void LogToActivityLog(string message, __ACTIVITYLOG_ENTRYTYPE type)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 ActivityLog.LogEntry((uint)type, Vsix.Name, message);
@@ -202,7 +202,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 
         private static void LogToStatusBar(string message)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 Statusbar.FreezeOutput(0);

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
                 _ = RetriggerAsync(true);
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 if (_currentSession == null && _broker.IsCompletionActive(_textView))

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json.Completion
             if (array == null)
                 yield break;
 
-            foreach (ArrayElementNode arrayElement in array.Elements)
+            foreach (ArrayElementNode arrayElement in array.ElementNodes)
             {
                 if (arrayElement.Value is TokenNode token && token.Text != context.ContextNode.GetText())
                 {

--- a/src/LibraryManager.Vsix/Json/JsonHelpers.cs
+++ b/src/LibraryManager.Vsix/Json/JsonHelpers.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json
                         state.DestinationPath = GetCanonicalizedValue(child);
                         break;
                     case ManifestConstants.Files:
-                        state.Files = (child.Value as ArrayNode)?.Elements.Select(e => GetCanonicalizedValue(e)).ToList();
+                        state.Files = (child.Value as ArrayNode)?.ElementNodes.Select(e => GetCanonicalizedValue(e)).ToList();
                         break;
                 }
             }

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Json.SuggestedActions
 
         public override void Invoke(CancellationToken cancellationToken)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await InvokeAsync(cancellationToken);
             });

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -28,6 +28,7 @@
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <!-- Live Unit Testing workarounds -->
     <CreateVsixContainer Condition="'$(BuildingForLiveUnitTesting)' == 'true'">false</CreateVsixContainer>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI
 
         private void InstallButton_Clicked(object sender, RoutedEventArgs e)
         {
-            Shell.ThreadHelper.JoinableTaskFactory.RunAsync(() => ClickInstallButtonAsync());
+            _ = Shell.ThreadHelper.JoinableTaskFactory.RunAsync(() => ClickInstallButtonAsync());
         }
 
         private async Task<bool> IsLibraryInstallationStateValidAsync()

--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 
         private void InstallPackage()
         {
-            Shell.ThreadHelper.JoinableTaskFactory.RunAsync(async () => await InstallPackageAsync()).Task.ConfigureAwait(false);
+            _ = Shell.ThreadHelper.JoinableTaskFactory.RunAsync(async () => await InstallPackageAsync());
         }
 
         private async Task InstallPackageAsync()

--- a/test/LibraryManager.IntegrationTest/Microsoft.Web.LibraryManager.IntegrationTest.csproj
+++ b/test/LibraryManager.IntegrationTest/Microsoft.Web.LibraryManager.IntegrationTest.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
+    <!-- Suppress the architecture mismatch warning from the apex package -->
+    <NoWarn>$(NoWarn);MSB3270</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
 - Updated to latest (17.7 GA) packages from VS
 - Addressed some warnings, old and new
   - VSTHRD analyzer complaining about unawaited tasks => explicitly discard to indicate fire-and-forget
   - OutputWindowPane.OutputString is deprecated => switch to OutputWindowTextWriter, which allows free-threaded writes to an output pane
   - Couple integration tests were failing by calling removed APIs => updated to latest (17.7) and tests now pass
   - Pinned a few package versions to resolve MSB3277 warnings
   - VS JSON parser's ArrayElementNode.Elements marked deprecated => move to ElementNodes.