### PR TITLE
Implement support for "fileMappings"

### DIFF
--- a/src/LibraryManager.Contracts/FileMapping.cs
+++ b/src/LibraryManager.Contracts/FileMapping.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Microsoft.Web.LibraryManager.Contracts
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class FileMapping
+    {
+        /// <summary>
+        /// Root path within the library content for this file mapping entry.
+        /// </summary>
+        public string? Root { get; set; }
+
+        /// <summary>
+        /// Destination folder within the project.
+        /// </summary>
+        public string? Destination { get; set; }
+
+        /// <summary>
+        /// The file patterns to match for this mapping, relative to <see cref="Root"/>.  Accepts glob patterns.
+        /// </summary>
+        public IReadOnlyList<string>? Files { get; set; }
+    }
+}

--- a/src/LibraryManager.Contracts/ILibraryInstallationState.cs
+++ b/src/LibraryManager.Contracts/ILibraryInstallationState.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Web.LibraryManager.Contracts
         IReadOnlyList<string> Files { get; }
 
         /// <summary>
+        /// List of mappings of a portion of library assets to a unique destination.
+        /// </summary>
+        IReadOnlyList<FileMapping> FileMappings { get; }
+
+        /// <summary>
         /// The path relative to the working directory to copy the files to.
         /// </summary>
         string DestinationPath { get; }

--- a/src/LibraryManager/Json/FileMapping.cs
+++ b/src/LibraryManager/Json/FileMapping.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+#nullable enable
+
+namespace Microsoft.Web.LibraryManager.Json
+{
+    internal class FileMapping
+    {
+        [JsonProperty(ManifestConstants.Root)]
+        public string? Root { get; set; }
+
+        [JsonProperty(ManifestConstants.Destination)]
+        public string? Destination { get; set; }
+
+        [JsonProperty(ManifestConstants.Files)]
+        public IReadOnlyList<string>? Files { get; set; }
+    }
+}

--- a/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
+++ b/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace Microsoft.Web.LibraryManager.Json
@@ -21,5 +19,8 @@ namespace Microsoft.Web.LibraryManager.Json
 
         [JsonProperty(ManifestConstants.Files)]
         public IReadOnlyList<string> Files { get; set; }
+
+        [JsonProperty(ManifestConstants.FileMappings)]
+        public IReadOnlyList<FileMapping> FileMappings { get; set; }
     }
 }

--- a/src/LibraryManager/Json/LibraryStateToFileConverter.cs
+++ b/src/LibraryManager/Json/LibraryStateToFileConverter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Web.LibraryManager.Json
                 ProviderId = provider,
                 DestinationPath = destination,
                 Files = stateOnDisk.Files,
