### PR TITLE
Drop netstandard for $(NetCoreTFM)

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;$(NetFxTFM)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreTFM);$(NetFxTFM)</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageTags>library, package, client-side, build</PackageTags>
@@ -16,8 +16,7 @@
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
-    <PackageReference Include="System.Runtime.Loader" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"  />
+    <PackageReference Include="System.Runtime.Loader" Condition="'$(TargetFramework)' == '$(NetCoreTFM)'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
+++ b/src/LibraryManager.Contracts/Microsoft.Web.LibraryManager.Contracts.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;$(NetFxTFM)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreTFM);$(NetFxTFM)</TargetFrameworks>
     <PackageTags>library, package, client-side</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
+++ b/src/LibraryManager/Microsoft.Web.LibraryManager.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;$(NetFxTFM)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreTFM);$(NetFxTFM)</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageTags>library, package, client-side</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,11 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
-    <PackageReference Include="System.ValueTuple" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
+    <PackageReference Include="System.ValueTuple" Condition="'$(TargetFramework)' != '$(NetCoreTFM)'" />
     <ProjectReference Include="..\LibraryManager.Contracts\Microsoft.Web.LibraryManager.Contracts.csproj" />
-    <Reference Include="System.ComponentModel.Composition" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
-    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
-    <Reference Include="System.Web" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
+    <Reference Include="System.ComponentModel.Composition" Condition="'$(TargetFramework)' != '$(NetCoreTFM)'" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' != '$(NetCoreTFM)'" />
+    <Reference Include="System.Web" Condition="'$(TargetFramework)' != '$(NetCoreTFM)'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\Text.Designer.cs">


### PR DESCRIPTION
Netstandard gives compatibility benefits for libraries to be used against netfx or netcore frameworks.  However, for libman, all of our projects that run on netcore already target that framework directly.

This change modifies the existing multitargeted projects to target netcore directly instead of netstandard.  This will allow future changes to use conditional compilation to leverage newer APIs in netcore that do not exist in the netstandard API surface.

The only breaking change here is that the Build project now uses .NET 8 for the build task.  This means consumers of that package who are not using .NET Framework will need to have a compatible version of the SDK; however, this aligns with the prior change in the CLI tool to require .NET 8 as well.