### PR TITLE
Open source file in FileMode Open

### DIFF
--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
         {
             try
             {
-                using (FileStream sourceStream = File.Open(sourceFile, FileMode.Open))
+                using (FileStream sourceStream = File.Open(sourceFile, FileMode.Open, FileAccess.Read))
                 {
                     await WriteToFileAsync(destinationFile, sourceStream, cancellationToken);
                 }


### PR DESCRIPTION
Opening the source file without providing `FileMode` will default to `FileMode.ReadWrite`. This lead to sporadic built errors which disappeared after explicitly setting `FileMode` to `FileAccess.Read`.
