### PR TITLE
Set SDK rollforward to LatestFeature

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.200",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This is needed as updating VS versions often push new feature versions of the SDK (such as 8.0.200 -> 8.0.300-preview, removing 8.0.200) which breaks building locally.