### PR TITLE
Switch away from deprecated NuGet API

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,8 @@
     <PackageVersion Include="Moq" Version="4.10.1" />
     <PackageVersion Include="NerdBank.GitVersioning" Version="3.3.37" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Nuget.VisualStudio" Version="6.0.0" />
+    <PackageVersion Include="Nuget.VisualStudio" Version="17.7.0" />
+    <PackageVersion Include="NuGet.VisualStudio.Contracts" Version="17.7.0" />
 
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -184,7 +184,8 @@
     <PackageReference Include="Microsoft.WebTools.Languages.Json.Editor" />
     <PackageReference Include="Microsoft.WebTools.Languages.Json.VS" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="Nuget.VisualStudio" />
+    <PackageReference Include="NuGet.VisualStudio" />
+    <PackageReference Include="NuGet.VisualStudio.Contracts" />
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="Commands\CommandTable\VSCommandTable.en.vsct">

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -545,5 +545,17 @@ namespace Microsoft.Web.LibraryManager.Vsix.Shared
                 }
             }
         }
+
+        public static Guid GetProjectGuid(Project project)
+        {
+            string uniqueName = project.UniqueName;
+            IVsSolution solution = (IVsSolution)Package.GetGlobalService(typeof(SVsSolution));
+            solution.GetProjectOfUniqueName(uniqueName, out IVsHierarchy hierarchy);
+            hierarchy.GetGuidProperty(
+                (uint)VSConstants.VSITEMID.Root,
+                (int)__VSHPROPID.VSHPROPID_ProjectIDGuid,
+                out Guid projectGuid);
+            return projectGuid;
+        }
     }
 }


### PR DESCRIPTION
The IVsPackageInstallerServices interface is marked deprecated for getting installed package info, due to threading problems within NuGet.  Switched to the new interface instead.