### PR TITLE
Integration tests for CLI and Build task

### DIFF
--- a/LibraryManager.sln
+++ b/LibraryManager.sln
@@ -64,6 +64,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.LibraryManage
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libman.IntegrationTest", "test\libman.IntegrationTest\libman.IntegrationTest.csproj", "{BE84C694-91F1-C170-7366-7B86EBC9B033}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.LibraryManager.Build.IntegrationTest", "test\LibraryManager.Build.IntegrationTest\Microsoft.Web.LibraryManager.Build.IntegrationTest.csproj", "{EC152F12-CB03-4405-D8AE-EE7FC6E32666}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -230,6 +232,18 @@ Global
 		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|x64.Build.0 = Release|Any CPU
 		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|x86.ActiveCfg = Release|Any CPU
 		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|x86.Build.0 = Release|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Release|x64.Build.0 = Release|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,6 +263,7 @@ Global
 		{E199195A-7EE8-9273-37B1-3726BCEAB87A} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 		{C8979E80-F4D3-3F21-D966-1B317CA64C23} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 		{BE84C694-91F1-C170-7366-7B86EBC9B033} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
+		{EC152F12-CB03-4405-D8AE-EE7FC6E32666} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {720C6A7F-67F7-4D00-881F-D3CDEA7ABE69}

--- a/LibraryManager.sln
+++ b/LibraryManager.sln
@@ -62,6 +62,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.LibraryManage
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.LibraryManager.Build.Test", "test\LibraryManager.Build.Test\Microsoft.Web.LibraryManager.Build.Test.csproj", "{C8979E80-F4D3-3F21-D966-1B317CA64C23}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libman.IntegrationTest", "test\libman.IntegrationTest\libman.IntegrationTest.csproj", "{BE84C694-91F1-C170-7366-7B86EBC9B033}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -216,6 +218,18 @@ Global
 		{C8979E80-F4D3-3F21-D966-1B317CA64C23}.Release|x64.Build.0 = Release|Any CPU
 		{C8979E80-F4D3-3F21-D966-1B317CA64C23}.Release|x86.ActiveCfg = Release|Any CPU
 		{C8979E80-F4D3-3F21-D966-1B317CA64C23}.Release|x86.Build.0 = Release|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Debug|x64.Build.0 = Debug|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Debug|x86.Build.0 = Debug|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|x64.ActiveCfg = Release|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|x64.Build.0 = Release|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|x86.ActiveCfg = Release|Any CPU
+		{BE84C694-91F1-C170-7366-7B86EBC9B033}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -234,6 +248,7 @@ Global
 		{F01D971D-AA93-60A2-2D84-05AF9AB1566F} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 		{E199195A-7EE8-9273-37B1-3726BCEAB87A} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 		{C8979E80-F4D3-3F21-D966-1B317CA64C23} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
+		{BE84C694-91F1-C170-7366-7B86EBC9B033} = {FFCD12F4-5CE2-4CC2-A2C4-EACC8F387D7A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {720C6A7F-67F7-4D00-881F-D3CDEA7ABE69}

--- a/test/LibraryManager.Build.IntegrationTest/BuildTestBase.cs
+++ b/test/LibraryManager.Build.IntegrationTest/BuildTestBase.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Web.LibraryManager.Build.IntegrationTest;
+
+[TestClass]
+[DeploymentItem(@"TestPackages", "TestPackages")]
+[DeploymentItem(@"TestSolution", "TestSolution")]
+public class BuildTestBase
+{
+    private const string BuildPackageName = "Microsoft.Web.LibraryManager.Build";
+    private const string ManifestFileName = "libman.json";
+    private const string TestProjectFolderName = "Libman.Build.TestApp";
+    private readonly string PackagesFolderPath = Path.Combine(Environment.CurrentDirectory, "TestPackages");
+    protected string TestProjectDirectory { get; private set; } = "";
+
+    [TestInitialize]
+    public async Task TestInitialize()
+    {
+        // test solution should be deployed with every test?
+        TestProjectDirectory = Path.Combine(Path.GetFullPath("TestSolution"), TestProjectFolderName);
+
+        // create an empty nuget.config with only our package source
+        await AddPackageReferenceAsync();
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        if (Directory.Exists(TestProjectDirectory))
+        {
+            Directory.Delete(TestProjectDirectory, true);
+        }
+    }
+
+    protected async Task RunDotnetCommandLineAsync(string arguments, string? workingDirectory)
+    {
+        var processStartInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory,
+        };
+
+        using (var process = Process.Start(processStartInfo))
+        {
+            await process.WaitForExitAsync();
+            if (process.ExitCode != 0)
+            {
+                string output = await process.StandardError.ReadToEndAsync() + await process.StandardOutput.ReadToEndAsync();
+                throw new InvalidOperationException($"CLI tool execution failed with arguments: {arguments}.\r\nOutput: {output}");
+            }
+        }
+    }
+
+    private async Task AddPackageReferenceAsync()
+    {
+        await RunDotnetCommandLineAsync($"nuget add source \"{PackagesFolderPath}\"", TestProjectDirectory);
+
+        await RunDotnetCommandLineAsync($"add package {BuildPackageName} --version {GetBuildPackageVersion()}", TestProjectDirectory);
+    }
+
+    private static string GetBuildPackageVersion()
+    {
+        return Directory.GetFiles("TestPackages", $"{BuildPackageName}.*.nupkg")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Select(name => name.Substring(BuildPackageName.Length + 1))
+            .OrderByDescending(version => version)
+            .First();
+    }
+
+    protected async Task CreateManifestFileAsync(string content)
+    {
+        string manifestFilePath = Path.Combine(TestProjectDirectory, ManifestFileName);
+        await Task.Run(() => File.WriteAllText(manifestFilePath, content));
+    }
+
+    protected void AssertFileExists(string relativeFilePath)
+    {
+        string filePath = Path.Combine(TestProjectDirectory, relativeFilePath);
+        Assert.IsTrue(File.Exists(filePath), $"Expected file '{filePath}' does not exist.");
+    }
+
+}

