### PR TITLE
Update CLI tool shim platforms to support ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Commit: TBD
 - Adds fileMappings support for filesystem provider
 - Fixes LIB016 error when using fileMappings
 - Fixes issue where restore-on-save in one project in VS removes files restored in a separate project
+- Add ARM platform shims to CLI tool
 
 ## 3.0.71
 Commit: 33c04f70a4f55f1cddbaddad60fc78a282b298d3

--- a/src/libman/libman.csproj
+++ b/src/libman/libman.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetCoreTFM)</TargetFramework>
     <RootNamespace>Microsoft.Web.LibraryManager.Tools</RootNamespace>
     <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64</PackAsToolShimRuntimeIdentifiers>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Microsoft.Web.LibraryManager.Cli</PackageId>
     <Description>Command line tool for Library Manager</Description>


### PR DESCRIPTION
- Added win-arm64 and osx-arm64
- Removed win-x86

I don't think x86 is supported anymore, according to https://github.com/dotnet/sdk/blob/f578225fe1fdd93db9efac273562b3709db9e8e9/src/Cli/dotnet/ShellShim/ShellShimTemplateFinder.cs#L27

Resolves #708 