-                FileMappings = stateOnDisk.FileMappings.Select(f => new Contracts.FileMapping { Destination = f.Destination, Root = f.Root, Files = f.Files }).ToList(),
+                FileMappings = stateOnDisk.FileMappings?.Select(f => new Contracts.FileMapping { Destination = f.Destination, Root = f.Root, Files = f.Files }).ToList(),
             };
 
             (state.Name, state.Version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(stateOnDisk.LibraryId, provider);

--- a/src/LibraryManager/LibraryInstallationState.cs
+++ b/src/LibraryManager/LibraryInstallationState.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Web.LibraryManager
         /// </summary>
         public string Version { get; set; }
 
+        /// <summary>
+        /// Mappings for multiple different files within the library to different destinations.
+        /// </summary>
+        public IReadOnlyList<FileMapping> FileMappings { get; set; }
+
         /// <summary>Internal use only</summary>
         public static LibraryInstallationState FromInterface(ILibraryInstallationState state,
                                                              string defaultProviderId = null,

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Web.LibraryManager
         /// <summary>
         /// Supported versions of Library Manager
         /// </summary>
-        public static readonly Version[] SupportedVersions = { new Version("1.0") };
+        public static readonly Version[] SupportedVersions = { new Version("1.0"), new Version("3.0") };
         private IHostInteraction _hostInteraction;
         private readonly List<ILibraryInstallationState> _libraries;
         private IDependencies _dependencies;

--- a/src/LibraryManager/ManifestConstants.cs
+++ b/src/LibraryManager/ManifestConstants.cs
@@ -13,44 +13,54 @@ namespace Microsoft.Web.LibraryManager
     public static class ManifestConstants
     {
         /// <summary>
-        /// libman.json libraries element 
+        /// libman.json libraries element
         /// </summary>
         public const string Version = "version";
 
         /// <summary>
-        /// libman.json libraries element 
+        /// libman.json libraries element
         /// </summary>
         public const string Libraries = "libraries";
 
         /// <summary>
-        /// libman.json library element 
+        /// libman.json library element
         /// </summary>
         public const string Library = "library";
 
         /// <summary>
-        /// libman.json destination element 
+        /// libman.json destination element
         /// </summary>
         public const string Destination = "destination";
 
         /// <summary>
-        /// libman.json defaultDestination element 
+        /// libman.json defaultDestination element
         /// </summary>
         public const string DefaultDestination = "defaultDestination";
 
         /// <summary>
-        /// libman.json provider element 
+        /// libman.json provider element
         /// </summary>
         public const string Provider = "provider";
 
         /// <summary>
-        /// libman.json defaultProvider element 
+        /// libman.json defaultProvider element
         /// </summary>
         public const string DefaultProvider = "defaultProvider";
 
         /// <summary>
-        /// libman.json files element 
+        /// libman.json files element
         /// </summary>
         public const string Files = "files";
+
+        /// <summary>
+        /// libman.json fileMappings element
+        /// </summary>
+        public const string FileMappings = "fileMappings";
+
+        /// <summary>
+        /// libman.json root element
+        /// </summary>
+        public const string Root = "root";
 
         /// <summary>
         /// For providers that support versioned libraries, this represents the evergreen latest version

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -247,48 +247,92 @@ namespace Microsoft.Web.LibraryManager.Providers
 
         private OperationResult<LibraryInstallationGoalState> GenerateGoalState(ILibraryInstallationState desiredState, ILibrary library)
         {
+            var mappings = new List<FileMapping>(desiredState.FileMappings ?? []);
             List<IError> errors = null;
-
-            if (string.IsNullOrEmpty(desiredState.DestinationPath))
+            if (desiredState.Files is { Count: > 0 })
             {
-                return OperationResult<LibraryInstallationGoalState>.FromError(PredefinedErrors.DestinationNotSpecified(desiredState.Name));
+                mappings.Add(new FileMapping { Destination = desiredState.DestinationPath, Files = desiredState.Files });
             }
-
-            IEnumerable<string> outFiles;
-            if (desiredState.Files == null || desiredState.Files.Count == 0)
+            else if (desiredState.FileMappings is null or { Count: 0 })
             {
-                outFiles = library.Files.Keys;
-            }
-            else
-            {
-                outFiles = FileGlobbingUtility.ExpandFileGlobs(desiredState.Files, library.Files.Keys);
+                // no files specified and no file mappings => include all files
+                mappings.Add(new FileMapping { Destination = desiredState.DestinationPath });
             }
 
             Dictionary<string, string> installFiles = new();
-            if (library.GetInvalidFiles(outFiles.ToList()) is IReadOnlyList<string> invalidFiles
-                && invalidFiles.Count > 0)
-            {
-                errors ??= [];
-                errors.Add(PredefinedErrors.InvalidFilesInLibrary(desiredState.Name, invalidFiles, library.Files.Keys));
-            }
 
-            foreach (string outFile in outFiles)
+            foreach (FileMapping fileMapping in mappings)
             {
-                // strip the source prefix
-                string destinationFile = Path.Combine(HostInteraction.WorkingDirectory, desiredState.DestinationPath, outFile);
-                if (!FileHelpers.IsUnderRootDirectory(destinationFile, HostInteraction.WorkingDirectory))
+                // if Root is not specified, assume it's the root of the library
+                string mappingRoot = fileMapping.Root ?? string.Empty;
+                // if Destination is not specified, inherit from the library entry
+                string destination = fileMapping.Destination ?? desiredState.DestinationPath;
+
+                if (destination is null)
                 {
                     errors ??= [];
-                    errors.Add(PredefinedErrors.PathOutsideWorkingDirectory());
+                    string libraryId = LibraryNamingScheme.GetLibraryId(desiredState.Name, desiredState.Version);
+                    errors.Add(PredefinedErrors.DestinationNotSpecified(libraryId));
+                    continue;
                 }
-                destinationFile = FileHelpers.NormalizePath(destinationFile);
 
-                // don't forget to include the cache folder in the path
-                string sourceFile = GetCachedFileLocalPath(desiredState, outFile);
-                sourceFile = FileHelpers.NormalizePath(sourceFile);
+                IReadOnlyList<string> fileFilters;
+                if (fileMapping.Files is { Count: > 0 })
+                {
+                    fileFilters = fileMapping.Files;
+                }
+                else
+                {
+                    fileFilters = ["**"];
+                }
 
-                // map destination back to the library-relative file it originated from
-                installFiles.Add(destinationFile, sourceFile);
+                if (mappingRoot.Length > 0)
+                {
+                    // prefix mappingRoot to each fileFilter item
+                    fileFilters = fileFilters.Select(f => $"{mappingRoot}/{f}").ToList();
+                }
+
+                List<string> outFiles = FileGlobbingUtility.ExpandFileGlobs(fileFilters, library.Files.Keys).ToList();
+
+                if (library.GetInvalidFiles(outFiles) is IReadOnlyList<string> invalidFiles
+    && invalidFiles.Count > 0)
+                {
+                    errors ??= [];
+                    errors.Add(PredefinedErrors.InvalidFilesInLibrary(desiredState.Name, invalidFiles, library.Files.Keys));
+                }
+
+                foreach (string outFile in outFiles)
+                {
+                    // strip the source prefix
+                    string relativeOutFile = mappingRoot.Length > 0 ? outFile.Substring(mappingRoot.Length + 1) : outFile;
+                    string destinationFile = Path.Combine(HostInteraction.WorkingDirectory, destination, relativeOutFile);
+                    destinationFile = FileHelpers.NormalizePath(destinationFile);
+
+                    if (!FileHelpers.IsUnderRootDirectory(destinationFile, HostInteraction.WorkingDirectory))
+                    {
+                        errors ??= [];
+                        errors.Add(PredefinedErrors.PathOutsideWorkingDirectory());
+                        continue;
+                    }
+
+                    // include the cache folder in the path
+                    string sourceFile = GetCachedFileLocalPath(desiredState, outFile);
+                    sourceFile = FileHelpers.NormalizePath(sourceFile);
+
+                    // map destination back to the library-relative file it originated from
+                    if (installFiles.ContainsKey(destinationFile))
+                    {
+                        // this file is already being installed from another mapping
+                        errors ??= [];
+                        string libraryId = LibraryNamingScheme.GetLibraryId(desiredState.Name, desiredState.Version);
+                        errors.Add(PredefinedErrors.LibraryCannotBeInstalledDueToConflicts(destinationFile, [libraryId]));
+                        continue;
+                    }
+                    else
+                    {
+                        installFiles.Add(destinationFile, sourceFile);
+                    }
+                }
             }
 
             if (errors is not null)

--- a/src/schema/libman.json
+++ b/src/schema/libman.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
     {
       "anyOf": [
@@ -20,11 +20,19 @@
           "$ref": "#/definitions/defaultDestination"
         }
       ]
+    },
+    {
+      "if": {
+        "$ref": "#/definitions/fileMapping"
+      },
+      "then": {
+        "$ref": "#/definitions/manifestVersion3"
+      }
     }
   ],
   "definitions": {
     "libraryEntry": {
-      "required": ["library"],
+      "required": [ "library" ],
       "properties": {
         "files": {
           "description": "The file names of the individual files to copy to the project.",
@@ -49,6 +57,34 @@
           "description": "The unique identifier of the provider",
           "type": "string",
           "minLength": 1
+        },
+        "fileMappings": {
+          "description": "A list of file mappings.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "root": {
+                "description": "The mapping root within the library contents. If omitted, defaults to the library root.",
+                "type": "string",
+                "minLength": 1
+              },
+              "destination": {
+                "description": "The destination for files included in this mapping. If omitted, defaults to a destination set for the library.",
+                "type": "string",
+                "minLength": 1
+              },
+              "files": {
+                "description": "The file names of the individual files to copy to the project, relative to the specified root. If omitted, defaults to all files.",
+                "type": "array",
+                "default": null,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -56,12 +92,12 @@
       "properties": {
         "libraries": {
           "items": {
-            "required": ["provider"]
+            "required": [ "provider" ]
           }
         }
       },
       "not": {
-        "required": ["defaultProvider"]
+        "required": [ "defaultProvider" ]
       }
     },
     "defaultProvider": {
@@ -77,12 +113,12 @@
       "properties": {
         "libraries": {
           "items": {
-            "required": ["destination"]
+            "required": [ "destination" ]
           }
         }
       },
       "not": {
-        "required": ["defaultDestination"]
+        "required": [ "defaultDestination" ]
       }
     },
     "defaultDestination": {
@@ -93,6 +129,23 @@
           "minLength": 1
         }
       }
+    },
+    "fileMapping": {
+      "properties": {
+        "libraries": {
+          "contains": {
+            "required": [ "fileMappings" ]
+          }
+        }
+      }
+    },
+    "manifestVersion3": {
+      "properties": {
+        "version": {
+          "const": "3.0"
+        }
+      },
+      "required": [ "version" ]
     }
   },
   "id": "https://json.schemastore.org/libman.json",
@@ -105,12 +158,12 @@
       }
     },
     "version": {
-      "description": "The syntax version of this config file. Can only be 1.0",
-      "enum": ["1.0"],
-      "default": "1.0"
+      "description": "The syntax version of this config file.",
+      "enum": [ "1.0", "3.0" ],
+      "default": "3.0"
     }
   },
