### PR TITLE
Followup: Fully remove references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,6 @@
     <PackageVersion Include="Microsoft.WebTools.Languages.Json" Version="$(WebToolsPackageVersion)" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Json.Editor" Version="$(WebToolsPackageVersion)" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Json.VS" Version="$(WebToolsPackageVersion)" />
-    <PackageVersion Include="MiniMatch" Version="2.0.0" />
     <PackageVersion Include="Moq" Version="4.10.1" />
     <PackageVersion Include="NerdBank.GitVersioning" Version="3.3.37" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -55,7 +55,7 @@
         but before NuGet generates a nuspec. See https://github.com/NuGet/Home/issues/4704.
         -->
     <ItemGroup>
-      <_PackageFiles Include="$(OutputPath)\**\Microsoft.Web.LibraryManager*.dll;$(OutputPath)\**\Minimatch.dll;$(OutputPath)\**\Newtonsoft.Json.dll" Exclude="$(OutputPath)\**\Microsoft.Web.LibraryManager.Build.dll">
+      <_PackageFiles Include="$(OutputPath)\**\Microsoft.Web.LibraryManager*.dll;$(OutputPath)\**\Newtonsoft.Json.dll" Exclude="$(OutputPath)\**\Microsoft.Web.LibraryManager.Build.dll">
         <PackagePath>tools\%(RecursiveDir)</PackagePath>
         <Visible>false</Visible>
         <BuildAction>Content</BuildAction>

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -385,7 +385,6 @@
   <ItemGroup>
     <ThirdPartyAssemblies Include="$(OutputPath)\MessagePack.dll" />
     <ThirdPartyAssemblies Include="$(OutputPath)\MessagePack.Annotations.dll" />
-    <ThirdPartyAssemblies Include="$(OutputPath)\Minimatch.dll" />
     <ThirdPartyAssemblies Include="$(OutputPath)\Nerdbank.Streams.dll" />
     <FilesToSign Include="@(ThirdPartyAssemblies)">
       <Authenticode>3PartySHA2</Authenticode>


### PR DESCRIPTION
https://github.com/aspnet/LibraryManager/pull/747 removed some references to Minimatch.dll but left a few behind.

Remove those latent references.