### PR TITLE
Use nuget.org for publicly available packages

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,30 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="libman" value="https://pkgs.dev.azure.com/azure-public/vswebtools/_packaging/libman/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="libman">
+      <package pattern="Microsoft.Extensions.CommandLineUtils.Sources" />
+      <package pattern="Microsoft.Test.Apex.*" />
+      <package pattern="Microsoft.VisualStudio.Internal.MicroBuild" />
+      <package pattern="Microsoft.WebTools.Languages.*" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="Castle.Core" />
+      <package pattern="MessagePack" />
+      <package pattern="MessagePack.*" />
+      <package pattern="Microsoft.*" />
+      <package pattern="Moq*" />
+      <package pattern="MSTest.*" />
+      <package pattern="Newtonsoft.Json" />
+      <package pattern="Nerdbank.GitVersioning" />
+      <package pattern="Nerdbank.Streams" />
+      <package pattern="Nuget.Frameworks" />
+      <package pattern="Nuget.VisualStudio" />
+      <package pattern="StreamJsonRpc" />
+      <package pattern="System.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
When package dependency versions change, the libman package feed (hosted on the azure-public ADO instance) is not writable by non-Microsoft employees.  This can lead to issues building the solution when adding/updating references, especially including when runtime packages update from SDK servicing.

This change fetches any publicly available packages from nuget.org, which makes it easier to support new packages or package upgrades.

Having multiple package sources is not a risk when using packageSourceMappings.

Resolves #728