### PR TITLE
Fix bug in FileHelpers.IsUnderRootDirectory for separator

### DIFF
--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -375,7 +375,9 @@ namespace Microsoft.Web.LibraryManager.Contracts
             string normalizedFilePath = NormalizePath(filePath);
             string normalizedRootDirectory = NormalizePath(rootDirectory);
 
-            return normalizedFilePath.Length > normalizedRootDirectory.Length
+            return normalizedFilePath.Length > normalizedRootDirectory.Length + 1
+                // normalization has edge cases where either / or \ may be retained
+                && normalizedFilePath[normalizedRootDirectory.Length] is '/' or '\\'
                 && normalizedFilePath.StartsWith(normalizedRootDirectory, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/test/LibraryManager.Test/FileHelpersTest.cs
+++ b/test/LibraryManager.Test/FileHelpersTest.cs
@@ -14,9 +14,11 @@ namespace Microsoft.Web.LibraryManager.Test
         [DataRow("C:\\dir\\file1.js", "C:\\dir", true)]
         [DataRow("C:\\dir\\", "C:\\dir\\", false)]
         [DataRow("/abc/def/ghi", "\\abc\\def", true)]
-        public void UnderRootDirectory(string path1, string path2, bool expectedResult)
+        [DataRow("abc/def", "abc", true)]
+        [DataRow("abcdef", "abc", false)]
+        public void UnderRootDirectory(string file, string directory, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, FileHelpers.IsUnderRootDirectory(path1, path2));
+            Assert.AreEqual(expectedResult, FileHelpers.IsUnderRootDirectory(file, directory));
         }
     }
 }


### PR DESCRIPTION
The logic had a flaw that it didn't verify the directory separator after the directory portion.  NormalizePath strips trailing slashes, so there will never be one.  However, for IsUnderRootDirectory, there must be a separator in the path.