### PR TITLE
Convert to MIT license

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -109,3 +109,6 @@ csharp_new_line_before_catch                          = true
 csharp_new_line_before_finally                        = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types     = true
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,12 +1,23 @@
-Copyright (c) .NET Foundation. All rights reserved.
+The MIT License (MIT)
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-these files except in compliance with the License. You may obtain a copy of the
-License at
+Copyright (c) .NET Foundation and Contributors
 
-http://www.apache.org/licenses/LICENSE-2.0
+All rights reserved.
 
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/LibraryManager.Build/Contracts/Dependencies.cs
+++ b/src/LibraryManager.Build/Contracts/Dependencies.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Build/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Build/Contracts/HostInteraction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Build/Contracts/Logger.cs
+++ b/src/LibraryManager.Build/Contracts/Logger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using LogLevel = Microsoft.Web.LibraryManager.Contracts.LogLevel;

--- a/src/LibraryManager.Build/Properties/AssemblyInfo.cs
+++ b/src/LibraryManager.Build/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Resources;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: NeutralResourcesLanguage("en")]

--- a/src/LibraryManager.Build/RestoreTask.cs
+++ b/src/LibraryManager.Build/RestoreTask.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Build.Framework;

--- a/src/LibraryManager.Contracts/Caching/ICacheService.cs
+++ b/src/LibraryManager.Contracts/Caching/ICacheService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/LibraryManager.Contracts/CancellationHelpers.cs
+++ b/src/LibraryManager.Contracts/CancellationHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/LibraryManager.Contracts/CompletionSet.cs
+++ b/src/LibraryManager.Contracts/CompletionSet.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Contracts/Configuration/ISettings.cs
+++ b/src/LibraryManager.Contracts/Configuration/ISettings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Contracts.Configuration
 {

--- a/src/LibraryManager.Contracts/Error.cs
+++ b/src/LibraryManager.Contracts/Error.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Contracts
 {

--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Contracts/GlobalSuppressions.cs
+++ b/src/LibraryManager.Contracts/GlobalSuppressions.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 

--- a/src/LibraryManager.Contracts/IDependencies.cs
+++ b/src/LibraryManager.Contracts/IDependencies.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/src/LibraryManager.Contracts/IError.cs
+++ b/src/LibraryManager.Contracts/IError.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Contracts
 {

--- a/src/LibraryManager.Contracts/IHostInteraction.cs
+++ b/src/LibraryManager.Contracts/IHostInteraction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Contracts/ILibrary.cs
+++ b/src/LibraryManager.Contracts/ILibrary.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/src/LibraryManager.Contracts/ILibraryCatalog.cs
+++ b/src/LibraryManager.Contracts/ILibraryCatalog.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/LibraryManager.Contracts/ILibraryGroup.cs
+++ b/src/LibraryManager.Contracts/ILibraryGroup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/LibraryManager.Contracts/ILibraryInstallationState.cs
+++ b/src/LibraryManager.Contracts/ILibraryInstallationState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/src/LibraryManager.Contracts/ILibraryOperationResult.cs
+++ b/src/LibraryManager.Contracts/ILibraryOperationResult.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/src/LibraryManager.Contracts/ILogger.cs
+++ b/src/LibraryManager.Contracts/ILogger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 

--- a/src/LibraryManager.Contracts/IProvider.cs
+++ b/src/LibraryManager.Contracts/IProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/LibraryManager.Contracts/IProviderFactory.cs
+++ b/src/LibraryManager.Contracts/IProviderFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Contracts
 {

--- a/src/LibraryManager.Contracts/IWebRequestHandler.cs
+++ b/src/LibraryManager.Contracts/IWebRequestHandler.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using System.Threading;

--- a/src/LibraryManager.Contracts/InvalidLibraryException.cs
+++ b/src/LibraryManager.Contracts/InvalidLibraryException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Contracts/LibraryInstallationGoalState.cs
+++ b/src/LibraryManager.Contracts/LibraryInstallationGoalState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/LibraryManager.Contracts/OperationResult.cs
+++ b/src/LibraryManager.Contracts/OperationResult.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
 

--- a/src/LibraryManager.Contracts/OperationType.cs
+++ b/src/LibraryManager.Contracts/OperationType.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Contracts
 {

--- a/src/LibraryManager.Contracts/PredefinedErrors.cs
+++ b/src/LibraryManager.Contracts/PredefinedErrors.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Contracts/Properties/AssemblyInfo.cs
+++ b/src/LibraryManager.Contracts/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Resources;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: NeutralResourcesLanguage("en")]

--- a/src/LibraryManager.Contracts/ResourceDownloadException.cs
+++ b/src/LibraryManager.Contracts/ResourceDownloadException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Web.LibraryManager.Contracts.Resources;

--- a/src/LibraryManager.Vsix/Commands/CleanCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/CleanCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel.Design;

--- a/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/InstallLibraryCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel.Design;

--- a/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/ManageLibrariesCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel.Design;

--- a/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel.Design;

--- a/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreOnBuildCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
+++ b/src/LibraryManager.Vsix/Commands/RestoreSolutionCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Constants.cs
+++ b/src/LibraryManager.Vsix/Constants.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/LibraryManager.Vsix/Contracts/Dependencies.cs
+++ b/src/LibraryManager.Vsix/Contracts/Dependencies.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Contracts/DependenciesFactory.cs
+++ b/src/LibraryManager.Vsix/Contracts/DependenciesFactory.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.Web.LibraryManager.Cache;

--- a/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
+++ b/src/LibraryManager.Vsix/Contracts/HostInteraction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Contracts/IDependenciesFactory.cs
+++ b/src/LibraryManager.Vsix/Contracts/IDependenciesFactory.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Web.LibraryManager.Contracts;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix.Contracts
 {

--- a/src/LibraryManager.Vsix/Contracts/Logger.cs
+++ b/src/LibraryManager.Vsix/Contracts/Logger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
+++ b/src/LibraryManager.Vsix/Contracts/PerProjectLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager.Vsix/ErrorList/DisplayError.cs
+++ b/src/LibraryManager.Vsix/ErrorList/DisplayError.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;

--- a/src/LibraryManager.Vsix/ErrorList/ErrorListPropagator.cs
+++ b/src/LibraryManager.Vsix/ErrorList/ErrorListPropagator.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/ErrorList/SinkManager.cs
+++ b/src/LibraryManager.Vsix/ErrorList/SinkManager.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.Shell.TableManager;
 using System;

--- a/src/LibraryManager.Vsix/ErrorList/TableDataSource.cs
+++ b/src/LibraryManager.Vsix/ErrorList/TableDataSource.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;

--- a/src/LibraryManager.Vsix/ErrorList/TableEntriesSnapshot.cs
+++ b/src/LibraryManager.Vsix/ErrorList/TableEntriesSnapshot.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using EnvDTE;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/LibraryManager.Vsix/Json/Completion/BaseCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/BaseCompletionProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionController.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/src/LibraryManager.Vsix/Json/Completion/CompletionElementProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/CompletionElementProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Utilities;

--- a/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/FilesCompletionProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;

--- a/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/LibraryIdCompletionProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Json/Completion/PathCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/PathCompletionProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Json/Completion/ProviderCompletionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/ProviderCompletionProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;

--- a/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/SimpleCompletionEntry.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Media;
 using Microsoft.VisualStudio.Imaging.Interop;

--- a/src/LibraryManager.Vsix/Json/Completion/VersionCompletionEntry.cs
+++ b/src/LibraryManager.Vsix/Json/Completion/VersionCompletionEntry.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Language.Intellisense;

--- a/src/LibraryManager.Vsix/Json/JsonHelpers.cs
+++ b/src/LibraryManager.Vsix/Json/JsonHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/SuggestedActionProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UninstallSuggestedActions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedAction.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.Imaging;

--- a/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
+++ b/src/LibraryManager.Vsix/Json/SuggestedActions/UpdateSuggestedActionSet.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
+++ b/src/LibraryManager.Vsix/Json/TextviewCreationListener.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/LibraryManagerPackage.cs
+++ b/src/LibraryManager.Vsix/LibraryManagerPackage.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel.Composition;

--- a/src/LibraryManager.Vsix/Properties/AssemblyInfo.cs
+++ b/src/LibraryManager.Vsix/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
 using System.Resources;

--- a/src/LibraryManager.Vsix/Search/ISearchService.cs
+++ b/src/LibraryManager.Vsix/Search/ISearchService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager.Vsix/Search/LocationSearchService.cs
+++ b/src/LibraryManager.Vsix/Search/LocationSearchService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Search/ProviderCatalogSearchService.cs
+++ b/src/LibraryManager.Vsix/Search/ProviderCatalogSearchService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Threading.Tasks;

--- a/src/LibraryManager.Vsix/Shared/DefaultSolutionEvents.cs
+++ b/src/LibraryManager.Vsix/Shared/DefaultSolutionEvents.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.VisualStudio;

--- a/src/LibraryManager.Vsix/Shared/ILibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/ILibraryCommandService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/LibraryManager.Vsix/Shared/ITaskStatusCenterService.cs
+++ b/src/LibraryManager.Vsix/Shared/ITaskStatusCenterService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TaskStatusCenter;

--- a/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
+++ b/src/LibraryManager.Vsix/Shared/LibraryCommandService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Shared/TaskStatusCenterService.cs
+++ b/src/LibraryManager.Vsix/Shared/TaskStatusCenterService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;

--- a/src/LibraryManager.Vsix/Shared/Telemetry.cs
+++ b/src/LibraryManager.Vsix/Shared/Telemetry.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Shared/VsHelpers.cs
+++ b/src/LibraryManager.Vsix/Shared/VsHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/Shared/WpfUtil.cs
+++ b/src/LibraryManager.Vsix/Shared/WpfUtil.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Shell;

--- a/src/LibraryManager.Vsix/UI/Controls/AutomationPeers/TextControlTypeAutomationPeer.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/AutomationPeers/TextControlTypeAutomationPeer.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;

--- a/src/LibraryManager.Vsix/UI/Controls/BindingProxy.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/BindingProxy.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Markup;
 

--- a/src/LibraryManager.Vsix/UI/Controls/CompletionEntry.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/CompletionEntry.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Web.LibraryManager.Contracts;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls
 {

--- a/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/EditorTooltip.xaml.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Controls;
 using Microsoft.VisualStudio.PlatformUI;

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeView.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows.Automation.Peers;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Web.LibraryManager.Vsix.UI.Models;

--- a/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeViewAutomationPeer.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/PackageContentsTreeViewAutomationPeer.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows.Automation.Peers;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls

--- a/src/LibraryManager.Vsix/UI/Controls/Search/LogicalOrConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/Search/LogicalOrConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Globalization;
 using System.Windows.Data;
 

--- a/src/LibraryManager.Vsix/UI/Controls/Search/Wrapper.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/Search/Wrapper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Windows;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Controls.Search

--- a/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/Controls/TextBoxWithSearch.xaml.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/UI/Converters/BoldingConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/BoldingConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;

--- a/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/CheckBoxAutomationNameConverter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Globalization;
 using System.Windows.Data;

--- a/src/LibraryManager.Vsix/UI/Converters/EnumToBoolConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/EnumToBoolConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Windows.Data;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Converters

--- a/src/LibraryManager.Vsix/UI/Converters/HintTextConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/HintTextConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Windows.Data;
 using Microsoft.Web.LibraryManager.Contracts;
 

--- a/src/LibraryManager.Vsix/UI/Converters/NotConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/NotConverter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Globalization;
 using System.Windows.Data;

--- a/src/LibraryManager.Vsix/UI/Converters/VisibleIfNonNullConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/VisibleIfNonNullConverter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Globalization;
 using System.Windows;

--- a/src/LibraryManager.Vsix/UI/Converters/WatermarkVisibilityConverter.cs
+++ b/src/LibraryManager.Vsix/UI/Converters/WatermarkVisibilityConverter.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Globalization;

--- a/src/LibraryManager.Vsix/UI/Extensions/RemoveCharacterExtension.cs
+++ b/src/LibraryManager.Vsix/UI/Extensions/RemoveCharacterExtension.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Windows.Markup;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Extensions

--- a/src/LibraryManager.Vsix/UI/IInstallDialog.cs
+++ b/src/LibraryManager.Vsix/UI/IInstallDialog.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI
 {

--- a/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialog.xaml.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/src/LibraryManager.Vsix/UI/InstallDialogProvider.cs
+++ b/src/LibraryManager.Vsix/UI/InstallDialogProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI
 {

--- a/src/LibraryManager.Vsix/UI/Models/ActionCommand.cs
+++ b/src/LibraryManager.Vsix/UI/Models/ActionCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Windows.Input;
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Models

--- a/src/LibraryManager.Vsix/UI/Models/BindableBase.cs
+++ b/src/LibraryManager.Vsix/UI/Models/BindableBase.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/LibraryManager.Vsix/UI/Models/FileSelection.cs
+++ b/src/LibraryManager.Vsix/UI/Models/FileSelection.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 {
     internal static class FileSelection
     {

--- a/src/LibraryManager.Vsix/UI/Models/FileSelectionType.cs
+++ b/src/LibraryManager.Vsix/UI/Models/FileSelectionType.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 {
     internal enum FileSelectionType
     {

--- a/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/InstallDialogViewModel.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/UI/Models/LibraryIdViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/LibraryIdViewModel.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/UI/Models/LibraryNameBinding.cs
+++ b/src/LibraryManager.Vsix/UI/Models/LibraryNameBinding.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 {

--- a/src/LibraryManager.Vsix/UI/Models/PackageItem.cs
+++ b/src/LibraryManager.Vsix/UI/Models/PackageItem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Imaging;

--- a/src/LibraryManager.Vsix/UI/Models/PackageItemType.cs
+++ b/src/LibraryManager.Vsix/UI/Models/PackageItemType.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.Web.LibraryManager.Vsix.UI.Models
 {
     public enum PackageItemType

--- a/src/LibraryManager.Vsix/UI/Models/SearchTextBoxViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/SearchTextBoxViewModel.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager.Vsix/UI/Models/SelectedProviderBinding.cs
+++ b/src/LibraryManager.Vsix/UI/Models/SelectedProviderBinding.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 

--- a/src/LibraryManager.Vsix/UI/Models/TargetLocationViewModel.cs
+++ b/src/LibraryManager.Vsix/UI/Models/TargetLocationViewModel.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel;

--- a/src/LibraryManager.Vsix/UI/Theming/Theme.cs
+++ b/src/LibraryManager.Vsix/UI/Theming/Theme.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.PlatformUI;

--- a/src/LibraryManager.Vsix/UI/Theming/ThemedWindow.cs
+++ b/src/LibraryManager.Vsix/UI/Theming/ThemedWindow.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls;

--- a/src/LibraryManager/Cache/CacheFileMetadata.cs
+++ b/src/LibraryManager/Cache/CacheFileMetadata.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/LibraryManager/Cache/CacheService.cs
+++ b/src/LibraryManager/Cache/CacheService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Cache/WebRequestHandler.cs
+++ b/src/LibraryManager/Cache/WebRequestHandler.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/LibraryManager/Configuration/Constants.cs
+++ b/src/LibraryManager/Configuration/Constants.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Configuration
 {

--- a/src/LibraryManager/Configuration/ProxySettings.cs
+++ b/src/LibraryManager/Configuration/ProxySettings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Configuration/Settings.cs
+++ b/src/LibraryManager/Configuration/Settings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/LibraryManager/FileConflict.cs
+++ b/src/LibraryManager/FileConflict.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/FileIdentifier.cs
+++ b/src/LibraryManager/FileIdentifier.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Helpers/CancellationHelpers.cs
+++ b/src/LibraryManager/Helpers/CancellationHelpers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/LibraryManager/Helpers/Extensions.cs
+++ b/src/LibraryManager/Helpers/Extensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Helpers/LibraryStateTypeConverter.cs
+++ b/src/LibraryManager/Helpers/LibraryStateTypeConverter.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using Newtonsoft.Json;

--- a/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
+++ b/src/LibraryManager/Json/LibraryInstallationStateOnDisk.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Json/LibraryStateToFileConverter.cs
+++ b/src/LibraryManager/Json/LibraryStateToFileConverter.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Web.LibraryManager.Contracts;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
 
 namespace Microsoft.Web.LibraryManager.Json

--- a/src/LibraryManager/Json/ManifestOnDisk.cs
+++ b/src/LibraryManager/Json/ManifestOnDisk.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Json/ManifestToFileConverter.cs
+++ b/src/LibraryManager/Json/ManifestToFileConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager/LibrariesValidator.cs
+++ b/src/LibraryManager/LibrariesValidator.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/LibraryInstallationState.cs
+++ b/src/LibraryManager/LibraryInstallationState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager/LibraryNaming/ILibraryNamingScheme.cs
+++ b/src/LibraryManager/LibraryNaming/ILibraryNamingScheme.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.LibraryNaming
 {

--- a/src/LibraryManager/LibraryNaming/LibraryIdToNameAndVersionConverter.cs
+++ b/src/LibraryManager/LibraryNaming/LibraryIdToNameAndVersionConverter.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/LibraryNaming/SimpleLibraryNamingScheme.cs
+++ b/src/LibraryManager/LibraryNaming/SimpleLibraryNamingScheme.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.LibraryNaming
 {

--- a/src/LibraryManager/LibraryNaming/VersionedLibraryNamingScheme.cs
+++ b/src/LibraryManager/LibraryNaming/VersionedLibraryNamingScheme.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 

--- a/src/LibraryManager/LibraryOperationResult.cs
+++ b/src/LibraryManager/LibraryOperationResult.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
 

--- a/src/LibraryManager/Logging/LogMessageGenerator.cs
+++ b/src/LibraryManager/Logging/LogMessageGenerator.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/ManifestConstants.cs
+++ b/src/LibraryManager/ManifestConstants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/LibraryManager/Minimatch/Minimatcher.cs
+++ b/src/LibraryManager/Minimatch/Minimatcher.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) 2014 SLaks
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 // Copied from https://github.com/SLaks/Minimatch/blob/0620000d171a45be30fa3214496475ef4e1c04e7/Minimatch/Minimatcher.cs
+// Copyright (c) 2014 SLaks
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Properties/AssemblyInfo.cs
+++ b/src/LibraryManager/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Resources;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: NeutralResourcesLanguage("en")]

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsCatalog.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsLibrary.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsLibrary.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsLibraryGroup.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsLibraryGroup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System;

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Cache;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager/Providers/Cdnjs/CdnjsProviderFactory.cs
+++ b/src/LibraryManager/Providers/Cdnjs/CdnjsProviderFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Web.LibraryManager.Cache;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemCatalog.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemLibrary.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemLibrary.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemLibraryGroup.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemLibraryGroup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/LibraryManager/Providers/FileSystem/FileSystemProviderFactory.cs
+++ b/src/LibraryManager/Providers/FileSystem/FileSystemProviderFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/LibraryManager/Providers/Unpkg/INpmPackageInfoFactory.cs
+++ b/src/LibraryManager/Providers/Unpkg/INpmPackageInfoFactory.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg

--- a/src/LibraryManager/Providers/Unpkg/INpmPackageSearch.cs
+++ b/src/LibraryManager/Providers/Unpkg/INpmPackageSearch.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/LibraryManager/Providers/Unpkg/NpmPackageInfo.cs
+++ b/src/LibraryManager/Providers/Unpkg/NpmPackageInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using Microsoft.Web.LibraryManager.Helpers;
 using Newtonsoft.Json.Linq;
 

--- a/src/LibraryManager/Providers/Unpkg/NpmPackageInfoFactory.cs
+++ b/src/LibraryManager/Providers/Unpkg/NpmPackageInfoFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/LibraryManager/Providers/Unpkg/NpmPackageSearch.cs
+++ b/src/LibraryManager/Providers/Unpkg/NpmPackageSearch.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgCatalog.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Providers/Unpkg/UnpkgLibrary.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgLibrary.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using Microsoft.Web.LibraryManager.Contracts;
 
 namespace Microsoft.Web.LibraryManager.Providers.Unpkg

--- a/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgLibraryGroup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Cache;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager/Providers/Unpkg/UnpkgProviderFactory.cs
+++ b/src/LibraryManager/Providers/Unpkg/UnpkgProviderFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using Microsoft.Web.LibraryManager.Cache;
 using Microsoft.Web.LibraryManager.Contracts;
 

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrCatalog.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrLibrary.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrLibrary.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrLibraryGroup.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrLibraryGroup.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/LibraryManager/Providers/jsDelivr/JsDelivrProviderFactory.cs
+++ b/src/LibraryManager/Providers/jsDelivr/JsDelivrProviderFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.Web.LibraryManager.Cache;

--- a/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
+++ b/src/LibraryManager/Providers/jsDelivr/jsDelivrProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Cache;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/src/LibraryManager/RelativePathEqualityComparer.cs
+++ b/src/LibraryManager/RelativePathEqualityComparer.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/LibraryManager/SemanticVersion.cs
+++ b/src/LibraryManager/SemanticVersion.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 
 namespace Microsoft.Web.LibraryManager
 {

--- a/src/LibraryManager/Utilities/EncryptionUtility.cs
+++ b/src/LibraryManager/Utilities/EncryptionUtility.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Security.Cryptography;

--- a/src/LibraryManager/Utilities/FileGlobbingUtility.cs
+++ b/src/LibraryManager/Utilities/FileGlobbingUtility.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Minimatch;

--- a/src/LibraryManager/Utilities/ParallelUtility.cs
+++ b/src/LibraryManager/Utilities/ParallelUtility.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Commands/BaseCommand.cs
+++ b/src/libman/Commands/BaseCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Commands/CacheCleanCommand.cs
+++ b/src/libman/Commands/CacheCleanCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/libman/Commands/CacheCommand.cs
+++ b/src/libman/Commands/CacheCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.CommandLineUtils;
 

--- a/src/libman/Commands/CacheListCommand.cs
+++ b/src/libman/Commands/CacheListCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Commands/CleanCommand.cs
+++ b/src/libman/Commands/CleanCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Commands/ConfigCommand.cs
+++ b/src/libman/Commands/ConfigCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Commands/InitCommand.cs
+++ b/src/libman/Commands/InitCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/libman/Commands/InstallCommand.cs
+++ b/src/libman/Commands/InstallCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Commands/LibmanApp.cs
+++ b/src/libman/Commands/LibmanApp.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.Extensions.CommandLineUtils;

--- a/src/libman/Commands/RestoreCommand.cs
+++ b/src/libman/Commands/RestoreCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/libman/Commands/UninstallCommand.cs
+++ b/src/libman/Commands/UninstallCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Commands/UpdateCommand.cs
+++ b/src/libman/Commands/UpdateCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Contracts/ConsoleLogger.cs
+++ b/src/libman/Contracts/ConsoleLogger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Text;

--- a/src/libman/Contracts/Dependencies.cs
+++ b/src/libman/Contracts/Dependencies.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Contracts/HostInteraction.cs
+++ b/src/libman/Contracts/HostInteraction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Contracts/IHostInteractionInternal.cs
+++ b/src/libman/Contracts/IHostInteractionInternal.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 

--- a/src/libman/Contracts/IInputReader.cs
+++ b/src/libman/Contracts/IInputReader.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Tools
 {

--- a/src/libman/EnvironmentSettings.cs
+++ b/src/libman/EnvironmentSettings.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/libman/ExitCode.cs
+++ b/src/libman/ExitCode.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Tools
 {

--- a/src/libman/GlobalSuppressions.cs
+++ b/src/libman/GlobalSuppressions.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 

--- a/src/libman/HostEnvironment.cs
+++ b/src/libman/HostEnvironment.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/src/libman/IHostEnvironment.cs
+++ b/src/libman/IHostEnvironment.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Tools.Contracts;

--- a/src/libman/ILibraryInstallationStateExtensions.cs
+++ b/src/libman/ILibraryInstallationStateExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Text;

--- a/src/libman/LibraryResolver.cs
+++ b/src/libman/LibraryResolver.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/ManifestRestorer.cs
+++ b/src/libman/ManifestRestorer.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/libman/Program.cs
+++ b/src/libman/Program.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/src/libman/Properties/AssemblyInfo.cs
+++ b/src/libman/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/test/LibraryManager.Contracts.Test/OperationResultTests.cs
+++ b/test/LibraryManager.Contracts.Test/OperationResultTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Microsoft.Web.LibraryManager.Contracts;
 
 namespace LibraryManager.Contracts.Test

--- a/test/LibraryManager.IntegrationTest/FileSaveRestoreTests.cs
+++ b/test/LibraryManager.IntegrationTest/FileSaveRestoreTests.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Web.LibraryManager.IntegrationTest

--- a/test/LibraryManager.IntegrationTest/Helpers/CompletionHelper.cs
+++ b/test/LibraryManager.IntegrationTest/Helpers/CompletionHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.Test.Apex.Editor;
 using Microsoft.Test.Apex.VisualStudio.Editor;

--- a/test/LibraryManager.IntegrationTest/Helpers/FileIOHelper.cs
+++ b/test/LibraryManager.IntegrationTest/Helpers/FileIOHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Omni.Common;

--- a/test/LibraryManager.IntegrationTest/Helpers/HelperWrapper.cs
+++ b/test/LibraryManager.IntegrationTest/Helpers/HelperWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/test/LibraryManager.IntegrationTest/InstallDialogTests.cs
+++ b/test/LibraryManager.IntegrationTest/InstallDialogTests.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
 using Microsoft.Test.Apex.VisualStudio.Shell;
 using Microsoft.Test.Apex.VisualStudio.Shell.ToolWindows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
+++ b/test/LibraryManager.IntegrationTest/LibmanCompletionTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using Microsoft.Test.Apex.Editor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/test/LibraryManager.IntegrationTest/Services/InstallDialogTestExtension.cs
+++ b/test/LibraryManager.IntegrationTest/Services/InstallDialogTestExtension.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using Microsoft.Test.Apex.Services;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.VisualStudio.Shell;

--- a/test/LibraryManager.IntegrationTest/Services/InstallDialogTestService.cs
+++ b/test/LibraryManager.IntegrationTest/Services/InstallDialogTestService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/LibraryManager.IntegrationTest/Services/InstallDialogVerifier.cs
+++ b/test/LibraryManager.IntegrationTest/Services/InstallDialogVerifier.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Test.Apex.VisualStudio;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Test.Apex.VisualStudio;
 
 namespace Microsoft.Web.LibraryManager.IntegrationTest.Services
 {

--- a/test/LibraryManager.IntegrationTest/SuggestedActionTests.cs
+++ b/test/LibraryManager.IntegrationTest/SuggestedActionTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/test/LibraryManager.IntegrationTest/Suppressions.cs
+++ b/test/LibraryManager.IntegrationTest/Suppressions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // Suppress integration tests from running under LUT.
 [assembly: TestCategory("SkipWhenLiveUnitTesting")]

--- a/test/LibraryManager.IntegrationTest/VisualStudioLibmanHostTests.cs
+++ b/test/LibraryManager.IntegrationTest/VisualStudioLibmanHostTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/test/LibraryManager.Mocks/Dependencies.cs
+++ b/test/LibraryManager.Mocks/Dependencies.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;

--- a/test/LibraryManager.Mocks/Error.cs
+++ b/test/LibraryManager.Mocks/Error.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 

--- a/test/LibraryManager.Mocks/HostInteraction.cs
+++ b/test/LibraryManager.Mocks/HostInteraction.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System;

--- a/test/LibraryManager.Mocks/Library.cs
+++ b/test/LibraryManager.Mocks/Library.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;

--- a/test/LibraryManager.Mocks/LibraryCatalog.cs
+++ b/test/LibraryManager.Mocks/LibraryCatalog.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;

--- a/test/LibraryManager.Mocks/LibraryGroup.cs
+++ b/test/LibraryManager.Mocks/LibraryGroup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Web.LibraryManager.Contracts;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/LibraryManager.Mocks/LibraryInstallationState.cs
+++ b/test/LibraryManager.Mocks/LibraryInstallationState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;

--- a/test/LibraryManager.Mocks/LibraryOperationResult.cs
+++ b/test/LibraryManager.Mocks/LibraryOperationResult.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Collections.Generic;

--- a/test/LibraryManager.Mocks/Logger.cs
+++ b/test/LibraryManager.Mocks/Logger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System;

--- a/test/LibraryManager.Mocks/Provider.cs
+++ b/test/LibraryManager.Mocks/Provider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 using System.Threading;

--- a/test/LibraryManager.Mocks/ProviderFactory.cs
+++ b/test/LibraryManager.Mocks/ProviderFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Web.LibraryManager.Contracts;
 

--- a/test/LibraryManager.Mocks/Settings.cs
+++ b/test/LibraryManager.Mocks/Settings.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Web.LibraryManager.Contracts.Configuration;
 

--- a/test/LibraryManager.Mocks/WebRequestHandler.cs
+++ b/test/LibraryManager.Mocks/WebRequestHandler.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/CacheServiceTest.cs
+++ b/test/LibraryManager.Test/CacheServiceTest.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Configuration/ProxySettingsTest.cs
+++ b/test/LibraryManager.Test/Configuration/ProxySettingsTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Net;

--- a/test/LibraryManager.Test/Configuration/SettingsTest.cs
+++ b/test/LibraryManager.Test/Configuration/SettingsTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/LibraryManager.Test/ErrorTest.cs
+++ b/test/LibraryManager.Test/ErrorTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/test/LibraryManager.Test/ExtensionsTest.cs
+++ b/test/LibraryManager.Test/ExtensionsTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/LibraryManager.Test/FileHelpersTest.cs
+++ b/test/LibraryManager.Test/FileHelpersTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/test/LibraryManager.Test/InvalidLibraryExceptionTest.cs
+++ b/test/LibraryManager.Test/InvalidLibraryExceptionTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/test/LibraryManager.Test/LibrariesValidatorTest.cs
+++ b/test/LibraryManager.Test/LibrariesValidatorTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
+++ b/test/LibraryManager.Test/LibraryIdToNameAndVersionConverterTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/LibraryManager.Test/LibraryInstallationResultTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationResultTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/LibraryInstallationStateTest.cs
+++ b/test/LibraryManager.Test/LibraryInstallationStateTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/ManifestTest.cs
+++ b/test/LibraryManager.Test/ManifestTest.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/PathEqualityComparerTest.cs
+++ b/test/LibraryManager.Test/PathEqualityComparerTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/test/LibraryManager.Test/Providers/BaseProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/BaseProviderTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsCatalogTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderFactoryTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderFactoryTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Cdnjs/CdnjsProviderTest.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemCatalogTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderFactoryTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderFactoryTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/FileSystem/FileSystemProviderTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrCatalogTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderFactoryTest.cs
+++ b/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderFactoryTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/JsDelivr/JsDelivrProviderTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Providers/Unpkg/NpmPackageInfoFactoryTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/NpmPackageInfoFactoryTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/LibraryManager.Test/Providers/Unpkg/NpmPackageInfoTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/NpmPackageInfoTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Providers.Unpkg;
 using Newtonsoft.Json.Linq;
 

--- a/test/LibraryManager.Test/Providers/Unpkg/NpmPackageSearchTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/NpmPackageSearchTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgCatalogTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderFactoryTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderFactoryTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
+++ b/test/LibraryManager.Test/Providers/Unpkg/UnpkgProviderTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/LibraryManager.Test/SemanticVersionTest.cs
+++ b/test/LibraryManager.Test/SemanticVersionTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Web.LibraryManager.Test

--- a/test/LibraryManager.Test/SimpleLibraryNamingSchemeTest.cs
+++ b/test/LibraryManager.Test/SimpleLibraryNamingSchemeTest.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.LibraryNaming;

--- a/test/LibraryManager.Test/TestUtilities/StringUtility.cs
+++ b/test/LibraryManager.Test/TestUtilities/StringUtility.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/test/LibraryManager.Test/TestUtils.cs
+++ b/test/LibraryManager.Test/TestUtils.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
 using System.Threading;
 
 namespace Microsoft.Web.LibraryManager.Test

--- a/test/LibraryManager.Test/Utilities/FileGlobbingUtilityTests.cs
+++ b/test/LibraryManager.Test/Utilities/FileGlobbingUtilityTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/LibraryManager.Test/Utilities/ParallelUtilityTests.cs
+++ b/test/LibraryManager.Test/Utilities/ParallelUtilityTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/LibraryManager.Test/VersionedLibraryNamingSchemeTest.cs
+++ b/test/LibraryManager.Test/VersionedLibraryNamingSchemeTest.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.LibraryNaming;

--- a/test/Microsoft.Web.LibraryManager.Build.Test/MockEngine.cs
+++ b/test/Microsoft.Web.LibraryManager.Build.Test/MockEngine.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
 using System;

--- a/test/Microsoft.Web.LibraryManager.Build.Test/RestoreTaskTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Build.Test/RestoreTaskTest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Reflection;

--- a/test/Microsoft.Web.LibraryManager.Build.Test/TaskItem.cs
+++ b/test/Microsoft.Web.LibraryManager.Build.Test/TaskItem.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/JSONHelpersTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/JSONHelpersTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Vsix;
 using Microsoft.Web.LibraryManager.Vsix.Json;
 using Microsoft.WebTools.Languages.Json.Parser;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Mocks/NullSearchService.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Mocks/NullSearchService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
 using Microsoft.Web.LibraryManager.Contracts;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Search/LocationSearchServiceTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Search/LocationSearchServiceTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Search/ProviderCatalogSearchServiceTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Search/ProviderCatalogSearchServiceTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Linq;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/Shared/LibraryCommandServiceTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/Shared/LibraryCommandServiceTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
 using System.IO;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/CheckBoxAutomationNameConverterTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/WatermarkVisibilityConverterTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Converters/WatermarkVisibilityConverterTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Windows;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/InstallDialogViewModelTest.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/InstallDialogViewModelTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Web.LibraryManager.Vsix.UI.Models;
 using Microsoft.Web.LibraryManager.Providers.Cdnjs;
 using Newtonsoft.Json;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/LibraryIdViewModelTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/TargetLocationViewModelTests.cs
+++ b/test/Microsoft.Web.LibraryManager.Vsix.Test/UI/Models/TargetLocationViewModelTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/TestGlobalSuppressions.cs
+++ b/test/TestGlobalSuppressions.cs
@@ -1,5 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Not for test method names")]
 

--- a/test/libman.Test/BaseCommandTests.cs
+++ b/test/libman.Test/BaseCommandTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/CommandTestBase.cs
+++ b/test/libman.Test/CommandTestBase.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/libman.Test/HostInteractionTests.cs
+++ b/test/libman.Test/HostInteractionTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/LibmanCacheCleanTests.cs
+++ b/test/libman.Test/LibmanCacheCleanTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/LibmanCacheListTest.cs
+++ b/test/libman.Test/LibmanCacheListTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/libman.Test/LibmanCleanTest.cs
+++ b/test/libman.Test/LibmanCleanTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/LibmanConfigTest.cs
+++ b/test/libman.Test/LibmanConfigTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/LibmanInitTests.cs
+++ b/test/libman.Test/LibmanInitTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/libman.Test/LibmanInstallTest.cs
+++ b/test/libman.Test/LibmanInstallTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/libman.Test/LibmanRestoreTest.cs
+++ b/test/libman.Test/LibmanRestoreTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using System.Linq;

--- a/test/libman.Test/LibmanUninstallTest.cs
+++ b/test/libman.Test/LibmanUninstallTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/libman.Test/LibmanUpdateTest.cs
+++ b/test/libman.Test/LibmanUpdateTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;

--- a/test/libman.Test/LibraryResolverTest.cs
+++ b/test/libman.Test/LibraryResolverTest.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/Mocks/HostEnvironment.cs
+++ b/test/libman.Test/Mocks/HostEnvironment.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/Mocks/HostInteractionInternal.cs
+++ b/test/libman.Test/Mocks/HostInteractionInternal.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/SampleTestCommand.cs
+++ b/test/libman.Test/SampleTestCommand.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/StringNewLineHelper.cs
+++ b/test/libman.Test/StringNewLineHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/TestEnvironmentHelper.cs
+++ b/test/libman.Test/TestEnvironmentHelper.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.Web.LibraryManager.Tools.Test
 {

--- a/test/libman.Test/TestInputReader.cs
+++ b/test/libman.Test/TestInputReader.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;

--- a/test/libman.Test/TestLogger.cs
+++ b/test/libman.Test/TestLogger.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Summary of the changes
 - Updated LICENSE.txt in the root
 - Updated all C# source files to have updated header
 - Added header rule to .editorconfig to maintain for future files

The phrasing was borrowed from the dotnet/runtime repo, which is also owned by the .NET Foundation.

Closes #712 
