### PR TITLE
Lower MSBuild output to Normal verbosity

### DIFF
--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Web.LibraryManager.Build
 
             CancellationToken token = CancellationToken.None;
 
-            Log.LogMessage(MessageImportance.High, Environment.NewLine + Resources.Text.Restore_OperationStarted);
+            Log.LogMessage(MessageImportance.Normal, Environment.NewLine + Resources.Text.Restore_OperationStarted);
 
             var dependencies = Dependencies.FromTask(ProjectDirectory, ProviderAssemblies.Select(pa => new FileInfo(pa.ItemSpec).FullName));
             Manifest manifest = Manifest.FromFileAsync(configFilePath.FullName, dependencies, token).Result;
@@ -117,11 +117,11 @@ namespace Microsoft.Web.LibraryManager.Build
                 if (fileCount > 0)
                 {
                     string text = string.Format(Resources.Text.Restore_NumberOfLibrariesSucceeded, results.Count(), Math.Round(sw.Elapsed.TotalSeconds, 2));
-                    Log.LogMessage(MessageImportance.High, Environment.NewLine + text + Environment.NewLine);
+                    Log.LogMessage(MessageImportance.Normal, Environment.NewLine + text + Environment.NewLine);
                 }
                 else
                 {
-                    Log.LogMessage(MessageImportance.High, Environment.NewLine + "Restore completed. Files already up-to-date" + Environment.NewLine);
+                    Log.LogMessage(MessageImportance.Normal, Environment.NewLine + "Restore completed. Files already up-to-date" + Environment.NewLine);
                 }
             }
         }


### PR DESCRIPTION
With this change, the begin and end messages are no longer shown when the verbosity is minimal.  This aligns with normal output - only the project level status is shown:

```
C:\temp\project> dotnet build -v:m
MSBuild version 17.9.4+90725d08d for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
  project -> C:\temp\project\bin\Debug\net8.0\project.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

When verbosity is increased to Normal, we see the following output for the libman restore:

```
C:\temp\project> dotnet build -v:n
...
   1:7>Project "C:\temp\project\project.csproj" on node 1 (default targets).
     1>LibraryManagerRestore:

         Restore operation started
         Restoring library jquery@3.2.1...
         lib/jquery/core.js written to destination
         lib/jquery/jquery.js written to destination
         lib/jquery/jquery.min.js written to destination
         lib/jquery/jquery.min.map written to destination
         lib/jquery/jquery.slim.js written to destination
         lib/jquery/jquery.slim.min.js written to destination
         lib/jquery/jquery.slim.min.map written to destination

         1 libraries restored in 0.07 seconds
```

Resolves #707  
