### PR TITLE
Revert "Use consolidated nuget feed"

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,22 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="libman" value="https://pkgs.dev.azure.com/azure-public/vswebtools/_packaging/libman/nuget/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet-myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="vs" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
   </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-myget-legacy">
+      <package pattern="Microsoft.Extensions.CommandLineUtils.Sources" />
+    </packageSource>
+    <packageSource key="vs">
+      <package pattern="Microsoft.Test.Apex.VisualStudio" />
+      <package pattern="Microsoft.VisualStudio.Internal.MicroBuild" />
+      <package pattern="Microsoft.WebTools.Languages.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,7 +4,7 @@
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
-    <add key="vs" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
+    <add key="libman" value="https://pkgs.dev.azure.com/azure-public/vswebtools/_packaging/libman/nuget/v3/index.json" />
   </packageSources>
 
   <packageSourceMapping>
@@ -14,7 +14,7 @@
     <packageSource key="dotnet-myget-legacy">
       <package pattern="Microsoft.Extensions.CommandLineUtils.Sources" />
     </packageSource>
-    <packageSource key="vs">
+    <packageSource key="libman">
       <package pattern="Microsoft.Test.Apex.VisualStudio" />
       <package pattern="Microsoft.VisualStudio.Internal.MicroBuild" />
       <package pattern="Microsoft.WebTools.Languages.*" />


### PR DESCRIPTION
Reverts aspnet/LibraryManager#714

This change caused permissions issues when non-Microsoft users attempt to restore the solution.  I was able to reproduce this on my personal (non-MSFT) device, and the restore worked after reverting the change.

It would also be a blocker for proposing a new package or package version, as users not authorized with the ADO feed would not have rights to promote new packages into the consolidated feed.  The main security issue with multiple feeds is described at https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping.  As long as each package is only requested from a single specific feed, it avoids the risk of a supply chain attack where a package from a one feed is maliciously faked on another feed, so since we previously had packageSource configured for each package, this should not be a concern (also, because we don't use nuget.org, all of these feeds should already be secured).

I doubt that reverting this change will solve the issue of proposing a new package version, as an unauthorized user still won't have permissions to promote packages to the dotnet-public feed either.  But at least this should address the restore problem.

Addresses #728 