### PR TITLE
Rework support for @latest version

### DIFF
--- a/src/LibraryManager/ManifestConstants.cs
+++ b/src/LibraryManager/ManifestConstants.cs
@@ -48,5 +48,10 @@ namespace Microsoft.Web.LibraryManager
         /// libman.json files element 
         /// </summary>
         public const string Files = "files";
+
+        /// <summary>
+        /// For providers that support versioned libraries, this represents the evergreen latest version
+        /// </summary>
+        public const string LatestVersion = "latest";
     }
 }

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -98,6 +98,18 @@ namespace Microsoft.Web.LibraryManager.Providers
             try
             {
                 ILibraryCatalog catalog = GetCatalog();
+
+                if (string.Equals(desiredState.Version, ManifestConstants.LatestVersion, StringComparison.Ordinal))
+                {
+                    // replace the @latest version with the latest version from the catalog.  This redirect
+                    // ensures that as new versions are released, we will not reuse stale "latest" assets
+                    // from the cache.
+                    string latestVersion = await catalog.GetLatestVersion(libraryId, includePreReleases: false, cancellationToken).ConfigureAwait(false);
+                    LibraryInstallationState newState = LibraryInstallationState.FromInterface(desiredState);
+                    newState.Version = latestVersion;
+                    desiredState = newState;
+                }
+
                 ILibrary library = await catalog.GetLibraryAsync(desiredState.Name, desiredState.Version, cancellationToken).ConfigureAwait(false);
 
                 if (library == null)

--- a/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
         public const string CacheFileName = "cache.json";
         public const string LibraryFileListUrlFormat = "https://unpkg.com/{0}@{1}/?meta"; // e.g. https://unpkg.com/jquery@3.3.1/?meta
         public const string LatestLibraryVersonUrl = "https://unpkg.com/{0}/package.json"; // e.g. https://unpkg.com/jquery/package.json
-        public const string LatestVersionTag = "latest";
 
         private readonly INpmPackageInfoFactory _packageInfoFactory;
         private readonly INpmPackageSearch _packageSearch;
@@ -58,7 +57,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
             try
             {
                 string latestLibraryVersionUrl = string.Format(LatestLibraryVersonUrl, libraryName);
-                string latestCacheFile = Path.Combine(_cacheFolder, libraryName, $"{LatestVersionTag}.json");
+                string latestCacheFile = Path.Combine(_cacheFolder, libraryName, $"{ManifestConstants.LatestVersion}.json");
 
                 string latestJson = await _cacheService.GetContentsFromUriWithCacheFallbackAsync(latestLibraryVersionUrl,
                                                                                                  latestCacheFile,
@@ -88,7 +87,7 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
             }
 
             string libraryId = _libraryNamingScheme.GetLibraryId(libraryName, version);
-            if (string.Equals(version, LatestVersionTag, StringComparison.Ordinal))
+            if (string.Equals(version, ManifestConstants.LatestVersion, StringComparison.Ordinal))
             {
                 string latestVersion = await GetLatestVersion(libraryId, includePreReleases: false, cancellationToken).ConfigureAwait(false);
                 libraryId = _libraryNamingScheme.GetLibraryId(libraryName, latestVersion);
@@ -263,8 +262,8 @@ namespace Microsoft.Web.LibraryManager.Providers.Unpkg
                     // support @latest version
                     completions.Add(new CompletionItem
                     {
-                        DisplayText = LatestVersionTag,
-                        InsertionText = _libraryNamingScheme.GetLibraryId(name, LatestVersionTag),
+                        DisplayText = ManifestConstants.LatestVersion,
+                        InsertionText = _libraryNamingScheme.GetLibraryId(name, ManifestConstants.LatestVersion),
                     });
 
                     completionSet.CompletionType = CompletionSortOrder.Version;

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
         public const string LatestLibraryVersionUrl = "https://data.jsdelivr.com/v1/package/npm/{0}";
         public const string LibraryFileListUrlFormatGH = "https://data.jsdelivr.com/v1/package/gh/{0}/flat";
         public const string LatestLibraryVersionUrlGH = "https://data.jsdelivr.com/v1/package/gh/{0}";
-        public const string LatestVersionTag = "latest";
 
         private readonly INpmPackageInfoFactory _packageInfoFactory;
         private readonly INpmPackageSearch _packageSearch;
@@ -61,7 +60,7 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
                 bool isGitHub = IsGitHub(libraryId);
                 string latestLibraryVersionUrl = string.Format(isGitHub ? LatestLibraryVersionUrlGH : LatestLibraryVersionUrl, name);
                 string cacheFileType = isGitHub ? "github" : "npm";
-                string latestLibraryVersionCacheFile = Path.Combine(_cacheFolder, name, $"{cacheFileType}-{LatestVersionTag}.json");
+                string latestLibraryVersionCacheFile = Path.Combine(_cacheFolder, name, $"{cacheFileType}-{ManifestConstants.LatestVersion}.json");
 
                 string latestVersionContent = await _cacheService.GetContentsFromUriWithCacheFallbackAsync(latestLibraryVersionUrl,
                                                                                                            latestLibraryVersionCacheFile,
@@ -116,7 +115,7 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
             }
 
             string libraryId = _libraryNamingScheme.GetLibraryId(name, version);
-            if (string.Equals(version, LatestVersionTag, StringComparison.Ordinal))
+            if (string.Equals(version, ManifestConstants.LatestVersion, StringComparison.Ordinal))
             {
                 string latestVersion = await GetLatestVersion(libraryId, includePreReleases: false, cancellationToken).ConfigureAwait(false);
                 libraryId = _libraryNamingScheme.GetLibraryId(name, latestVersion);
@@ -288,8 +287,8 @@ namespace Microsoft.Web.LibraryManager.Providers.jsDelivr
                     // support @latest version
                     completions.Add(new CompletionItem
                     {
-                        DisplayText = LatestVersionTag,
-                        InsertionText = _libraryNamingScheme.GetLibraryId(name, LatestVersionTag),
+                        DisplayText = ManifestConstants.LatestVersion,
+                        InsertionText = _libraryNamingScheme.GetLibraryId(name, ManifestConstants.LatestVersion),
                     });
 
                     completionSet.CompletionType = CompletionSortOrder.Version;

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -135,6 +135,19 @@ namespace Microsoft.Web.LibraryManager.Test.Providers.Cdnjs
         }
 
         [TestMethod]
+        public async Task GetLibraryAsync_LatestVersion_Success()
+        {
+            CdnjsCatalog sut = SetupCatalog();
+
+            ILibrary library = await sut.GetLibraryAsync("sampleLibrary", "latest", CancellationToken.None);
+
+            Assert.IsNotNull(library);
+            Assert.AreEqual("sampleLibrary", library.Name);
+            Assert.AreEqual("3.1.4", library.Version);
+            Assert.IsNotNull(library.Files);
+        }
+
+        [TestMethod]
         public async Task GetLibraryAsync_InvalidLibraryId()
         {
             CdnjsCatalog sut = SetupCatalog();


### PR DESCRIPTION
Currently, unpkg and jsdelivr support using 'latest' as a version.  When files are requested by libman, they redirect (HTTP302) to the URL for the current latest files.  We put those files into the cache like any other version (in a folder name 'latest') and all is well.

However, when a new version is released, libman continues to use the now-stale downloaded assets from the cache.  There isn't a signal to realize when to purge the latest version from the cache.

This change instead simply turns 'latest' into the latest version we determine from the provider.  There is a small risk that we are out of sync with the CDN: for example, since we get the version data from NPM, it might not match the version that e.g. jsdelivr redirects to.  But this should be extremely rare.

Doing it this way also allows cdnjs to support 'latest'.  I didn't add it to the completion items, but I did verify that it works (CLI install, restore, and the file list in VS all support foo@latest for cdnjs now too).

Resolves #748 
