### PR TITLE
Use LangVersion=latest everywhere

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,7 @@
     <CheckForOverflowUnderflow Condition=" '$(Configuration)' == 'Debug' ">true</CheckForOverflowUnderflow>
     <NetFxTFM>net481</NetFxTFM>
     <NetCoreTFM>net8.0</NetCoreTFM>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -28,7 +28,6 @@
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <!-- Live Unit Testing workarounds -->
     <CreateVsixContainer Condition="'$(BuildingForLiveUnitTesting)' == 'true'">false</CreateVsixContainer>
-    <LangVersion>11</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Many language features in recent .NET releases work fine on .NET Framework, but by default the compiler version used is based on the target framework during build.  This means that in a multitargeted project, code for .NET Framework will use a different compiler version than code for .NET, which either prevents us from using newer features, or splits the codebase.

By using so targeting the latest version of C# everywhere, it allows us to leverage those new features regardless of framework.  For any new features that have runtime requirements (i.e. are not compatible with .NET Framework), the compiler will issue an error anyway.