-  "required": ["libraries"],
+  "required": [ "libraries", "version" ],
   "title": "JSON schema for client-side library config files",
   "type": "object"
 }

--- a/test/LibraryManager.Mocks/LibraryInstallationState.cs
+++ b/test/LibraryManager.Mocks/LibraryInstallationState.cs
@@ -12,41 +12,28 @@ namespace Microsoft.Web.LibraryManager.Mocks
     /// <seealso cref="LibraryManager.Contracts.ILibraryInstallationState" />
     public class LibraryInstallationState : ILibraryInstallationState
     {
-        /// <summary>
-        /// The unique identifier of the provider.
-        /// </summary>
+        /// <inheritdoc />
         public virtual string ProviderId { get; set; }
 
-        /// <summary>
-        /// The list of file names to install
-        /// </summary>
+        /// <inheritdoc />
         public virtual IReadOnlyList<string> Files { get; set; }
 
-        /// <summary>
-        /// The path relative to the working directory to copy the files to.
-        /// </summary>
+        /// <inheritdoc />
         public virtual string DestinationPath { get; set; }
 
-        /// <summary>
-        /// Name of the library.
-        /// </summary>
+        /// <inheritdoc />
         public string Name { get; set; }
 
-        /// <summary>
-        /// Version of the library.
-        /// </summary>
+        /// <inheritdoc />
         public string Version { get; set; }
 
-        /// <summary>
-        /// Indicates whether the library is using the default destination
-        /// </summary>
+        /// <inheritdoc />
         public bool IsUsingDefaultDestination { get; set; }
 
-        /// <summary>
-        /// Indicates whether the library is using the default provider.
-        /// </summary>
+        /// <inheritdoc />
         public bool IsUsingDefaultProvider { get; set; }
 
+        /// <inheritdoc />
         public IReadOnlyList<FileMapping> FileMappings => throw new System.NotImplementedException();
     }
 }

