### PR TITLE
#682 Add non-zero exit code on general exception and on error in Restore command

### DIFF
--- a/src/LibraryManager.Contracts/ExitCode.cs
+++ b/src/LibraryManager.Contracts/ExitCode.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Web.LibraryManager.Contracts
+{
+    /// <summary>
+    /// Exit codes of libman tool
+    /// </summary>
+    public enum ExitCode
+    {
+        /// <summary>
+        /// Indicates successful execution
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// Indicates failed execution
+        /// </summary>
+        Failure = 1
+    }
+}

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Web.LibraryManager
         /// Restores all libraries in the <see cref="Libraries"/> collection.
         /// </summary>
         /// <param name="cancellationToken">A token that allows for cancellation of the operation.</param>
-        public async Task<IEnumerable<ILibraryOperationResult>> RestoreAsync(CancellationToken cancellationToken)
+        public async Task<IList<ILibraryOperationResult>> RestoreAsync(CancellationToken cancellationToken)
         {
             //TODO: This should have an "undo scope"
             var results = new List<ILibraryOperationResult>();

--- a/src/libman/Commands/RestoreCommand.cs
+++ b/src/libman/Commands/RestoreCommand.cs
@@ -35,14 +35,14 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
                 sw.Stop();
                 LogErrors(validationResults.SelectMany(r => r.Errors));
 
-                return 0;
+                return (int)ExitCode.Failure;
             }
 
-            IEnumerable<ILibraryOperationResult> results = await ManifestRestorer.RestoreManifestAsync(manifest, Logger, CancellationToken.None);
+            IList<ILibraryOperationResult> results = await ManifestRestorer.RestoreManifestAsync(manifest, Logger, CancellationToken.None);
             sw.Stop();
             LogResultsSummary(results, OperationType.Restore, sw.Elapsed);
 
-            return 0;
+            return results.Any(r => r.Errors.Any()) ? (int)ExitCode.Failure : (int)ExitCode.Success;
         }
     }
 }

--- a/src/libman/ExitCode.cs
+++ b/src/libman/ExitCode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Web.LibraryManager.Contracts
+namespace Microsoft.Web.LibraryManager.Tools
 {
     /// <summary>
     /// Exit codes of libman tool

--- a/src/libman/ManifestRestorer.cs
+++ b/src/libman/ManifestRestorer.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Web.LibraryManager.Tools
         /// <param name="logger"></param>
         /// <param name="cancelToken"></param>
         /// <returns></returns>
-        public static async Task<IEnumerable<ILibraryOperationResult>> RestoreManifestAsync(Manifest manifest, ILogger logger, CancellationToken cancelToken)
+        public static async Task<IList<ILibraryOperationResult>> RestoreManifestAsync(Manifest manifest, ILogger logger, CancellationToken cancelToken)
         {
-            IEnumerable<ILibraryOperationResult> results = await manifest.RestoreAsync(cancelToken);
+            IList<ILibraryOperationResult> results = await manifest.RestoreAsync(cancelToken);
 
-            IEnumerable<ILibraryOperationResult> failures = results.Where(r => r.Errors.Any());
+            IList<ILibraryOperationResult> failures = results.Where(r => r.Errors.Any()).ToList();
             if (failures.Any())
             {
                 var librarySpecificErrors = new StringBuilder();

--- a/src/libman/Program.cs
+++ b/src/libman/Program.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Web.LibraryManager.Tools
     {
         static void Main(string[] args)
         {
+            Environment.ExitCode = (int)ExitCode.Failure;
 #if DEBUG
             int debugIndex = args.ToList().FindIndex(a => a.Equals("--debug", StringComparison.OrdinalIgnoreCase));
             if (debugIndex > 0)
@@ -32,7 +33,7 @@ namespace Microsoft.Web.LibraryManager.Tools
             app.Configure();
             try
             {
-                app.Execute(args);
+                Environment.ExitCode = app.Execute(args);
             }
             catch (CommandParsingException cpe)
             {

--- a/test/libman.Test/LibmanRestoreTest.cs
+++ b/test/libman.Test/LibmanRestoreTest.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Tools.Commands;
 
 namespace Microsoft.Web.LibraryManager.Tools.Test
@@ -44,7 +45,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), contents);
 
             int result = command.Execute();
-            Assert.AreEqual(0, result);
+            Assert.AreEqual((int)ExitCode.Success, result);
 
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.min.js")));
             Assert.IsTrue(File.Exists(Path.Combine(WorkingDir, "wwwroot", "core.js")));
@@ -71,7 +72,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             File.WriteAllText(Path.Combine(WorkingDir, "libman.json"), contents);
 
             int result = command.Execute();
-            Assert.AreEqual(0, result);
+            Assert.AreEqual((int)ExitCode.Failure, result);
 
             Assert.IsFalse(File.Exists(Path.Combine(WorkingDir, "wwwroot", "jquery.min.js")));
             Assert.IsFalse(File.Exists(Path.Combine(WorkingDir, "wwwroot", "core.js")));

--- a/test/libman.Test/LibmanRestoreTest.cs
+++ b/test/libman.Test/LibmanRestoreTest.cs
@@ -4,7 +4,6 @@
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Tools.Commands;
 
 namespace Microsoft.Web.LibraryManager.Tools.Test


### PR DESCRIPTION
Summary of the changes
 - Used return value from Microsoft.Extensions.CommandLineUtils.Execute() to propagate exit code, was hardcoded to 0
 - Eliminated unclear use of IEnumerable variables with multiple enumerations when evaluating 'restore' results

Resolves #682 
