### PR TITLE
Spacebar on the "Files" node should toggle state

### DIFF
--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
@@ -31,7 +31,15 @@ namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 
                 if (packageItem != null)
                 {
-                    packageItem.IsChecked = !packageItem.IsChecked;
+                    if (packageItem.IsChecked.HasValue)
+                    {
+                        packageItem.IsChecked = !packageItem.IsChecked;
+                    }
+                    else
+                    {
+                        // if it is partially checked, clear all selections, just like clicking with the mouse
+                        packageItem.IsChecked = false;
+                    }
                     e.Handled = true;
                 }
             }


### PR DESCRIPTION
If the "Files" node is partially checked, the user using spacebar will find nothing happens on spacebar because packageItem.IsChecked is null, so !packageItem.IsChecked is also null. Adjust spacebar behavior to match mouseclick behavior
