### PR TITLE
Introduce OperationResult type

### DIFF
--- a/LibraryManager.sln
+++ b/LibraryManager.sln
@@ -55,6 +55,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Web.LibraryManage
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Web.LibraryManager.Vsix.Test", "test\Microsoft.Web.LibraryManager.Vsix.Test\Microsoft.Web.LibraryManager.Vsix.Test.csproj", "{00EE7B7F-EDA3-49E6-AA38-118C15B58CDB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Web.LibraryManager.Contracts.Test", "test\LibraryManager.Contracts.Test\Microsoft.Web.LibraryManager.Contracts.Test.csproj", "{514120AD-8F89-476A-8AB3-F582E6CA8697}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "schema", "schema", "{4B76692E-EF61-499F-900F-752FFC08D6E9}"
 	ProjectSection(SolutionItems) = preProject
 		src\schema\libman.json = src\schema\libman.json
@@ -202,6 +204,18 @@ Global
 		{00EE7B7F-EDA3-49E6-AA38-118C15B58CDB}.Release|x64.Build.0 = Release|Any CPU
 		{00EE7B7F-EDA3-49E6-AA38-118C15B58CDB}.Release|x86.ActiveCfg = Release|Any CPU
 		{00EE7B7F-EDA3-49E6-AA38-118C15B58CDB}.Release|x86.Build.0 = Release|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Debug|x64.Build.0 = Debug|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Debug|x86.Build.0 = Debug|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Release|Any CPU.Build.0 = Release|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Release|x64.ActiveCfg = Release|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Release|x64.Build.0 = Release|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Release|x86.ActiveCfg = Release|Any CPU
+		{514120AD-8F89-476A-8AB3-F582E6CA8697}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -219,6 +233,7 @@ Global
 		{E9BE3307-5F07-4757-BB06-3460813D7B9D} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 		{00EE7B7F-EDA3-49E6-AA38-118C15B58CDB} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 		{4B76692E-EF61-499F-900F-752FFC08D6E9} = {A72570B1-99EF-4BDD-B629-321CD56C9F7F}
+		{514120AD-8F89-476A-8AB3-F582E6CA8697} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {720C6A7F-67F7-4D00-881F-D3CDEA7ABE69}

--- a/src/LibraryManager.Contracts/OperationResult.cs
+++ b/src/LibraryManager.Contracts/OperationResult.cs
@@ -3,12 +3,14 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Web.LibraryManager.Contracts
 {
     /// <summary>
-    /// Represents the outcome of an operation, including an output, a state of completion, and any applicable errors.
+    /// Represents the output of an operation, including cancellation status, up-to-date status, and any applicable errors.
+    /// If the result is null, the operation is considered to be unsuccessful.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public class OperationResult<T>
@@ -54,7 +56,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// <remarks>
         /// The value is <c>True</c> if the <see cref="Errors"/> list is empty and the operation was not cancelled.
         /// </remarks>
-        public bool Success => !Cancelled && Errors.Count == 0;
+        public bool Success => !Cancelled && Errors.Count == 0 && Result is not null;
 
         /// <summary>
         /// <c>True</c> if the library is up to date; otherwise <c>False</c>.
@@ -69,7 +71,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
         public IList<IError> Errors { get; }
 
         /// <summary>
-        /// The output of the operation, if any.
+        /// The output of the operation, if available.  A null result indicates a failed operation.
         /// </summary>
         public T? Result { get; set; }
 
@@ -96,6 +98,17 @@ namespace Microsoft.Web.LibraryManager.Contracts
         public static OperationResult<T> FromError(IError error)
         {
             return new OperationResult<T>(error);
+        }
+
+        /// <summary>Create an OperationResult from a list of errors</summary>
+        public static OperationResult<T> FromErrors(params IError[] errors)
+        {
+            if (errors.Length == 0)
+            {
+                throw new InvalidOperationException("Must specify at least one error");
+            }
+
+            return new OperationResult<T>(errors);
         }
 
         /// <summary>Create an up-to-date outcome for the specified output.</summary>

--- a/src/LibraryManager.Contracts/OperationResult.cs
+++ b/src/LibraryManager.Contracts/OperationResult.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Microsoft.Web.LibraryManager.Contracts
+{
+    /// <summary>
+    /// Represents the outcome of an operation, including an output, a state of completion, and any applicable errors.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class OperationResult<T>
+    {
+        /// <summary>
+        /// Create a new instance of <see cref="OperationResult{T}"/>.
+        /// </summary>
+        public OperationResult(T? result)
+        {
+            Errors = new List<IError>();
+            Result = result;
+        }
+
+        /// <summary>
+        /// Create a new instance of an OperationResult with the specified errors but no output.
+        /// </summary>
+        /// <param name="errors"></param>
+        public OperationResult(params IError[] errors)
+        {
+            Errors = new List<IError>(errors);
+        }
+
+        /// <summary>
+        /// Creates a new OperationResult with a specified output and errors.
+        /// </summary>
+        /// <param name="result"></param>
+        /// <param name="error"></param>
+        public OperationResult(T result, params IError[] error)
+        {
+            var list = new List<IError>(error);
+            Errors = list;
+            Result = result;
+        }
+
+        /// <summary>
+        /// <c>True</c> if the installation was cancelled; otherwise false;
+        /// </summary>
+        public bool Cancelled { get; set; }
+
+        /// <summary>
+        /// <c>True</c> if the install was successful; otherwise <c>False</c>.
+        /// </summary>
+        /// <remarks>
+        /// The value is <c>True</c> if the <see cref="Errors"/> list is empty and the operation was not cancelled.
+        /// </remarks>
+        public bool Success => !Cancelled && Errors.Count == 0;
+
+        /// <summary>
+        /// <c>True</c> if the library is up to date; otherwise <c>False</c>.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        public bool UpToDate { get; set; }
+
+        /// <summary>
+        /// A list of errors that occurred during the operation.
+        /// </summary>
+        public IList<IError> Errors { get; }
+
+        /// <summary>
+        /// The output of the operation, if any.
+        /// </summary>
+        public T? Result { get; set; }
+
+        /// <summary>
+        /// Create a successful result with the specified output.
+        /// </summary>
+        public static OperationResult<T> FromSuccess(T output)
+        {
+            return new OperationResult<T>(output);
+        }
+
+        /// <summary>
+        /// Create a cancelled outcome, with a specified output if applicable.
+        /// </summary>
+        public static OperationResult<T> FromCancelled(T? output)
+        {
+            return new OperationResult<T>(output)
+            {
+                Cancelled = true
+            };
+        }
+
+        /// <summary>Create an OperationResult from an error</summary>
+        public static OperationResult<T> FromError(IError error)
+        {
+            return new OperationResult<T>(error);
+        }
+
+        /// <summary>Create an up-to-date outcome for the specified output.</summary>
+        public static OperationResult<T> FromUpToDate(T output)
+        {
+            return new OperationResult<T>(output)
+            {
+                UpToDate = true,
+            };
+        }
+    }
+}

--- a/src/LibraryManager.Contracts/Properties/AssemblyInfo.cs
+++ b/src/LibraryManager.Contracts/Properties/AssemblyInfo.cs
@@ -2,4 +2,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: NeutralResourcesLanguage("en")]
-[assembly:InternalsVisibleTo("Microsoft.Web.LibraryManager.Test")]
+[assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.Test")]
+[assembly: InternalsVisibleTo("Microsoft.Web.LibraryManager.Contracts.Test")]

--- a/src/LibraryManager/LibraryOperationResult.cs
+++ b/src/LibraryManager/LibraryOperationResult.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Web.LibraryManager.Contracts;
@@ -29,11 +31,7 @@ namespace Microsoft.Web.LibraryManager
         /// <summary>Internal use only</summary>
         public LibraryOperationResult(params IError[] error)
         {
-            Errors = new List<IError>();
-            foreach (IError e in error)
-            {
-                Errors.Add(e);
-            }
+            Errors = new List<IError>(error);
         }
 
         /// <summary>
@@ -47,7 +45,7 @@ namespace Microsoft.Web.LibraryManager
         public bool UpToDate { get; set; }
 
         /// <summary>
-        /// <code>True</code> if the install was successfull; otherwise <code>False</code>.
+        /// <code>True</code> if the install was successful; otherwise <code>False</code>.
         /// </summary>
         /// <remarks>
         /// The value is usually <code>True</code> if the <see cref="Microsoft.Web.LibraryManager.Contracts.ILibraryOperationResult.Errors" /> list is empty.
@@ -66,7 +64,7 @@ namespace Microsoft.Web.LibraryManager
         /// The <see cref="Microsoft.Web.LibraryManager.Contracts.ILibraryInstallationState" /> object passed to the
         /// <see cref="Microsoft.Web.LibraryManager.Contracts.IProvider" /> for installation.
         /// </summary>
-        public ILibraryInstallationState InstallationState { get; set; }
+        public ILibraryInstallationState? InstallationState { get; set; }
 
         /// <summary>Internal use only</summary>
         public static LibraryOperationResult FromSuccess(ILibraryInstallationState installationState)

--- a/test/LibraryManager.Contracts.Test/Microsoft.Web.LibraryManager.Contracts.Test.csproj
+++ b/test/LibraryManager.Contracts.Test/Microsoft.Web.LibraryManager.Contracts.Test.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreTFM);$(NetFxTFM)</TargetFrameworks>
+
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LibraryManager.Contracts\Microsoft.Web.LibraryManager.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/test/LibraryManager.Contracts.Test/OperationResultTests.cs
+++ b/test/LibraryManager.Contracts.Test/OperationResultTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Web.LibraryManager.Contracts;
+
+namespace LibraryManager.Contracts.Test
+{
+    [TestClass]
+    public class OperationResultTests
+    {
+        [TestMethod]
+        public void HasResult_NoErrors_Success()
+        {
+            var sut = new OperationResult<object>(new object());
+
+            Assert.IsTrue(sut.Success);
+            Assert.IsFalse(sut.Cancelled);
+            Assert.IsNotNull(sut.Result);
+            Assert.AreEqual(0, sut.Errors.Count);
+            Assert.IsFalse(sut.UpToDate);
+        }
+
+        [TestMethod]
+        public void HasResult_WithErrors_Failure()
+        {
+            var sut = new OperationResult<object>(new Error("TEST", "Test error"))
+            {
+                Result = new object(),
+            };
+
+            Assert.IsFalse(sut.Success);
+            Assert.IsFalse(sut.Cancelled);
+            Assert.IsNotNull(sut.Result);
+            Assert.AreEqual(1, sut.Errors.Count);
+            Assert.AreEqual("TEST", sut.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public void NoResult_NoErrors_Failure()
+        {
+            // This scenario may represent an unknown failure - no errors were reported,
+            // but the expected result was not returned, so the operation was not successful.
+
+            var sut = new OperationResult<object>((object?)null);
+
+            Assert.IsFalse(sut.Success);
+            Assert.IsFalse(sut.Cancelled);
+            Assert.IsNull(sut.Result);
+            Assert.AreEqual(0, sut.Errors.Count);
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Cancelled_NoErrors_Failure(bool isResultNull)
+        {
+            var sut = new OperationResult<object>(isResultNull ? null : new object())
+            {
+                Cancelled = true,
+            };
+
+            Assert.IsFalse(sut.Success);
+            Assert.IsTrue(sut.Cancelled);
+            Assert.AreEqual(isResultNull, sut.Result is null);
+            Assert.AreEqual(0, sut.Errors.Count);
+        }
+    }
+}


### PR DESCRIPTION
This type is a clone of LibraryOperationResult, but made generic.  LibraryOperationResult is similar to an Option or Maybe type, with specific metadata - whether the operation was cancelled, had errors, or was already up-to-date (all very appropriate for LibMan scenarios).  It's a useful type but limited to ILibraryInstallationState.  Introducing a generic allows the same semantics, but with any result type.  (We could deprecate LibraryOperationResult in the future, but I wanted to keep this PR as minimal as possible.)

There is one semantic difference between OperationResult and LibraryOperationResult: in the new type, a null result is considered unsuccessful, even if there are no errors provided.  That was the implied usage in LOR, but not explicit; the new type makes this explicit.

I also chose not to make an interface abstraction for this type, and to add it to the Contracts project.  The interface seemed like an unnecessary burden for a simple wrapper type.  I'm adding it to Contracts because I plan to use this on a new method in IProvider, so it needs to be at this level of the LibMan architecture.