### PR TITLE
Fix expanding template expressions from defaultDestination for CLI install 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -82,7 +82,7 @@ dotnet_naming_style.start_underscore_style.required_prefix      = _
 [*.cs]
 # Don't prefer "var" when not apparent
 csharp_style_var_for_built_in_types                   = false : warning
-csharp_style_var_when_type_is_apparent                = true : suggestion
+csharp_style_var_when_type_is_apparent                = false : silent
 csharp_style_var_elsewhere                            = false : warning
 
 # Prefer method-like constructs to have a block body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Commit: TBD
 - Adds fileMappings support for filesystem provider
 - Fixes LIB016 error when using fileMappings
 - Fixes issue where restore-on-save in one project in VS removes files restored in a separate project
+- Fixes issue where CLI install command did not expand templated expressions in defaultDestination
 
 ## 3.0.71
 Commit: 33c04f70a4f55f1cddbaddad60fc78a282b298d3

--- a/src/LibraryManager/Json/LibraryStateToFileConverter.cs
+++ b/src/LibraryManager/Json/LibraryStateToFileConverter.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Utilities;
 
 namespace Microsoft.Web.LibraryManager.Json
 {
@@ -30,7 +31,7 @@ namespace Microsoft.Web.LibraryManager.Json
             string provider = string.IsNullOrEmpty(stateOnDisk.ProviderId) ? _defaultProvider : stateOnDisk.ProviderId;
 
             (string name, string version) = LibraryIdToNameAndVersionConverter.Instance.GetLibraryNameAndVersion(stateOnDisk.LibraryId, provider);
-            string destination = string.IsNullOrEmpty(stateOnDisk.DestinationPath) ? ExpandDestination(_defaultDestination, name, version) : stateOnDisk.DestinationPath;
+            string destination = string.IsNullOrEmpty(stateOnDisk.DestinationPath) ? PathTemplateUtility.ExpandPathTemplate(_defaultDestination, name, version) : stateOnDisk.DestinationPath;
 
             var state = new LibraryInstallationState()
             {
@@ -45,31 +46,6 @@ namespace Microsoft.Web.LibraryManager.Json
             };
 
             return state;
-        }
-
-        /// <summary>
-        /// Expands [Name] and [Version] tokens in the DefaultDestination
-        /// </summary>
-        /// <param name="destination">The default destination string</param>
-        /// <param name="name">Package name</param>
-        /// <param name="version">Package version</param>
-        /// <returns></returns>
-        [SuppressMessage("Globalization", "CA1307:Specify StringComparison for clarity", Justification = "Not available on net481, not needed here (caseless)")]
-        private string ExpandDestination(string destination, string name, string version)
-        {
-            if (destination is null || !destination.Contains("["))
-            {
-                return destination;
-            }
-
-            // if the name contains a slash (either filesystem or scoped packages),
-            // trim that and only take the last segment.
-            int cutIndex = name.LastIndexOfAny(['/', '\\']);
-
-            StringBuilder stringBuilder = new StringBuilder(destination);
-            stringBuilder.Replace("[Name]", cutIndex == -1 ? name : name.Substring(cutIndex + 1));
-            stringBuilder.Replace("[Version]", version);
-            return stringBuilder.ToString();
         }
 
         public LibraryInstallationStateOnDisk ConvertToLibraryInstallationStateOnDisk(ILibraryInstallationState state)

--- a/src/LibraryManager/Manifest.cs
+++ b/src/LibraryManager/Manifest.cs
@@ -12,6 +12,7 @@ using Microsoft.Web.LibraryManager.Contracts;
 using Microsoft.Web.LibraryManager.Helpers;
 using Microsoft.Web.LibraryManager.Json;
 using Microsoft.Web.LibraryManager.LibraryNaming;
+using Microsoft.Web.LibraryManager.Utilities;
 using Newtonsoft.Json;
 
 namespace Microsoft.Web.LibraryManager
@@ -150,7 +151,7 @@ namespace Microsoft.Web.LibraryManager
 
             if (libraryState.DestinationPath == null)
             {
-                libraryState.DestinationPath = defaultDestination;
+                libraryState.DestinationPath = PathTemplateUtility.ExpandPathTemplate(defaultDestination, state.Name, state.Version);
                 libraryState.IsUsingDefaultDestination = true;
             }
         }

--- a/src/LibraryManager/Utilities/PathTemplateUtility.cs
+++ b/src/LibraryManager/Utilities/PathTemplateUtility.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Microsoft.Web.LibraryManager.Utilities
+{
+    /// <summary>
+    /// Utility for path template operations.
+    /// </summary>
+    public static class PathTemplateUtility
+    {
+        /// <summary>
+        /// Expands a path template using [Name] and [Version] tokens.
+        /// </summary>
+        /// <param name="template">Template string</param>
+        /// <param name="name">Library name</param>
+        /// <param name="version">Library version</param>
+        [SuppressMessage("Globalization", "CA1307:Specify StringComparison for clarity", Justification = "Not available on net481, not needed here (caseless)")]
+        public static string ExpandPathTemplate(string template, string name, string version)
+        {
+            if (template is null || !template.Contains('['))
+            {
+                return template;
+            }
+
+            // if the name contains a slash (either filesystem or scoped packages),
+            // trim that and only take the last segment as the library name.
+            int cutIndex = name.LastIndexOfAny(['/', '\\']);
+            name = cutIndex == -1 ? name : name.Substring(cutIndex + 1);
+
+            return template.Replace("[Name]", name)
+                           .Replace("[Version]", version);
+        }
+    }
+}

--- a/test/libman.IntegrationTest/InstallTests.cs
+++ b/test/libman.IntegrationTest/InstallTests.cs
@@ -15,4 +15,21 @@ public class InstallTests : CliTestBase
 
         AssertFileExists("test/jquery/jquery.min.js");
     }
+
+    [TestMethod]
+    public async Task Install_UsingTemplateInDefaultDestination()
+    {
+        string manifest = """
+            {
+                "version": "3.0",
+                "defaultProvider": "cdnjs",
+                "defaultDestination": "wwwroot/lib/[Name]/"
+            }
+            """;
+        await CreateManifestFileAsync(manifest);
+
+        await ExecuteCliToolAsync("install bootstrap@5.3.2 --provider cdnjs --files css/bootstrap.min.css --files js/bootstrap.bundle.min.js");
+        AssertFileExists("wwwroot/lib/bootstrap/css/bootstrap.min.css");
+        AssertFileExists("wwwroot/lib/bootstrap/js/bootstrap.bundle.min.js");
+    }
 }


### PR DESCRIPTION
Apply the same expansion when installing libraries whether the manifest is from disk or generated in memory.  (CLI updates the manifest on disk after the install succeeds.)

Some extras:
- turned off preference for var when the type is apparent.  Since we don't use var through the majority of the code, this was distracting.
- Added a workaround for running the CLI integration tests when a workaround is in place for #728.  Apparently if a parent directory's nuget.config configures packageSourceMappings, there isn't a way to turn it off in a child directory's nuget.config.

Resolves #821 
