### PR TITLE
Remove OneLocBuildPat

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -58,7 +58,7 @@ steps:
       prSourceBranchPrefix: 'locfiles'
       isAutoCompletePrSelected: false
       packageSourceAuth: patAuth
-      patVariable: '$(OneLocBuildPat)'
+      dependencyPackageSource: $(LocDependencyPackageSource)
     condition: ne(variables['Build.Reason'], 'PullRequest')
 
 - task: CopyFiles@1


### PR DESCRIPTION
Removes the use of OneLocBuildPat for accessing OneLoc depencencies. Changed the package source for the OneLoc dependencies to a variable that is set on the internal pipeline to a feed with the dependencies as an upstream.