--- a/test/LibraryManager.Build.IntegrationTest/Microsoft.Web.LibraryManager.Build.IntegrationTest.csproj
+++ b/test/LibraryManager.Build.IntegrationTest/Microsoft.Web.LibraryManager.Build.IntegrationTest.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreTFM)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- set build dependency so the nupkg is built for tests to consume -->
+    <ProjectReference Include="..\..\src\LibraryManager.Build\Microsoft.Web.LibraryManager.Build.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="TestSolution\**\*" />
+    <None Remove="TestSolution\**\*" />
+    <Content Remove="TestSolution\**\*" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="TestSolution\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <!-- Copy the nupkgs needed to run CLI and Build package integration tests -->
+  <Target Name="CopyNupkgFiles" AfterTargets="Build" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+
+    </PropertyGroup>
+    <ItemGroup>
+      <BuildNupkg Include="..\..\artifacts\$(Configuration)\Microsoft.Web.LibraryManager.Build.$(PackageVersion).nupkg" />
+    </ItemGroup>
+    <Copy SourceFiles="@(BuildNupkg)" DestinationFolder="$(OutputPath)\TestPackages" />
+  </Target>
+
+</Project>

--- a/test/LibraryManager.Build.IntegrationTest/RestoreTests.cs
+++ b/test/LibraryManager.Build.IntegrationTest/RestoreTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Web.LibraryManager.Build.IntegrationTest;
+
+[TestClass]
+public class RestoreTests : BuildTestBase
+{
+    [TestMethod]
+    public async Task Restore_LibraryWithFileMapping_NamedFiles()
+    {
+        string manifest = """
+            {
+                "version": "3.0",
+                "defaultProvider": "jsdelivr",
+                "libraries": [
+                    {
+                        "library": "jquery@3.6.0",
+                        "destination": "wwwroot/lib/jquery",
+                        "fileMappings": [
+                            {
+                                "files": [
+                                    "dist/jquery.min.js",
+                                    "dist/jquery.min.map"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+        await CreateManifestFileAsync(manifest);
+
+        await RunDotnetCommandLineAsync("build", TestProjectDirectory);
+
+        AssertFileExists("wwwroot/lib/jquery/dist/jquery.min.js");
+        AssertFileExists("wwwroot/lib/jquery/dist/jquery.min.map");
+    }
+}

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Directory.Build.props
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <PropertyGroup>
+
+
+  </PropertyGroup>
+</Project>

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Directory.Build.targets
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <Target Name="CustomAfterBuildTarget" AfterTargets="Build">
+      <Message Text="Hello from CustomAfterBuildTarget" Importance="high" />
+  </Target>
+</Project>

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Directory.Packages.props
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Directory.Packages.props
@@ -1,0 +1,7 @@
+<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <PropertyGroup>
+
+
+  </PropertyGroup>
+</Project>

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp.sln
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libman.Build.TestApp", "Libman.Build.TestApp\Libman.Build.TestApp.csproj", "{DB512B50-3DA7-4082-99E4-99C0ED151545}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DB512B50-3DA7-4082-99E4-99C0ED151545}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB512B50-3DA7-4082-99E4-99C0ED151545}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB512B50-3DA7-4082-99E4-99C0ED151545}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB512B50-3DA7-4082-99E4-99C0ED151545}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/Libman.Build.TestApp.csproj
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/Libman.Build.TestApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/Program.cs
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/Properties/launchSettings.json
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:13287",
+      "sslPort": 44380
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5264",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7009;http://localhost:5264",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/appsettings.Development.json
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/appsettings.json
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/Libman.Build.TestApp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/test/LibraryManager.Build.IntegrationTest/TestSolution/nuget.config
+++ b/test/LibraryManager.Build.IntegrationTest/TestSolution/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/test/libman.IntegrationTest/InstallTests.cs
+++ b/test/libman.IntegrationTest/InstallTests.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Web.LibraryManager.Cli.IntegrationTest;
+
+[TestClass]
+public class InstallTests : CliTestBase
+{
+    [TestMethod]
+    public async Task Install_FileSpecified()
+    {
+        await ExecuteCliToolAsync("install jquery@3.6.0 --provider cdnjs --destination test/jquery --files jquery.min.js");
+
+        AssertFileExists("test/jquery/jquery.min.js");
+    }
+}

--- a/test/libman.IntegrationTest/RestoreTests.cs
+++ b/test/libman.IntegrationTest/RestoreTests.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Web.LibraryManager.Cli.IntegrationTest;
+
+[TestClass]
+public class RestoreTests : CliTestBase
+{
+    [TestMethod]
+    public async Task Restore_WithFileMapping_ConcreteFileNames()
+    {
+        string manifest = """
+            {
+                "version": "3.0",
+                "defaultProvider": "jsdelivr",
+                "libraries": [
+                    {
+                        "library": "jquery@3.6.0",
+                        "destination": "wwwroot/lib/jquery",
+                        "fileMappings": [
+                            {
+                                "files": [
+                                    "dist/jquery.min.js",
+                                    "dist/jquery.min.map"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+        await CreateManifestFileAsync(manifest);
+
+        await ExecuteCliToolAsync("restore");
+
+        AssertFileExists("wwwroot/lib/jquery/dist/jquery.min.js");
+        AssertFileExists("wwwroot/lib/jquery/dist/jquery.min.map");
+    }
+
+    [TestMethod]
+    public async Task Restore_WithFileMapping_FileGlobs()
+    {
+        string manifest = """
+            {
+                "version": "3.0",
+                "defaultProvider": "jsdelivr",
+                "libraries": [
+                    {
+                        "library": "jquery@3.6.0",
+                        "destination": "wwwroot/lib/jquery",
+                        "fileMappings": [
+                            {
+                                "files": [
+                                    "dist/jquery.min.*",
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+        await CreateManifestFileAsync(manifest);
+
+        await ExecuteCliToolAsync("restore");
+
+        AssertFileExists("wwwroot/lib/jquery/dist/jquery.min.js");
+        AssertFileExists("wwwroot/lib/jquery/dist/jquery.min.map");
+    }
+
+    [TestMethod]
+    public async Task Restore_WithFileMapping_FileGlobs_SetRootPath()
+    {
+        string manifest = """
+            {
+                "version": "3.0",
+                "defaultProvider": "jsdelivr",
+                "libraries": [
+                    {
+                        "library": "jquery@3.6.0",
+                        "destination": "wwwroot/lib/jquery",
+                        "fileMappings": [
+                            {
+                                "root": "dist",
+                                "files": [
+                                    "jquery.min.*",
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+        await CreateManifestFileAsync(manifest);
+
+        await ExecuteCliToolAsync("restore");
+
+        AssertFileExists("wwwroot/lib/jquery/jquery.min.js");
+        AssertFileExists("wwwroot/lib/jquery/jquery.min.map");
+    }
+}

--- a/test/libman.IntegrationTest/libman.IntegrationTest.csproj
+++ b/test/libman.IntegrationTest/libman.IntegrationTest.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreTFM)</TargetFramework>
+    <RootNamespace>Microsoft.Web.LibraryManager.Cli.IntegrationTest</RootNamespace>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- set build dependency so the nupkg is built for tests to consume -->
+    <ProjectReference Include="..\..\src\libman\libman.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <!-- Copy the nupkgs needed to run CLI and Build package integration tests -->
+  <Target Name="CopyNupkgFiles" AfterTargets="Build" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+      
+    </PropertyGroup>
+    <ItemGroup>
+      <LibmanNupkg Include="..\..\artifacts\$(Configuration)\Microsoft.Web.LibraryManager.Cli.$(PackageVersion).nupkg" />
+    </ItemGroup>
+    <Copy SourceFiles="@(LibmanNupkg)" DestinationFolder="$(OutputPath)\TestPackages" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Each new integration test project has steps to set up using the package from the current build.  This will allow more consistent testing in addition to the Visual Studio integration tests.

Currently each project just has some basic tests to get started.  We can add more scenarios later, this PR is to introduce the core infrastructure with some basic starters.
