### PR TITLE
Change file normalization to not lowercase all file names

### DIFF
--- a/src/LibraryManager.Contracts/FileHelpers.cs
+++ b/src/LibraryManager.Contracts/FileHelpers.cs
@@ -385,7 +385,7 @@ namespace Microsoft.Web.LibraryManager.Contracts
         /// Normalizes the path string so it can be easily compared.
         /// </summary>
         /// <remarks>
-        /// Result will be lowercase and have any trailing slashes removed.
+        /// Result will be resolved to an absolute path and have any trailing slashes removed.
         /// </remarks>
         public static string NormalizePath(string path)
         {
@@ -398,17 +398,6 @@ namespace Microsoft.Web.LibraryManager.Contracts
             if (IsHttpUri(path))
             {
                 return path;
-            }
-
-            // net451 does not have the OSPlatform apis to determine if the OS is windows or not.
-            // This also does not handle the fact that MacOS can be configured to be either sensitive or insenstive 
-            // to the casing.
-            if (Path.DirectorySeparatorChar == '\\')
-            {
-#pragma warning disable CA1308 // Normalize strings to uppercase
-                               // Reason: we prefer lowercase names for file paths
-                path = path.ToLowerInvariant();
-#pragma warning restore CA1308 // Normalize strings to uppercase
             }
 
             return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/src/LibraryManager/Providers/BaseProvider.cs
+++ b/src/LibraryManager/Providers/BaseProvider.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Web.LibraryManager.Providers
                 mappings.Add(new FileMapping { Destination = desiredState.DestinationPath });
             }
 
-            Dictionary<string, string> installFiles = new();
+            Dictionary<string, string> installFiles = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (FileMapping fileMapping in mappings)
             {


### PR DESCRIPTION
This can cause issues if we assume a case-insensitive environment, but a user has a case-sensitive tool.

Instead, when trying to find duplicate paths, we'll let a StringComparer do the work to determine if the paths are the same.

Resolves #779 
