### PR TITLE
Add signWithProd for service connection

### DIFF
--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -58,6 +58,7 @@ extends:
             signing:
               enabled: true
               signType: $(SignType)
+              signWithProd: true
               zipSources: false
             swix:
               enabled: true


### PR DESCRIPTION
Looks like missing signWithProd attribute for Microbuild service connection
