### PR TITLE
Add a --whatif option to CLI update command

### DIFF
--- a/src/libman/Commands/UpdateCommand.cs
+++ b/src/libman/Commands/UpdateCommand.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
         /// <remarks>Needs the full library id.</remarks>
         public CommandOption ToVersion { get; private set; }
 
+        /// <summary>
+        /// Option to specify if this should print the operation that would be carried out, but not make changes.
+        /// </summary>
+        public CommandOption WhatIf { get; private set; }
+
         public override BaseCommand Configure(CommandLineApplication parent = null)
         {
             base.Configure(parent);
@@ -56,6 +61,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             Provider = Option("--provider|-p", Resources.Text.UpdateCommandProviderOptionDesc, CommandOptionType.SingleValue);
             PreRelease = Option("-pre", Resources.Text.UpdateCommandPreReleaseOptionDesc, CommandOptionType.NoValue);
             ToVersion = Option("--to", Resources.Text.UpdateCommandToVersionOptionDesc, CommandOptionType.SingleValue);
+            WhatIf = Option("--whatif", Resources.Text.WhatIfOptionDesc, CommandOptionType.NoValue);
 
             // Reserve this.
             Provider.ShowInHelpText = false;
@@ -103,6 +109,12 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
             if (newVersion == null || newVersion == libraryToUpdate.Version)
             {
                 Logger.Log(string.Format(Resources.Text.LatestVersionAlreadyInstalled, libraryToUpdate.Name), LogLevel.Operation);
+                return 0;
+            }
+
+            if (WhatIf.HasValue())
+            {
+                Logger.Log(string.Format(Resources.Text.WhatIfOutputMessage, libraryToUpdate.Name, newVersion), LogLevel.Operation);
                 return 0;
             }
 

--- a/src/libman/Resources/Text.Designer.cs
+++ b/src/libman/Resources/Text.Designer.cs
@@ -955,5 +955,23 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
                 return ResourceManager.GetString("VerbosityOptionDesc", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Print what operations would be carried out, without making any changes..
+        /// </summary>
+        internal static string WhatIfOptionDesc {
+            get {
+                return ResourceManager.GetString("WhatIfOptionDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Library &quot;{0}&quot; would be updated to latest version &quot;{1}&quot;.
+        /// </summary>
+        internal static string WhatIfOutputMessage {
+            get {
+                return ResourceManager.GetString("WhatIfOutputMessage", resourceCulture);
+            }
+        }
     }
 }

--- a/src/libman/Resources/Text.resx
+++ b/src/libman/Resources/Text.resx
@@ -431,4 +431,10 @@ Please specify a different destination.</value>
   <data name="UseDefault" xml:space="preserve">
     <value>Use the default settings for the libman.json file</value>
   </data>
+  <data name="WhatIfOptionDesc" xml:space="preserve">
+    <value>Print what operations would be carried out, without making any changes.</value>
+  </data>
+  <data name="WhatIfOutputMessage" xml:space="preserve">
+    <value>Library "{0}" would be updated to latest version "{1}"</value>
+  </data>
 </root>


### PR DESCRIPTION
This flag will cause the command to print a message indicating what changes would be made, but not commit any changes to the file system. It's useful to plan in advance before making changes.

Resolves #723 
