### PR TITLE
Change -pre to --pre for CLI update command

### DIFF
--- a/src/libman/Commands/UpdateCommand.cs
+++ b/src/libman/Commands/UpdateCommand.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Commands
 
             LibraryName = Argument("libraryName", Resources.Text.UpdateCommandLibraryArgumentDesc, multipleValues: false);
             Provider = Option("--provider|-p", Resources.Text.UpdateCommandProviderOptionDesc, CommandOptionType.SingleValue);
-            PreRelease = Option("-pre", Resources.Text.UpdateCommandPreReleaseOptionDesc, CommandOptionType.NoValue);
+            PreRelease = Option("--pre", Resources.Text.UpdateCommandPreReleaseOptionDesc, CommandOptionType.NoValue);
             ToVersion = Option("--to", Resources.Text.UpdateCommandToVersionOptionDesc, CommandOptionType.SingleValue);
 
             // Reserve this.

--- a/src/libman/Resources/Text.Designer.cs
+++ b/src/libman/Resources/Text.Designer.cs
@@ -855,7 +855,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Resources {
         /// <summary>
         ///   Looks up a localized string similar to     libman update jquery
         ///    libman update jquery --to 3.3.1
-        ///    libman update jquery -pre
+        ///    libman update jquery --pre
         ///.
         /// </summary>
         internal static string UpdateCommandExamples {

--- a/src/libman/Resources/Text.resx
+++ b/src/libman/Resources/Text.resx
@@ -296,7 +296,7 @@
   <data name="UpdateCommandExamples" xml:space="preserve">
     <value>    libman update jquery
     libman update jquery --to 3.3.1
-    libman update jquery -pre
+    libman update jquery --pre
 </value>
   </data>
   <data name="UpdateCommandRemarks" xml:space="preserve">


### PR DESCRIPTION
All the other command parameters are consistent about following the GNU convention of using -- for long names and - for short (single-letter) names.  This one was just inconsistent.

This may be considered a breaking change, so it is best to align with the 3.0 change if possible.
