### PR TITLE
Add setting to force TLS 1.2

### DIFF
--- a/src/LibraryManager/Cache/WebRequestHandler.cs
+++ b/src/LibraryManager/Cache/WebRequestHandler.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Web.LibraryManager.Cache
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var httpMessageHandler = new HttpClientHandler();
 #pragma warning restore CA2000 // Dispose objects before losing scope
-            if (_settings.TryGetValue("forcetls12", out string value) && value.Length > 0)
+            if (_settings.TryGetValue(Constants.ForceTls12, out string value) && value.Length > 0)
             {
                 httpMessageHandler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
             }

--- a/src/LibraryManager/Cache/WebRequestHandler.cs
+++ b/src/LibraryManager/Cache/WebRequestHandler.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Configuration;
 using Microsoft.Web.LibraryManager.Contracts;
+using Microsoft.Web.LibraryManager.Contracts.Configuration;
 using Microsoft.Web.LibraryManager.Helpers;
 
 namespace Microsoft.Web.LibraryManager.Cache
@@ -20,12 +21,14 @@ namespace Microsoft.Web.LibraryManager.Cache
     {
         private readonly ConcurrentDictionary<string, HttpClient> _cachedHttpClients = new ConcurrentDictionary<string, HttpClient>();
 
-        public static IWebRequestHandler Instance { get; } = new WebRequestHandler(ProxySettings.Default);
+        public static IWebRequestHandler Instance { get; } = new WebRequestHandler(ProxySettings.Default, Settings.DefaultSettings);
         private readonly ProxySettings _proxySettings;
+        private readonly ISettings _settings;
 
-        public WebRequestHandler(ProxySettings proxySettings)
+        public WebRequestHandler(ProxySettings proxySettings, ISettings settings)
         {
             _proxySettings = proxySettings;
+            _settings = settings;
         }
 
         public void Dispose()
@@ -55,9 +58,14 @@ namespace Microsoft.Web.LibraryManager.Cache
 
         private HttpClient CreateHttpClient(string url)
         {
+            
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var httpMessageHandler = new HttpClientHandler();
 #pragma warning restore CA2000 // Dispose objects before losing scope
+            if (_settings.TryGetValue("forcetls12", out string value) && value.Length > 0)
+            {
+                httpMessageHandler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
+            }
             httpMessageHandler.Proxy = _proxySettings.GetProxy(new Uri(url));
             var httpClient = new HttpClient(httpMessageHandler);
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd($"LibraryManager/{ThisAssembly.AssemblyFileVersion}");

--- a/src/LibraryManager/Configuration/Constants.cs
+++ b/src/LibraryManager/Configuration/Constants.cs
@@ -17,5 +17,6 @@ namespace Microsoft.Web.LibraryManager.Configuration
         public const string HttpsProxyPassword = "https_proxy.password";
         public const string HttpsProxyBypass = "https_proxy.bypass";
 
+        public const string ForceTls12 = "forcetls12";
     }
 }


### PR DESCRIPTION
Per #711 (and #699 before it), some users need to force TLS 1.2 for libman to work.

This change adds a new user setting, "forcetls12", which will set libman to use TLS1.2 for any HttpClient it creates.

I verified via WireShark that the traffic to services (cdnjs, etc) that libman calls to switched from 1.3 (my system default) to 1.2 when this setting was in place, and returned to 1.3 by unsetting it.  I could also see that other connections from within VS were still using TLS1.3 so we didn't affect other components on accident.

Resolves #711 
