### PR TITLE
Generalize project system interactions to CPS

### DIFF
--- a/src/LibraryManager.Vsix/Constants.cs
+++ b/src/LibraryManager.Vsix/Constants.cs
@@ -14,6 +14,13 @@ namespace Microsoft.Web.LibraryManager.Vsix
         public const string ErrorCodeLink = "https://github.com/aspnet/LibraryManager/wiki/Error-codes#{0}";
         public const string WAP = "{349C5851-65DF-11DA-9384-00065B846F21}";
         public const string WebsiteProject = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
+        /// <summary>
+        /// Project capability for .NET web projects. Used only for UI context rules.
+        /// </summary>
         public const string DotNetCoreWebCapability = "DotNetCoreWeb";
+        /// <summary>
+        /// Project capability for CPS-based projects. Used to determine how to add/remove items to the project.
+        /// </summary>
+        public const string CpsCapability = "CPS";
     }
 }

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -85,9 +85,9 @@ namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 
             //Delete from project
             Project project = VsHelpers.GetDTEProjectFromConfig(_configFilePath);
-            bool isCoreProject = await VsHelpers.IsDotNetCoreWebProjectAsync(project);
+            bool isCpsProject = await VsHelpers.IsCpsProject(project);
 
-            if (!isCoreProject)
+            if (!isCpsProject)
             {
                 var logAction = new Action<string, LogLevel>((message, level) => { Logger.Log(message, level); });
                 bool deleteFromProject = await VsHelpers.DeleteFilesFromProjectAsync(project, absolutePaths, logAction, cancellationToken);

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Shared
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (IsCapabilityMatch(project, Constants.DotNetCoreWebCapability))
+            if (IsCapabilityMatch(project, Constants.CpsCapability))
             {
                 return;
             }
@@ -140,7 +140,7 @@ namespace Microsoft.Web.LibraryManager.Vsix.Shared
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            if (project == null || IsCapabilityMatch(project, Constants.DotNetCoreWebCapability))
+            if (project == null || IsCapabilityMatch(project, Constants.CpsCapability))
             {
                 return;
             }
@@ -244,11 +244,14 @@ namespace Microsoft.Web.LibraryManager.Vsix.Shared
             return false;
         }
 
-        public static async Task<bool> IsDotNetCoreWebProjectAsync(Project project)
+        /// <summary>
+        /// Returns whether the DTE project is a CPS-based project
+        /// </summary>
+        public static async Task<bool> IsCpsProject(Project project)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (project == null || IsCapabilityMatch(project, Constants.DotNetCoreWebCapability))
+            if (project == null || IsCapabilityMatch(project, Constants.CpsCapability))
             {
                 return true;
             }


### PR DESCRIPTION
We can share behavior across all CPS projects for handling files additions/removals.  CPS is much more efficient for bulk edits - they work from the file system automatically, so we don't have to do batched edits on the UI thread in VS. This is something we should take advantage of for as many project types as possible, not limited to DotNetCoreWeb.

Resolves #710