--- a/test/LibraryManager.Mocks/LibraryInstallationState.cs
+++ b/test/LibraryManager.Mocks/LibraryInstallationState.cs
@@ -46,5 +46,7 @@ namespace Microsoft.Web.LibraryManager.Mocks
         /// Indicates whether the library is using the default provider.
         /// </summary>
         public bool IsUsingDefaultProvider { get; set; }
+
+        public IReadOnlyList<FileMapping> FileMappings => throw new System.NotImplementedException();
     }
 }

--- a/test/libman.Test/BaseCommandTests.cs
+++ b/test/libman.Test/BaseCommandTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             command.DefaultProvider = "cdnjs";
             command.Execute();
 
-            Assert.AreEqual("1.0", command.Manifest.Version);
+            Assert.AreEqual("3.0", command.Manifest.Version);
 
         }
 

--- a/test/libman.Test/LibmanInitTests.cs
+++ b/test/libman.Test/LibmanInitTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             string contents = File.ReadAllText(libmanFilePath);
 
             string expectedContents = @"{
-  ""version"": ""1.0"",
+  ""version"": ""3.0"",
   ""defaultProvider"": ""cdnjs"",
   ""defaultDestination"": ""wwwroot"",
   ""libraries"": []
@@ -69,7 +69,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             string contents = File.ReadAllText(libmanFilePath);
 
             string expectedContents = @"{
-  ""version"": ""1.0"",
+  ""version"": ""3.0"",
   ""defaultProvider"": ""cdnjs"",
   ""libraries"": []
 }";
@@ -95,7 +95,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
             string contents = File.ReadAllText(libmanFilePath);
 
             string expectedContents = @"{
-  ""version"": ""1.0"",
+  ""version"": ""3.0"",
   ""defaultProvider"": ""unpkg"",
   ""libraries"": []
 }";

--- a/test/libman.Test/LibmanInstallTest.cs
+++ b/test/libman.Test/LibmanInstallTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             string text = File.ReadAllText(Path.Combine(WorkingDir, "libman.json"));
             string expectedText = @"{
-  ""version"": ""1.0"",
+  ""version"": ""3.0"",
   ""defaultProvider"": ""cdnjs"",
   ""libraries"": [
     {
@@ -64,7 +64,7 @@ namespace Microsoft.Web.LibraryManager.Tools.Test
 
             string text = File.ReadAllText(Path.Combine(WorkingDir, "libman.json"));
             string expectedText = @"{
-  ""version"": ""1.0"",
+  ""version"": ""3.0"",
   ""defaultProvider"": ""cdnjs"",
   ""libraries"": [
     {


### PR DESCRIPTION
Summary of the changes:
 - Adds support for parsing fileMappings and calculating the goal state from them.
 - Adds support for fileMappings to the schema.  Includes a schema validation error if the schema uses fileMappings but doesn't have a sufficiently high version set.
 - Enables manifest version "3.0" and sets that as the default for newly created manifests.

This implements #738.  There will be an additional PR to make the JSON completion in the editor work for fileMappings.