### PR TITLE
Update package references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild" PrivateAssets="All" />
-    <PackageReference Include="NerdBank.GitVersioning" PrivateAssets="All" />
+    <PackageReference Include="NerdBank.GitVersioning" PrivateAssets="All" Condition="!Exists('packages.config')" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="16.9.0" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="16.9.0" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.3" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.3" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.7.188" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.66" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.7.188" />
-    <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.65" />
+    <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.66" />
     <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.7.188" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0" Version="17.5.33428.388" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.7.37355" />
@@ -28,10 +28,10 @@
     <PackageVersion Include="Microsoft.WebTools.Languages.Json" Version="$(WebToolsPackageVersion)" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Json.Editor" Version="$(WebToolsPackageVersion)" />
     <PackageVersion Include="Microsoft.WebTools.Languages.Json.VS" Version="$(WebToolsPackageVersion)" />
-    <PackageVersion Include="Moq" Version="4.10.1" />
-    <PackageVersion Include="NerdBank.GitVersioning" Version="3.3.37" />
+    <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="NerdBank.GitVersioning" Version="3.6.133" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Nuget.VisualStudio" Version="6.0.0" />
+    <PackageVersion Include="Nuget.VisualStudio" Version="17.7.1" />
 
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
@@ -45,7 +45,7 @@
 
     <!-- Test references -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.7.34031.279" />
+    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.10.34923.60" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.0.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.0.3" />
 

--- a/LibraryManager.sln
+++ b/LibraryManager.sln
@@ -30,12 +30,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{E67307E3
 		build\PackageVersions.targets = build\PackageVersions.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.LibraryManager.Vsix", "src\LibraryManager.Vsix\Microsoft.Web.LibraryManager.Vsix.csproj", "{EDA2179C-D952-449F-9A3D-8B3A152D6E5A}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Web.LibraryManager", "src\LibraryManager\Microsoft.Web.LibraryManager.csproj", "{707356DD-96B9-49F6-AF2A-9D23B857A1E2}"
 	ProjectSection(ProjectDependencies) = postProject
 		{FF466454-426B-4AD7-8B00-D50011BE716F} = {FF466454-426B-4AD7-8B00-D50011BE716F}
 	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.LibraryManager.Vsix", "src\LibraryManager.Vsix\Microsoft.Web.LibraryManager.Vsix.csproj", "{EDA2179C-D952-449F-9A3D-8B3A152D6E5A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Web.LibraryManager.Test", "test\LibraryManager.Test\Microsoft.Web.LibraryManager.Test.csproj", "{08C91CC3-4057-4D76-8B9A-B6A0557B64EB}"
 EndProject

--- a/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
+++ b/src/LibraryManager.Vsix/Microsoft.Web.LibraryManager.Vsix.csproj
@@ -382,14 +382,6 @@
   <ItemGroup>
     <None Include="Commands\CommandTable\LocalizationFiles\VSCommandTable.*.xlf" />
   </ItemGroup>
-  <ItemGroup>
-    <ThirdPartyAssemblies Include="$(OutputPath)\MessagePack.dll" />
-    <ThirdPartyAssemblies Include="$(OutputPath)\MessagePack.Annotations.dll" />
-    <ThirdPartyAssemblies Include="$(OutputPath)\Nerdbank.Streams.dll" />
-    <FilesToSign Include="@(ThirdPartyAssemblies)">
-      <Authenticode>3PartySHA2</Authenticode>
-    </FilesToSign>
-  </ItemGroup>
   <Target Name="PreCreateVsixContainer" BeforeTargets="CreateVsixContainer">
     <ItemGroup>
       <VSIXSourceItem Include="$(OutputPath)%(DstLocales.Identity)\Microsoft.Web.LibraryManager.resources.dll" Condition="Exists('$(OutputPath)\%(DstLocales.Identity)\Microsoft.Web.LibraryManager.resources.dll')">
@@ -411,7 +403,7 @@
     </ItemGroup>
     <ItemGroup>
       <ReferencePath Condition="&#xD;&#xA;              '%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'&#xD;&#xA;              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'&#xD;&#xA;              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'&#xD;&#xA;              or '%(FileName)' == 'Nuget.VisualStudio'&#xD;&#xA;              ">
-        <EmbedInteropTypes>true</EmbedInteropTypes>
+        <EmbedInteropTypes>false</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>
   </Target>
@@ -423,7 +415,6 @@
       </_VsixSourceItemsFromNuGet>
       <!-- Replace the existing VSIX source items as they are picked up before any signing can occur on them -->
       <VSIXSourceItem Remove="@(_VsixSourceItemsFromNuGet)" />
-      <VSIXSourceItem Include="$(OutputPath)\%(_VsixSourceItemsFromNuGet.FileName)%(_VsixSourceItemsFromNuGet.Extension)" Condition="Exists('$(OutputPath)\%(_VsixSourceItemsFromNuGet.FileName)%(_VsixSourceItemsFromNuGet.Extension)')" />
     </ItemGroup>
   </Target>
 </Project>

--- a/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
+++ b/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Test.Apex.Editor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet;
 
 namespace Microsoft.Web.LibraryManager.IntegrationTest
 {

--- a/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
+++ b/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Test.Apex.Editor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NuGet;
 
 namespace Microsoft.Web.LibraryManager.IntegrationTest
 {

--- a/test/LibraryManager.Mocks/Microsoft.Web.LibraryManager.Mocks.csproj
+++ b/test/LibraryManager.Mocks/Microsoft.Web.LibraryManager.Mocks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;$(NetFxTFM)</TargetFrameworks>
+        <TargetFrameworks>$(NetCoreTFM);$(NetFxTFM)</TargetFrameworks>
         <PackageTags>mocks, unit test, library, client-side, package</PackageTags>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Update a number of packages to be more modern
Stop shipping binaries to run in VisualStudio that VisualStudio already ships (With binding redirects/etc.)
Update the SLN file so that the Vsix project is the default startup project.
