### PR TITLE
ComponentGovernance: Update Microsoft.Build packages *just* to 17.11.48

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,9 +11,9 @@
   <ItemGroup>
     <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.4" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.7.188" />


### PR DESCRIPTION
A less aggressive approach than https://github.com/aspnet/LibraryManager/pull/816