### PR TITLE
Fix build targets

### DIFF
--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
-    <PackageReference Include="System.Runtime.Loader" Condition="'$(TargetFramework)' == '$(NetCoreTFM)'" />
+    <PackageReference Include="System.Runtime.Loader" Condition="'$(TargetFramework)' == '$(NetCoreTFM)'" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.targets
+++ b/src/LibraryManager.Build/Microsoft.Web.LibraryManager.Build.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netstandard2.0\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
-        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\$(NetFxTFM)\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
+        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
+        <_LibraryTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net481\Microsoft.Web.LibraryManager.Build.dll</_LibraryTaskAssembly>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Fixes two issues in the recent changes to the targets file in the Build package:
 - The path to the build task assembly was incorrectly updated since we now build the project for net8.0 and net481.  Also, it was updated to use an MSBuild variable that exists in this repo, but the targets file runs in the context of the consumer (which wouldn't have it defined).  So the path was returned to a hard-coded value.  This will need to be maintained as target frameworks get updated (or we need a better way to generate the targets file).
 - The Build package was passing the dependency to System.Runtime.Loader transitively.  This was causing warnings with .NET 9's stricter security advisory due to the runtime dependencies (System.Private.Uri specifically).  This should not be a transitive dependency for consumers, so setting it to PrivateAssets fixes the issue.

Resolves #770 
